### PR TITLE
chore: extract repeated string literals to satisfy goconst

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,7 @@ linters:
           - gosec
           - gocritic
           - errorlint
+          - goconst
 
       - path: e2e/
         linters:

--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,13 @@ var (
 	ErrNoContent = errors.New("no content")
 )
 
+// JSON field names used in MCP handshake payloads.
+const (
+	fieldName            = "name"
+	fieldVersion         = "version"
+	fieldProtocolVersion = "protocolVersion"
+)
+
 // Transport defines the interface for client-side transport.
 type Transport interface {
 	// Send sends a request and waits for a response.
@@ -221,10 +228,10 @@ func parseBuildInfo(bi map[string]any) *BuildInfo {
 // Initialize performs the MCP handshake with the server.
 func (c *Client) Initialize(ctx context.Context) (*ServerInfo, error) {
 	params := map[string]any{
-		"protocolVersion": c.opts.protocolVer,
+		fieldProtocolVersion: c.opts.protocolVer,
 		"clientInfo": map[string]any{
-			"name":    c.opts.clientName,
-			"version": c.opts.clientVer,
+			fieldName:    c.opts.clientName,
+			fieldVersion: c.opts.clientVer,
 		},
 		"capabilities": map[string]any{},
 	}
@@ -241,15 +248,15 @@ func (c *Client) Initialize(ctx context.Context) (*ServerInfo, error) {
 
 	info := &ServerInfo{}
 
-	if pv, ok := result["protocolVersion"].(string); ok {
+	if pv, ok := result[fieldProtocolVersion].(string); ok {
 		info.ProtocolVersion = pv
 	}
 
 	if si, ok := result["serverInfo"].(map[string]any); ok {
-		if name, ok := si["name"].(string); ok {
+		if name, ok := si[fieldName].(string); ok {
 			info.Name = name
 		}
-		if ver, ok := si["version"].(string); ok {
+		if ver, ok := si[fieldVersion].(string); ok {
 			info.Version = ver
 		}
 		if title, ok := si["title"].(string); ok {

--- a/mcp.go
+++ b/mcp.go
@@ -41,6 +41,17 @@ import (
 	grpctransport "github.com/felixgeelhaar/mcp-go/transport/grpc"
 )
 
+// JSON field names used in MCP protocol payloads. Extracted as constants
+// so map-literal builders share a single source of truth (and silence
+// goconst).
+const (
+	fieldName            = "name"
+	fieldVersion         = "version"
+	fieldProtocolVersion = "protocolVersion"
+	fieldListChanged     = "listChanged"
+	fieldText            = "text"
+)
+
 // Re-export core types for convenience
 
 // ServerInfo contains server metadata exposed to clients.
@@ -578,19 +589,19 @@ func (h *requestHandler) handleInitialize(_ context.Context, req *protocol.Reque
 	capabilities := make(map[string]any)
 
 	if manifest.Capabilities.Tools || len(h.srv.Tools()) > 0 {
-		capabilities["tools"] = map[string]any{"listChanged": true}
+		capabilities["tools"] = map[string]any{fieldListChanged: true}
 	}
 	if manifest.Capabilities.Resources || len(h.srv.Resources()) > 0 {
-		capabilities["resources"] = map[string]any{"listChanged": true}
+		capabilities["resources"] = map[string]any{fieldListChanged: true}
 	}
 	if manifest.Capabilities.Prompts || len(h.srv.Prompts()) > 0 {
-		capabilities["prompts"] = map[string]any{"listChanged": true}
+		capabilities["prompts"] = map[string]any{fieldListChanged: true}
 	}
 
 	// Build serverInfo with required fields
 	serverInfo := map[string]any{
-		"name":    manifest.Name,
-		"version": manifest.Version,
+		fieldName:    manifest.Name,
+		fieldVersion: manifest.Version,
 	}
 
 	// Add optional MCP spec fields if set
@@ -612,9 +623,9 @@ func (h *requestHandler) handleInitialize(_ context.Context, req *protocol.Reque
 	}
 
 	result := map[string]any{
-		"protocolVersion": manifest.ProtocolVersion,
-		"serverInfo":      serverInfo,
-		"capabilities":    capabilities,
+		fieldProtocolVersion: manifest.ProtocolVersion,
+		"serverInfo":         serverInfo,
+		"capabilities":       capabilities,
 	}
 
 	// Include instructions if set
@@ -631,7 +642,7 @@ func (h *requestHandler) handleToolsList(_ context.Context, req *protocol.Reques
 	toolList := make([]map[string]any, 0, len(tools))
 	for _, t := range tools {
 		item := map[string]any{
-			"name":        t.Name,
+			fieldName:     t.Name,
 			"description": t.Description,
 			"inputSchema": t.InputSchema,
 		}
@@ -742,8 +753,8 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 		}
 		response["content"] = []map[string]any{
 			{
-				"type": "text",
-				"text": textContent,
+				"type":    fieldText,
+				fieldText: textContent,
 			},
 		}
 	}
@@ -761,8 +772,8 @@ func (h *requestHandler) handleResourcesList(_ context.Context, req *protocol.Re
 	resourceList := make([]map[string]any, 0, len(resources))
 	for _, r := range resources {
 		item := map[string]any{
-			"uri":  r.URITemplate,
-			"name": r.Name,
+			"uri":     r.URITemplate,
+			fieldName: r.Name,
 		}
 		if r.Description != "" {
 			item["description"] = r.Description
@@ -813,7 +824,7 @@ func (h *requestHandler) handleResourcesRead(ctx context.Context, req *protocol.
 			{
 				"uri":      content.URI,
 				"mimeType": content.MimeType,
-				"text":     content.Text,
+				fieldText:  content.Text,
 			},
 		},
 	}
@@ -832,7 +843,7 @@ func (h *requestHandler) handlePromptsList(_ context.Context, req *protocol.Requ
 	promptList := make([]map[string]any, 0, len(prompts))
 	for _, p := range prompts {
 		item := map[string]any{
-			"name": p.Name,
+			fieldName: p.Name,
 		}
 		if p.Description != "" {
 			item["description"] = p.Description
@@ -841,7 +852,7 @@ func (h *requestHandler) handlePromptsList(_ context.Context, req *protocol.Requ
 			args := make([]map[string]any, 0, len(p.Arguments))
 			for _, arg := range p.Arguments {
 				argItem := map[string]any{
-					"name":     arg.Name,
+					fieldName:  arg.Name,
 					"required": arg.Required,
 				}
 				if arg.Description != "" {

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -8,6 +8,21 @@ import (
 	"github.com/felixgeelhaar/mcp-go/protocol"
 )
 
+// Shared string constants for middleware audit/auth/rate-limit/size-limit
+// emitters. Defined here since AuditEvent is the canonical home; auth.go,
+// ratelimit.go, sizelimit.go and logging.go reuse them.
+const (
+	statusError   = "error"
+	statusSuccess = "success"
+
+	actionToolsList    = "tools.list"
+	actionToolsExecute = "tools.execute"
+
+	// Log/audit field keys reused across middleware emitters.
+	fieldKeyMethod = "method"
+	fieldKeyError  = "error"
+)
+
 type AuditEvent struct {
 	Timestamp     time.Time      `json:"timestamp"`
 	CorrelationID string         `json:"correlationId"`
@@ -58,13 +73,13 @@ func (a *AuditMiddleware) Middleware() Middleware {
 			event.Error = ""
 			switch {
 			case err != nil:
-				event.Status = "error"
+				event.Status = statusError
 				event.Error = err.Error()
 			case resp != nil && resp.Error != nil:
-				event.Status = "error"
+				event.Status = statusError
 				event.Error = resp.Error.Message
 			default:
-				event.Status = "success"
+				event.Status = statusSuccess
 			}
 
 			a.logger.LogEvent(ctx, event)
@@ -76,27 +91,27 @@ func (a *AuditMiddleware) Middleware() Middleware {
 
 func classifyAction(method string) string {
 	switch method {
-	case "initialize":
+	case protocol.MethodInitialize:
 		return "session.start"
-	case "notifications/initialized":
+	case protocol.MethodInitialized:
 		return "session.ready"
-	case "tools/list":
-		return "tools.list"
-	case "tools/call":
-		return "tools.execute"
-	case "resources/list":
+	case protocol.MethodToolsList:
+		return actionToolsList
+	case protocol.MethodToolsCall:
+		return actionToolsExecute
+	case protocol.MethodResourcesList:
 		return "resources.list"
-	case "resources/read":
+	case protocol.MethodResourcesRead:
 		return "resources.read"
-	case "resources/subscribe":
+	case protocol.MethodResourcesSubscribe:
 		return "resources.subscribe"
-	case "resources/unsubscribe":
+	case protocol.MethodResourcesUnsubscribe:
 		return "resources.unsubscribe"
-	case "prompts/list":
+	case protocol.MethodPromptsList:
 		return "prompts.list"
-	case "prompts/get":
+	case protocol.MethodPromptsGet:
 		return "prompts.get"
-	case "ping":
+	case protocol.MethodPing:
 		return "health.ping"
 	case "tasks/create":
 		return "tasks.create"
@@ -106,7 +121,7 @@ func classifyAction(method string) string {
 		return "tasks.list"
 	case "tasks/cancel":
 		return "tasks.cancel"
-	case "logging/setLevel":
+	case protocol.MethodLoggingSetLevel:
 		return "logging.configure"
 	default:
 		return "unknown"

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -110,8 +110,8 @@ func Auth(authenticator Authenticator, opts ...AuthOption) Middleware {
 			if err != nil {
 				if cfg.logger != nil {
 					cfg.logger.Warn("authentication failed",
-						Field{Key: "method", Value: req.Method},
-						Field{Key: "error", Value: err.Error()},
+						Field{Key: fieldKeyMethod, Value: req.Method},
+						Field{Key: fieldKeyError, Value: err.Error()},
 					)
 				}
 				return nil, &protocol.Error{
@@ -123,7 +123,7 @@ func Auth(authenticator Authenticator, opts ...AuthOption) Middleware {
 			if identity == nil {
 				if cfg.logger != nil {
 					cfg.logger.Warn("authentication failed: no identity",
-						Field{Key: "method", Value: req.Method},
+						Field{Key: fieldKeyMethod, Value: req.Method},
 					)
 				}
 				return nil, &protocol.Error{
@@ -134,7 +134,7 @@ func Auth(authenticator Authenticator, opts ...AuthOption) Middleware {
 
 			if cfg.logger != nil {
 				cfg.logger.Debug("authenticated",
-					Field{Key: "method", Value: req.Method},
+					Field{Key: fieldKeyMethod, Value: req.Method},
 					Field{Key: "identity", Value: identity.ID},
 				)
 			}

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -44,7 +44,7 @@ func Logging(logger Logger) Middleware {
 
 			// Build fields
 			fields := []Field{
-				NewField("method", req.Method),
+				NewField(fieldKeyMethod, req.Method),
 				NewField("duration", duration),
 			}
 
@@ -54,7 +54,7 @@ func Logging(logger Logger) Middleware {
 			}
 
 			if err != nil {
-				fields = append(fields, NewField("error", err.Error()))
+				fields = append(fields, NewField(fieldKeyError, err.Error()))
 				logger.Error("request failed", fields...)
 			} else {
 				logger.Info("request completed", fields...)

--- a/middleware/ratelimit.go
+++ b/middleware/ratelimit.go
@@ -57,7 +57,7 @@ func RateLimit(rate int, burst int, opts ...RateLimitOption) Middleware {
 			if !limiter.Allow(ctx, key) {
 				if cfg.logger != nil {
 					cfg.logger.Warn("rate limit exceeded",
-						Field{Key: "method", Value: req.Method},
+						Field{Key: fieldKeyMethod, Value: req.Method},
 						Field{Key: "key", Value: key},
 					)
 				}

--- a/middleware/sizelimit.go
+++ b/middleware/sizelimit.go
@@ -36,7 +36,7 @@ func SizeLimit(maxBytes int64, opts ...SizeLimitOption) Middleware {
 				if size > maxBytes {
 					if cfg.logger != nil {
 						cfg.logger.Warn("request size limit exceeded",
-							Field{Key: "method", Value: req.Method},
+							Field{Key: fieldKeyMethod, Value: req.Method},
 							Field{Key: "size", Value: size},
 							Field{Key: "max", Value: maxBytes},
 						)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const tagRequired = "required"
+
 // Schema represents a JSON Schema.
 type Schema struct {
 	Type        string             `json:"type,omitempty"`
@@ -32,7 +34,7 @@ func GenerateFromType(t reflect.Type) (*Schema, error) {
 
 func generateFromType(t reflect.Type) (*Schema, error) {
 	// Handle pointers
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -40,18 +42,18 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 	case reflect.Struct:
 		return generateStructSchema(t)
 	case reflect.String:
-		return &Schema{Type: "string"}, nil
+		return &Schema{Type: typeString}, nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return &Schema{Type: "integer"}, nil
+		return &Schema{Type: typeInteger}, nil
 	case reflect.Float32, reflect.Float64:
-		return &Schema{Type: "number"}, nil
+		return &Schema{Type: typeNumber}, nil
 	case reflect.Bool:
-		return &Schema{Type: "boolean"}, nil
+		return &Schema{Type: typeBoolean}, nil
 	case reflect.Slice, reflect.Array:
 		return generateArraySchema(t)
 	case reflect.Map:
-		return &Schema{Type: "object"}, nil
+		return &Schema{Type: typeObject}, nil
 	default:
 		return &Schema{}, nil
 	}
@@ -59,7 +61,7 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 
 func generateStructSchema(t reflect.Type) (*Schema, error) {
 	schema := &Schema{
-		Type:       "object",
+		Type:       typeObject,
 		Properties: make(map[string]*Schema),
 	}
 
@@ -107,7 +109,7 @@ func generateArraySchema(t reflect.Type) (*Schema, error) {
 	}
 
 	return &Schema{
-		Type:  "array",
+		Type:  typeArray,
 		Items: itemSchema,
 	}, nil
 }
@@ -121,7 +123,7 @@ func parseJSONSchemaTag(tag string, schema *Schema, required *[]string, fieldNam
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 
-		if part == "required" {
+		if part == tagRequired {
 			*required = append(*required, fieldName)
 			continue
 		}

--- a/server/completion.go
+++ b/server/completion.go
@@ -4,6 +4,12 @@ import (
 	"context"
 )
 
+// CompletionRef Type values defined by the MCP completion spec.
+const (
+	CompletionRefPrompt   = "ref/prompt"
+	CompletionRefResource = "ref/resource"
+)
+
 // CompletionHandler handles completion requests for prompts or resources.
 type CompletionHandler func(ctx context.Context, ref CompletionRef, argument CompletionArgument) (*CompletionResult, error)
 
@@ -73,9 +79,9 @@ func (r *completionRegistry) Handle(ctx context.Context, ref CompletionRef, arg 
 	var handler CompletionHandler
 
 	switch ref.Type {
-	case "ref/prompt":
+	case CompletionRefPrompt:
 		handler = r.promptHandlers[ref.Name]
-	case "ref/resource":
+	case CompletionRefResource:
 		handler = r.resourceHandlers[ref.URI]
 		// Try to match by URI template pattern if exact match fails
 		if handler == nil {

--- a/server/sampling.go
+++ b/server/sampling.go
@@ -14,6 +14,12 @@ const (
 	RoleAssistant Role = "assistant"
 )
 
+// Content type tag values used inside Content.Type.
+const (
+	contentTypeText  = "text"
+	contentTypeImage = "image"
+)
+
 // Content represents the content of a message.
 type Content struct {
 	Type     string `json:"type"`
@@ -25,7 +31,7 @@ type Content struct {
 // NewTextContent creates a text content block.
 func NewTextContent(text string) Content {
 	return Content{
-		Type: "text",
+		Type: contentTypeText,
 		Text: text,
 	}
 }
@@ -33,7 +39,7 @@ func NewTextContent(text string) Content {
 // NewImageContent creates an image content block.
 func NewImageContent(mimeType, data string) Content {
 	return Content{
-		Type:     "image",
+		Type:     contentTypeImage,
 		MimeType: mimeType,
 		Data:     data,
 	}

--- a/server/tasks.go
+++ b/server/tasks.go
@@ -20,6 +20,12 @@ const (
 	TaskStatusCanceled  TaskStatus = "canceled"
 )
 
+// Task metadata field keys.
+const (
+	metaKeyName   = "name"
+	metaKeyParams = "params"
+)
+
 type TaskResult struct {
 	Data  any    `json:"data,omitempty"`
 	Error string `json:"error,omitempty"`
@@ -197,8 +203,8 @@ func (m *TaskManager) CreateTask(ctx context.Context, req CreateTaskRequest) (*T
 		Message:   "Task queued",
 		CreatedAt: time.Now(),
 		Metadata: map[string]any{
-			"name":   req.Name,
-			"params": req.Params,
+			metaKeyName:   req.Name,
+			metaKeyParams: req.Params,
 		},
 	}
 

--- a/server/tool.go
+++ b/server/tool.go
@@ -154,7 +154,7 @@ func (b *ToolBuilder) validateHandler(fn any) error {
 
 	// Store input type
 	inputType := fnType.In(inputParamIdx)
-	if inputType.Kind() == reflect.Ptr {
+	if inputType.Kind() == reflect.Pointer {
 		inputType = inputType.Elem()
 	}
 	b.tool.inputType = inputType

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -34,6 +34,14 @@ import (
 	"github.com/felixgeelhaar/mcp-go/transport"
 )
 
+// JSON field names used in testutil request/response payloads.
+const (
+	fieldName      = "name"
+	fieldArguments = "arguments"
+	fieldURI       = "uri"
+	fieldText      = "text"
+)
+
 // TestClient is a test client for MCP servers.
 type TestClient struct {
 	t       testing.TB
@@ -121,7 +129,7 @@ func (tc *TestClient) Initialize() (map[string]any, error) {
 	resp, err := tc.SendRequest(protocol.MethodInitialize, map[string]any{
 		"protocolVersion": protocol.MCPVersion,
 		"clientInfo": map[string]any{
-			"name":    "test-client",
+			fieldName: "test-client",
 			"version": "1.0.0",
 		},
 	})
@@ -179,8 +187,8 @@ func (tc *TestClient) CallTool(name string, args any) (string, error) {
 	tc.t.Helper()
 
 	resp, err := tc.SendRequest(protocol.MethodToolsCall, map[string]any{
-		"name":      name,
-		"arguments": args,
+		fieldName:      name,
+		fieldArguments: args,
 	})
 	if err != nil {
 		return "", err
@@ -215,7 +223,7 @@ func (tc *TestClient) CallTool(name string, args any) (string, error) {
 		return "", fmt.Errorf("nil content item")
 	}
 
-	text, _ := first["text"].(string)
+	text, _ := first[fieldText].(string)
 	return text, nil
 }
 
@@ -224,8 +232,8 @@ func (tc *TestClient) CallToolRaw(name string, args any) (*protocol.Response, er
 	tc.t.Helper()
 
 	return tc.SendRequest(protocol.MethodToolsCall, map[string]any{
-		"name":      name,
-		"arguments": args,
+		fieldName:      name,
+		fieldArguments: args,
 	})
 }
 
@@ -268,7 +276,7 @@ func (tc *TestClient) ReadResource(uri string) (string, error) {
 	tc.t.Helper()
 
 	resp, err := tc.SendRequest(protocol.MethodResourcesRead, map[string]any{
-		"uri": uri,
+		fieldURI: uri,
 	})
 	if err != nil {
 		return "", err
@@ -303,7 +311,7 @@ func (tc *TestClient) ReadResource(uri string) (string, error) {
 		return "", fmt.Errorf("nil contents item")
 	}
 
-	text, _ := first["text"].(string)
+	text, _ := first[fieldText].(string)
 	return text, nil
 }
 
@@ -346,8 +354,8 @@ func (tc *TestClient) GetPrompt(name string, args map[string]string) (map[string
 	tc.t.Helper()
 
 	resp, err := tc.SendRequest(protocol.MethodPromptsGet, map[string]any{
-		"name":      name,
-		"arguments": args,
+		fieldName:      name,
+		fieldArguments: args,
 	})
 	if err != nil {
 		return nil, err
@@ -424,7 +432,7 @@ func (h *requestHandler) handleInitialize(req *protocol.Request) (*protocol.Resp
 	result := map[string]any{
 		"protocolVersion": manifest.ProtocolVersion,
 		"serverInfo": map[string]any{
-			"name":    manifest.Name,
+			fieldName: manifest.Name,
 			"version": manifest.Version,
 		},
 		"capabilities": capabilities,
@@ -439,7 +447,7 @@ func (h *requestHandler) handleToolsList(req *protocol.Request) (*protocol.Respo
 	toolList := make([]map[string]any, 0, len(tools))
 	for _, t := range tools {
 		toolList = append(toolList, map[string]any{
-			"name":        t.Name,
+			fieldName:     t.Name,
 			"description": t.Description,
 			"inputSchema": t.InputSchema,
 		})
@@ -469,7 +477,7 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 
 	response := map[string]any{
 		"content": []map[string]any{
-			{"type": "text", "text": result},
+			{"type": fieldText, fieldText: result},
 		},
 	}
 
@@ -482,8 +490,8 @@ func (h *requestHandler) handleResourcesList(req *protocol.Request) (*protocol.R
 	resourceList := make([]map[string]any, 0, len(resources))
 	for _, r := range resources {
 		item := map[string]any{
-			"uri":  r.URITemplate,
-			"name": r.Name,
+			fieldURI:  r.URITemplate,
+			fieldName: r.Name,
 		}
 		if r.Description != "" {
 			item["description"] = r.Description
@@ -534,7 +542,7 @@ func (h *requestHandler) handlePromptsList(req *protocol.Request) (*protocol.Res
 	promptList := make([]map[string]any, 0, len(prompts))
 	for _, p := range prompts {
 		item := map[string]any{
-			"name": p.Name,
+			fieldName: p.Name,
 		}
 		if p.Description != "" {
 			item["description"] = p.Description
@@ -543,7 +551,7 @@ func (h *requestHandler) handlePromptsList(req *protocol.Request) (*protocol.Res
 			args := make([]map[string]any, 0, len(p.Arguments))
 			for _, arg := range p.Arguments {
 				argItem := map[string]any{
-					"name":     arg.Name,
+					fieldName:  arg.Name,
 					"required": arg.Required,
 				}
 				if arg.Description != "" {
@@ -551,7 +559,7 @@ func (h *requestHandler) handlePromptsList(req *protocol.Request) (*protocol.Res
 				}
 				args = append(args, argItem)
 			}
-			item["arguments"] = args
+			item[fieldArguments] = args
 		}
 		promptList = append(promptList, item)
 	}

--- a/transport/http.go
+++ b/transport/http.go
@@ -12,6 +12,10 @@ import (
 	"github.com/felixgeelhaar/mcp-go/protocol"
 )
 
+// healthStatusField is the JSON field name used in /health and /healthz
+// payloads.
+const healthStatusField = "status"
+
 type HTTP struct {
 	addr            string
 	readTimeout     time.Duration
@@ -131,7 +135,7 @@ func (h *HTTP) createHandler(handler Handler) http.Handler {
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		_ = json.NewEncoder(w).Encode(map[string]string{healthStatusField: "ok"})
 	})
 
 	mux.HandleFunc("/healthz", h.handleHealthz)
@@ -175,8 +179,8 @@ func (h *HTTP) handleHealthz(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(httpStatus)
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"status": status,
-		"ready":  ready,
+		healthStatusField: status,
+		"ready":           ready,
 	})
 }
 

--- a/transport/stdio.go
+++ b/transport/stdio.go
@@ -113,7 +113,7 @@ func (s *Stdio) SendNotification(method string, params any) error {
 	}
 
 	notif := Notification{
-		JSONRPC: "2.0",
+		JSONRPC: JSONRPCVersion,
 		Method:  method,
 		Params:  paramsData,
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -8,6 +8,10 @@ import (
 	"github.com/felixgeelhaar/mcp-go/protocol"
 )
 
+// JSONRPCVersion is the JSON-RPC version emitted in every transport-level
+// notification or response. MCP is JSON-RPC 2.0.
+const JSONRPCVersion = "2.0"
+
 // Handler processes incoming MCP requests.
 type Handler interface {
 	HandleRequest(ctx context.Context, req *protocol.Request) (*protocol.Response, error)

--- a/transport/websocket.go
+++ b/transport/websocket.go
@@ -225,7 +225,7 @@ func (s *wsNotificationSender) SendNotification(method string, params any) error
 	}
 
 	notif := Notification{
-		JSONRPC: "2.0",
+		JSONRPC: JSONRPCVersion,
 		Method:  method,
 		Params:  paramsData,
 	}


### PR DESCRIPTION
## Summary

Extract recurring JSON field names, JSON-RPC version, audit action labels, log field keys, and content type tags into package-level constants so the codebase passes \`golangci-lint run ./...\` cleanly. The pre-commit hook had been silently failing on \`goconst\` (min-occurrences: 3) for a while; this gets it back to zero issues.

No runtime behaviour change — every literal is replaced by a constant of the same value.

### Notable changes

- \`middleware/audit.go\` \`classifyAction\` now references existing \`protocol.Method*\` constants instead of duplicating method strings.
- \`reflect.Ptr\` → \`reflect.Pointer\` (govet inline) in \`schema/schema.go\` and \`server/tool.go\`.
- \`examples/\` now also excluded from \`goconst\`, matching the existing \`errcheck/gosec/gocritic/errorlint\` exclusion for that path.
- Touched packages: \`mcp\`, \`client\`, \`schema\`, \`server\`, \`middleware\`, \`testutil\`, \`transport\`.

This is prep work for a follow-up fix to \`schema\` that needs to commit on a clean lint baseline.

## Test plan

- [x] \`golangci-lint run ./...\` → 0 issues
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` succeeds
- [x] \`go test -race -count=1 ./...\` all packages green
- [x] Pre-commit hook (\`.githooks/pre-commit\`) passes locally