### PR TITLE
feat(website): add blog with first post about why MCP needs a Go framework

### DIFF
--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -7,6 +7,7 @@ const navItems = [
   { href: '/mcp-go/concepts', label: 'Concepts' },
   { href: '/mcp-go/comparison', label: 'Comparison' },
   { href: '/mcp-go/faq', label: 'FAQ' },
+  { href: '/mcp-go/blog', label: 'Blog' },
 ];
 ---
 

--- a/website/src/layouts/BlogPostLayout.astro
+++ b/website/src/layouts/BlogPostLayout.astro
@@ -1,0 +1,190 @@
+---
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import '../styles/global.css';
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  date: string;
+  author?: string;
+  description?: string;
+}
+
+const { title, subtitle, date, author = 'mcp-go team', description } = Astro.props;
+const fullTitle = `${title} | mcp-go`;
+const metaDescription = description || subtitle || title;
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+}
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={metaDescription} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
+    <title>{fullTitle}</title>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <article class="container blog-post">
+        <header class="post-header">
+          <a href="/mcp-go/blog" class="back-link">&larr; Back to Blog</a>
+          <h1 class="post-title">{title}</h1>
+          {subtitle && <p class="post-subtitle">{subtitle}</p>}
+          <div class="post-meta">
+            <time datetime={date}>{formatDate(date)}</time>
+            {author && <span class="post-author">by {author}</span>}
+          </div>
+        </header>
+        <div class="post-content">
+          <slot />
+        </div>
+      </article>
+    </main>
+    <Footer />
+  </body>
+</html>
+
+<style>
+  main {
+    min-height: calc(100vh - 140px);
+  }
+
+  .blog-post {
+    max-width: 720px;
+    padding-top: var(--space-8);
+    padding-bottom: var(--space-16);
+  }
+
+  .post-header {
+    margin-bottom: var(--space-10);
+    padding-bottom: var(--space-8);
+    border-bottom: 1px solid var(--color-border-default);
+  }
+
+  .back-link {
+    display: inline-block;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-6);
+    transition: color 0.15s ease;
+  }
+
+  .back-link:hover {
+    color: var(--color-accent);
+  }
+
+  .post-title {
+    font-size: var(--text-3xl);
+    line-height: 1.2;
+    margin-bottom: var(--space-4);
+  }
+
+  .post-subtitle {
+    font-size: var(--text-lg);
+    color: var(--color-text-secondary);
+    font-style: italic;
+    margin-bottom: var(--space-4);
+  }
+
+  .post-meta {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .post-meta time {
+    margin-right: var(--space-3);
+  }
+
+  .post-author::before {
+    content: '·';
+    margin-right: var(--space-3);
+  }
+
+  .post-content :global(h2) {
+    font-size: var(--text-xl);
+    margin-top: var(--space-10);
+    margin-bottom: var(--space-4);
+  }
+
+  .post-content :global(h3) {
+    font-size: var(--text-lg);
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-3);
+  }
+
+  .post-content :global(p) {
+    margin-bottom: var(--space-4);
+    line-height: 1.75;
+  }
+
+  .post-content :global(ul),
+  .post-content :global(ol) {
+    margin-bottom: var(--space-4);
+    padding-left: var(--space-6);
+  }
+
+  .post-content :global(li) {
+    margin-bottom: var(--space-2);
+    line-height: 1.7;
+  }
+
+  .post-content :global(blockquote) {
+    border-left: 3px solid var(--color-accent);
+    padding-left: var(--space-4);
+    margin: var(--space-6) 0;
+    font-style: italic;
+    color: var(--color-text-secondary);
+  }
+
+  .post-content :global(hr) {
+    border: none;
+    border-top: 1px solid var(--color-border-default);
+    margin: var(--space-10) 0;
+  }
+
+  .post-content :global(strong) {
+    color: var(--color-text-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 768px) {
+    .blog-post {
+      padding-top: var(--space-4);
+      padding-bottom: var(--space-8);
+    }
+
+    .post-header {
+      margin-bottom: var(--space-6);
+      padding-bottom: var(--space-6);
+    }
+
+    .post-title {
+      font-size: var(--text-2xl);
+    }
+
+    .post-subtitle {
+      font-size: var(--text-base);
+    }
+
+    .post-content :global(h2) {
+      font-size: var(--text-lg);
+      margin-top: var(--space-8);
+    }
+
+    .post-content :global(h3) {
+      font-size: var(--text-base);
+      margin-top: var(--space-6);
+    }
+  }
+</style>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -1,0 +1,135 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const posts = [
+  {
+    slug: 'why-mcp-needs-go-framework',
+    title: 'Why MCP needs a real Go framework (and not just SDKs)',
+    subtitle: 'Or: why we built mcp-go — the Gin-style framework for MCP servers in Go',
+    date: '2024-12-27',
+    description: 'This post explains why MCP needs a real Go framework, how SDKs and frameworks differ, and why we built mcp-go.'
+  }
+];
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+}
+---
+
+<BaseLayout title="Blog" description="Articles about building MCP servers in Go with mcp-go.">
+  <section class="container blog-list">
+    <h1>Blog</h1>
+    <p class="intro">
+      Insights, updates, and guides from the mcp-go project.
+    </p>
+
+    <div class="posts">
+      {posts.map((post) => (
+        <article class="post-card">
+          <a href={`/mcp-go/blog/${post.slug}`} class="post-link">
+            <time datetime={post.date}>{formatDate(post.date)}</time>
+            <h2>{post.title}</h2>
+            {post.subtitle && <p class="post-subtitle">{post.subtitle}</p>}
+            <span class="read-more">Read more &rarr;</span>
+          </a>
+        </article>
+      ))}
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .blog-list {
+    max-width: 720px;
+    padding-top: var(--space-8);
+    padding-bottom: var(--space-16);
+  }
+
+  .intro {
+    font-size: var(--text-lg);
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-10);
+  }
+
+  .posts {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+  }
+
+  .post-card {
+    padding: var(--space-6);
+    background-color: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    transition: border-color 0.15s ease;
+  }
+
+  .post-card:hover {
+    border-color: var(--color-accent);
+  }
+
+  .post-link {
+    display: block;
+    text-decoration: none;
+  }
+
+  .post-link time {
+    display: block;
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-2);
+  }
+
+  .post-link h2 {
+    font-size: var(--text-xl);
+    color: var(--color-text-primary);
+    margin-bottom: var(--space-2);
+    transition: color 0.15s ease;
+  }
+
+  .post-card:hover .post-link h2 {
+    color: var(--color-accent);
+  }
+
+  .post-subtitle {
+    font-size: var(--text-base);
+    color: var(--color-text-secondary);
+    font-style: italic;
+    margin-bottom: var(--space-3);
+  }
+
+  .read-more {
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+    font-weight: 500;
+  }
+
+  @media (max-width: 768px) {
+    .blog-list {
+      padding-top: var(--space-4);
+      padding-bottom: var(--space-8);
+    }
+
+    .intro {
+      font-size: var(--text-base);
+      margin-bottom: var(--space-6);
+    }
+
+    .post-card {
+      padding: var(--space-4);
+    }
+
+    .post-link h2 {
+      font-size: var(--text-lg);
+    }
+
+    .post-subtitle {
+      font-size: var(--text-sm);
+    }
+  }
+</style>

