### PR TITLE
feat(client): HTTP transport for client-side JSON-RPC

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -1,0 +1,262 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/felixgeelhaar/mcp-go/protocol"
+)
+
+// HTTPTransport speaks JSON-RPC to an MCP server over HTTP. It mirrors
+// the wire format served by transport.HTTP at the /mcp endpoint:
+// every request is POSTed as application/json and the response body
+// is the matching JSON-RPC response.
+//
+// The transport is safe for concurrent use: the underlying
+// http.Client serializes connection reuse, and Send carries no shared
+// per-request state.
+type HTTPTransport struct {
+	endpoint   string
+	httpClient *http.Client
+	headers    http.Header
+}
+
+// HTTPTransportOption configures an HTTPTransport.
+type HTTPTransportOption func(*httpTransportOptions)
+
+type httpTransportOptions struct {
+	httpClient *http.Client
+	headers    http.Header
+	bearer     string
+	caBundle   *x509.CertPool
+	insecure   bool
+	timeout    time.Duration
+	endpoint   string
+}
+
+// WithHTTPClient overrides the http.Client used for requests. When
+// supplied, WithBearerToken / WithCABundle / WithInsecureSkipVerify /
+// WithRequestTimeout become no-ops on the transport TLS configuration —
+// the caller is expected to have set those on the supplied client.
+func WithHTTPClient(c *http.Client) HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.httpClient = c }
+}
+
+// WithBearerToken attaches Authorization: Bearer <token> to every
+// outbound request. Empty token is a no-op so callers can pass it
+// unconditionally.
+func WithBearerToken(token string) HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.bearer = token }
+}
+
+// WithHTTPHeader attaches a static header to every outbound request.
+// Repeated calls accumulate; pass the same key twice to send multiple
+// values. Use for forwarding tenant headers, telemetry headers, etc.
+func WithHTTPHeader(key, value string) HTTPTransportOption {
+	return func(o *httpTransportOptions) {
+		if o.headers == nil {
+			o.headers = http.Header{}
+		}
+		o.headers.Add(key, value)
+	}
+}
+
+// WithCABundle pins the set of CAs used to verify the upstream TLS
+// certificate. Use this when the operator runs a private MCP server
+// behind their own PKI. Ignored when WithHTTPClient supplies a fully
+// configured client.
+func WithCABundle(pool *x509.CertPool) HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.caBundle = pool }
+}
+
+// WithInsecureSkipVerify disables TLS certificate verification.
+// Dangerous; only useful for local development. Ignored when
+// WithHTTPClient supplies a fully configured client.
+func WithInsecureSkipVerify() HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.insecure = true }
+}
+
+// WithRequestTimeout sets the per-request timeout on the underlying
+// http.Client. The Send context still applies and overrides this when
+// it expires sooner. Default: 30s.
+func WithRequestTimeout(d time.Duration) HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.timeout = d }
+}
+
+// WithEndpointPath overrides the URL path used for requests. The
+// default ("/mcp") matches transport.HTTP. Use this only when an
+// operator runs the server behind a path-rewriting proxy.
+func WithEndpointPath(path string) HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.endpoint = path }
+}
+
+// NewHTTPTransport constructs a transport that POSTs JSON-RPC
+// requests to the supplied base URL. The base URL must include a
+// scheme (http or https) and host; the transport appends "/mcp" by
+// default (override via WithEndpointPath).
+//
+// Returns an error when baseURL is malformed or supplies a scheme
+// other than http/https.
+func NewHTTPTransport(baseURL string, opts ...HTTPTransportOption) (*HTTPTransport, error) {
+	if baseURL == "" {
+		return nil, errors.New("mcp-go/client: HTTP transport requires a base URL")
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse base URL: %w", err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("HTTP transport scheme %q not supported (use http or https)", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, errors.New("HTTP transport base URL missing host")
+	}
+
+	options := httpTransportOptions{
+		timeout:  30 * time.Second,
+		endpoint: "/mcp",
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	endpoint := joinURL(u, options.endpoint)
+
+	client := options.httpClient
+	if client == nil {
+		client = buildHTTPClient(options)
+	}
+
+	headers := options.headers
+	if headers == nil {
+		headers = http.Header{}
+	}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept", "application/json")
+	if options.bearer != "" {
+		headers.Set("Authorization", "Bearer "+options.bearer)
+	}
+
+	return &HTTPTransport{
+		endpoint:   endpoint,
+		httpClient: client,
+		headers:    headers,
+	}, nil
+}
+
+func buildHTTPClient(o httpTransportOptions) *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if o.caBundle != nil || o.insecure {
+		tr.TLSClientConfig = &tls.Config{
+			RootCAs:            o.caBundle,
+			InsecureSkipVerify: o.insecure, //nolint:gosec // Opt-in via WithInsecureSkipVerify.
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
+	return &http.Client{
+		Timeout:   o.timeout,
+		Transport: tr,
+	}
+}
+
+func joinURL(base *url.URL, path string) string {
+	if path == "" {
+		return base.String()
+	}
+	cloned := *base
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	cloned.Path = strings.TrimRight(cloned.Path, "/") + path
+	return cloned.String()
+}
+
+// Send marshals the JSON-RPC request, POSTs it to the configured
+// endpoint, and returns the decoded response. Network errors and
+// non-2xx HTTP statuses surface as errors; a JSON-RPC-level error
+// (resp.Error != nil) is preserved on the returned response so the
+// Client can surface protocol errors cleanly.
+func (t *HTTPTransport) Send(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, t.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	for k, vs := range t.headers {
+		for _, v := range vs {
+			httpReq.Header.Add(k, v)
+		}
+	}
+
+	resp, err := t.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("post request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &HTTPStatusError{
+			Status:  resp.StatusCode,
+			Body:    truncate(respBody, 512),
+			Headers: resp.Header.Clone(),
+		}
+	}
+
+	var out protocol.Response
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// Close releases idle connections held by the underlying http.Client.
+// The transport itself is reusable after Close — Send opens a new
+// connection on the next call.
+func (t *HTTPTransport) Close() error {
+	if c, ok := t.httpClient.Transport.(interface{ CloseIdleConnections() }); ok {
+		c.CloseIdleConnections()
+	}
+	return nil
+}
+
+// HTTPStatusError signals a non-2xx HTTP response from the server.
+// Callers can branch on Status to decide between retry-on-5xx and
+// fail-fast-on-4xx semantics.
+type HTTPStatusError struct {
+	Status  int
+	Body    string
+	Headers http.Header
+}
+
+// Error implements error.
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("mcp HTTP %d: %s", e.Status, e.Body)
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "...(truncated)"
+}

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -1,0 +1,342 @@
+package client_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/felixgeelhaar/mcp-go/client"
+	"github.com/felixgeelhaar/mcp-go/protocol"
+)
+
+// echoServer accepts a single JSON-RPC POST and replies with a fixed
+// result. It captures the last received headers and body for
+// assertion.
+type echoServer struct {
+	mu       sync.Mutex
+	path     string
+	headers  http.Header
+	body     []byte
+	response any
+	status   int
+	wait     time.Duration
+}
+
+func (e *echoServer) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		expected := e.path
+		if expected == "" {
+			expected = "/mcp"
+		}
+		if r.URL.Path != expected {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		e.mu.Lock()
+		e.headers = r.Header.Clone()
+		e.body = body
+		e.mu.Unlock()
+		if e.wait > 0 {
+			select {
+			case <-time.After(e.wait):
+			case <-r.Context().Done():
+				return
+			}
+		}
+		if e.status == 0 {
+			e.status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(e.status)
+		if e.response != nil {
+			_ = json.NewEncoder(w).Encode(e.response)
+		}
+	}
+}
+
+func mkRequest(t *testing.T, id int64, method string) *protocol.Request {
+	t.Helper()
+	idRaw, err := json.Marshal(id)
+	if err != nil {
+		t.Fatalf("marshal id: %v", err)
+	}
+	return &protocol.Request{JSONRPC: "2.0", ID: idRaw, Method: method}
+}
+
+func TestHTTPTransport_RoundTrip(t *testing.T) {
+	srv := &echoServer{
+		response: map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  map[string]any{"echoed": true},
+		},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL)
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+
+	resp, err := tr.Send(context.Background(), mkRequest(t, 1, "tools/list"))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok || result["echoed"] != true {
+		t.Errorf("Result=%v want echoed=true", resp.Result)
+	}
+}
+
+func TestHTTPTransport_BearerTokenForwarded(t *testing.T) {
+	srv := &echoServer{
+
+		response: map[string]any{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]any{},
+		},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL, client.WithBearerToken("s3cret"))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := srv.headers.Get("Authorization"); got != "Bearer s3cret" {
+		t.Errorf("Authorization=%q want Bearer s3cret", got)
+	}
+}
+
+func TestHTTPTransport_CustomHeaderForwarded(t *testing.T) {
+	srv := &echoServer{
+
+		response: map[string]any{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]any{},
+		},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL,
+		client.WithHTTPHeader("X-Org-Id", "org-1"),
+		client.WithHTTPHeader("X-Trace", "abc"),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := srv.headers.Get("X-Org-Id"); got != "org-1" {
+		t.Errorf("X-Org-Id=%q", got)
+	}
+	if got := srv.headers.Get("X-Trace"); got != "abc" {
+		t.Errorf("X-Trace=%q", got)
+	}
+	if got := srv.headers.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type=%q", got)
+	}
+}
+
+func TestHTTPTransport_NonSuccessStatus(t *testing.T) {
+	srv := &echoServer{
+
+		status: http.StatusUnauthorized,
+		response: map[string]any{
+			"error": "missing token",
+		},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL)
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	_, err = tr.Send(context.Background(), mkRequest(t, 1, "ping"))
+	var statusErr *client.HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("err=%v want HTTPStatusError", err)
+	}
+	if statusErr.Status != http.StatusUnauthorized {
+		t.Errorf("Status=%d want 401", statusErr.Status)
+	}
+	if !strings.Contains(statusErr.Body, "missing token") {
+		t.Errorf("Body=%q want contains 'missing token'", statusErr.Body)
+	}
+}
+
+func TestHTTPTransport_ContextCancellation(t *testing.T) {
+	srv := &echoServer{
+
+		wait: 200 * time.Millisecond,
+		response: map[string]any{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]any{},
+		},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL)
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := tr.Send(ctx, mkRequest(t, 1, "ping")); err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestHTTPTransport_TLSWithCustomCAPool(t *testing.T) {
+	srv := &echoServer{
+
+		response: map[string]any{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]any{"tls": true},
+		},
+	}
+	ts := httptest.NewTLSServer(srv.handler(t))
+	defer ts.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ts.Certificate())
+
+	tr, err := client.NewHTTPTransport(ts.URL, client.WithCABundle(pool))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	resp, err := tr.Send(context.Background(), mkRequest(t, 1, "ping"))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if m, ok := resp.Result.(map[string]any); !ok || m["tls"] != true {
+		t.Errorf("Result=%v", resp.Result)
+	}
+}
+
+func TestHTTPTransport_TLSDefaultPoolRejectsSelfSigned(t *testing.T) {
+	srv := &echoServer{
+
+		response: map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{}},
+	}
+	ts := httptest.NewTLSServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL)
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err == nil {
+		t.Fatal("expected TLS verification failure")
+	}
+}
+
+func TestHTTPTransport_InsecureSkipVerify(t *testing.T) {
+	srv := &echoServer{
+
+		response: map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{}},
+	}
+	ts := httptest.NewTLSServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL, client.WithInsecureSkipVerify())
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}
+
+func TestHTTPTransport_CustomHTTPClientWins(t *testing.T) {
+	srv := &echoServer{
+
+		response: map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{}},
+	}
+	ts := httptest.NewTLSServer(srv.handler(t))
+	defer ts.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ts.Certificate())
+	custom := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		},
+	}
+	tr, err := client.NewHTTPTransport(ts.URL,
+		client.WithHTTPClient(custom),
+		client.WithCABundle(nil), // ignored when WithHTTPClient is set
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}
+
+func TestHTTPTransport_RejectsBadURL(t *testing.T) {
+	cases := []struct{ url, want string }{
+		{"", "base URL"},
+		{"://broken", "parse"},
+		{"ftp://example.com", "scheme"},
+		{"https://", "host"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			_, err := client.NewHTTPTransport(tc.url)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("NewHTTPTransport(%q) err=%v want contains %q", tc.url, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTTPTransport_EndpointPathOverride(t *testing.T) {
+	srv := &echoServer{
+		path:     "/api/mcp",
+		response: map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{}},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL, client.WithEndpointPath("/api/mcp"))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `client.HTTPTransport`, the request/response counterpart to the existing `transport.HTTP` server. It mirrors `StdioTransport`'s `Send` / `Close` contract so it slots into `client.New(...)` unchanged. Closes the gap blocking downstream HTTP federation use cases (currently anything that connects an MCP client to a remote `transport.HTTP` server has to roll its own JSON-RPC poster).

Wire format matches `transport.HTTP` exactly:

```
POST <baseURL>/mcp
Content-Type: application/json
<JSON-RPC request>
```

## Design

- `Transport` interface unchanged. New transport is opt-in alongside stdio.
- Construction via `client.NewHTTPTransport(baseURL, opts...)` returns an error on malformed URL / unsupported scheme / missing host.
- Options: `WithHTTPClient`, `WithBearerToken`, `WithHTTPHeader`, `WithCABundle`, `WithInsecureSkipVerify`, `WithRequestTimeout`, `WithEndpointPath`. Custom `WithHTTPClient` takes precedence so callers retain full control of TLS / proxy / retry behaviour.
- Non-2xx responses surface as a typed `*HTTPStatusError` (status + truncated body + headers) so callers can branch retry-on-5xx vs fail-fast-on-4xx without parsing strings.
- Default TLS uses `tls.VersionTLS12` minimum.

## Test plan

- [x] `go test ./...` (full repo, no regressions)
- [x] Round-trip against `httptest.NewServer`
- [x] `Authorization: Bearer ...` header forwarding
- [x] Custom static headers + `Content-Type: application/json` always set
- [x] `*HTTPStatusError` classification on 401 / non-2xx with body capture
- [x] Per-request `context.WithTimeout` honoured
- [x] Custom CA bundle accepts pinned cert; default pool rejects self-signed; `WithInsecureSkipVerify` accepts both
- [x] `WithHTTPClient` override wins over `WithCABundle`
- [x] URL validation: empty, malformed, unsupported scheme, missing host
- [x] `WithEndpointPath` reaches a custom path

11 new tests, all passing under `gofmt`/`go vet`/`golangci-lint`/`go test`.