--- a/website/src/pages/blog/why-mcp-needs-go-framework.astro
+++ b/website/src/pages/blog/why-mcp-needs-go-framework.astro
@@ -1,0 +1,190 @@
+---
+import BlogPostLayout from '../../layouts/BlogPostLayout.astro';
+---
+
+<BlogPostLayout
+  title="Why MCP needs a real Go framework (and not just SDKs)"
+  subtitle="Or: why we built mcp-go — the Gin-style framework for MCP servers in Go"
+  date="2024-12-27"
+  description="This post explains why MCP needs a real Go framework, how SDKs and frameworks differ, and why we built mcp-go."
+>
+
+<p>
+  The Model Context Protocol (MCP) is quickly becoming the connective tissue between AI agents, developer tools, and internal automation.
+</p>
+
+<p>
+  But if you're building MCP servers in Go today, you'll notice something familiar:
+  you're handed a protocol SDK — and then you're on your own.
+</p>
+
+<p>
+  That's fine for experimentation.
+  It breaks down quickly in production.
+</p>
+
+<p>
+  This post explains why MCP needs a real Go framework, how SDKs and frameworks differ, and why we built mcp-go.
+</p>
+
+<hr />
+
+<h2>MCP SDKs are necessary — but insufficient</h2>
+
+<p>SDKs do an important job:</p>
+
+<ul>
+  <li>enforce protocol correctness</li>
+  <li>track spec changes</li>
+  <li>expose low-level primitives</li>
+</ul>
+
+<p>That's exactly what they should do.</p>
+
+<p>But SDKs intentionally do not:</p>
+
+<ul>
+  <li>define application structure</li>
+  <li>enforce input validation</li>
+  <li>provide middleware</li>
+  <li>offer production defaults</li>
+  <li>optimize for developer experience</li>
+</ul>
+
+<p>If you've used Go long enough, this pattern is familiar.</p>
+
+<hr />
+
+<h2>The HTTP analogy everyone understands</h2>
+
+<p>Go already solved this once.</p>
+
+<ul>
+  <li><code>net/http</code> gives you correctness and control</li>
+  <li>frameworks like Gin give you structure, ergonomics, and safety</li>
+</ul>
+
+<p>Nobody argues that Gin "competes" with <code>net/http</code>.
+They live at different layers.</p>
+
+<p>MCP is no different.</p>
+
+<hr />
+
+<h2>The real problem: production MCP servers</h2>
+
+<p>Once you move beyond demos, every MCP server needs the same things:</p>
+
+<ul>
+  <li>typed inputs</li>
+  <li>validation before business logic</li>
+  <li>consistent error handling</li>
+  <li>middleware (auth, timeouts, logging, rate limits)</li>
+  <li>multiple transports (stdio for agents, HTTP for services)</li>
+  <li>predictable defaults</li>
+</ul>
+
+<p>Without a framework, every team rebuilds this themselves.</p>
+
+<p>That's wasted effort — and inconsistent outcomes.</p>
+
+<hr />
+
+<h2>Enter mcp-go</h2>
+
+<p>
+  mcp-go is a Go framework for building MCP servers, designed the same way Gin was designed for HTTP.
+</p>
+
+<p><strong>What it focuses on:</strong></p>
+
+<ul>
+  <li>typed handlers</li>
+  <li>automatic JSON Schema generation</li>
+  <li>first-class middleware</li>
+  <li>multiple transports from the same server</li>
+  <li>boring, production-safe defaults</li>
+</ul>
+
+<p><strong>What it intentionally avoids:</strong></p>
+
+<ul>
+  <li>agent logic</li>
+  <li>LLM abstractions</li>
+  <li>"magic"</li>
+  <li>protocol reinvention</li>
+</ul>
+
+<p>If the MCP SDK is the kernel, mcp-go is the runtime.</p>
+
+<hr />
+
+<h2>A concrete example</h2>
+
+<p>Instead of manually decoding maps and validating input, you write:</p>
+
+<pre><code>{`srv.Tool("search").
+    Input(SearchInput{}).
+    Handler(func(ctx context.Context, in SearchInput) (any, error) {
+        return svc.Search(ctx, in.Query, in.Limit)
+    })`}</code></pre>
+
+<p>Schema generation, validation, and error mapping happen automatically.</p>
+
+<p>
+  This is not about saving keystrokes.
+  It's about making the correct thing the easy thing.
+</p>
+
+<hr />
+
+<h2>SDKs, community libraries, and frameworks can coexist</h2>
+
+<p>The MCP ecosystem doesn't need "one library to rule them all".</p>
+
+<p>It needs:</p>
+
+<ul>
+  <li>a protocol SDK for correctness</li>
+  <li>community SDKs for flexibility</li>
+  <li>a framework for building real systems</li>
+</ul>
+
+<p>That's where mcp-go fits.</p>
+
+<hr />
+
+<h2>Who mcp-go is for</h2>
+
+<ul>
+  <li>Go platform and infra teams</li>
+  <li>AI tooling and automation services</li>
+  <li>OSS authors building on MCP</li>
+  <li>anyone deploying MCP servers in production</li>
+</ul>
+
+<p>
+  If you just want raw protocol access, an SDK is perfect.
+  If you want structure and safety, you want a framework.
+</p>
+
+<hr />
+
+<h2>Closing</h2>
+
+<p>
+  Frameworks don't replace SDKs.
+  They unlock adoption.
+</p>
+
+<p>
+  That's why we built mcp-go — and why we think MCP in Go needs one.
+</p>
+
+<p>
+  <a href="https://github.com/felixgeelhaar/mcp-go" target="_blank" rel="noopener">
+    View mcp-go on GitHub &rarr;
+  </a>
+</p>
+
+</BlogPostLayout>


### PR DESCRIPTION
Add blog infrastructure and first blog post explaining the value proposition
of mcp-go as a framework (not just an SDK) for building MCP servers in Go.

- Add BlogPostLayout for article pages with proper typography
- Add blog index page listing all posts
- Add first post: "Why MCP needs a real Go framework"
- Update navigation header to include Blog link