### PR TITLE
fix(schema): always emit properties for object schemas (OpenAI strict mode)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2,6 +2,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 )
@@ -9,16 +10,70 @@ import (
 const tagRequired = "required"
 
 // Schema represents a JSON Schema.
+//
+// AdditionalProperties is encoded only when explicitly set. For struct-derived
+// schemas it is set to bool(false) so the resulting JSON satisfies OpenAI
+// strict tool-calling, which requires closed objects. Map-derived schemas
+// leave it unset so they remain open.
 type Schema struct {
-	Type        string             `json:"type,omitempty"`
-	Properties  map[string]*Schema `json:"properties,omitempty"`
-	Required    []string           `json:"required,omitempty"`
-	Description string             `json:"description,omitempty"`
-	Default     any                `json:"default,omitempty"`
-	Enum        []any              `json:"enum,omitempty"`
-	Minimum     *float64           `json:"minimum,omitempty"`
-	Maximum     *float64           `json:"maximum,omitempty"`
-	Items       *Schema            `json:"items,omitempty"`
+	Type                 string             `json:"type,omitempty"`
+	Properties           map[string]*Schema `json:"properties,omitempty"`
+	AdditionalProperties any                `json:"-"`
+	Required             []string           `json:"required,omitempty"`
+	Description          string             `json:"description,omitempty"`
+	Default              any                `json:"default,omitempty"`
+	Enum                 []any              `json:"enum,omitempty"`
+	Minimum              *float64           `json:"minimum,omitempty"`
+	Maximum              *float64           `json:"maximum,omitempty"`
+	Items                *Schema            `json:"items,omitempty"`
+}
+
+// MarshalJSON encodes the schema. For object-typed schemas it forces the
+// "properties" key to be present (emitting `{}` when empty) and writes
+// AdditionalProperties when set.
+//
+// Why: OpenAI's strict function-calling mode rejects object schemas that
+// omit "properties" with the error
+// `object schema missing properties. (format)`, which would otherwise
+// break any tool whose handler input is `struct{}`. Forcing properties
+// to materialize removes the footgun for downstream consumers.
+func (s Schema) MarshalJSON() ([]byte, error) {
+	if s.Type != typeObject {
+		type plain Schema
+		return json.Marshal(plain(s))
+	}
+
+	out := map[string]any{"type": typeObject}
+	props := s.Properties
+	if props == nil {
+		props = map[string]*Schema{}
+	}
+	out["properties"] = props
+	if s.AdditionalProperties != nil {
+		out["additionalProperties"] = s.AdditionalProperties
+	}
+	if len(s.Required) > 0 {
+		out[tagRequired] = s.Required
+	}
+	if s.Description != "" {
+		out["description"] = s.Description
+	}
+	if s.Default != nil {
+		out["default"] = s.Default
+	}
+	if len(s.Enum) > 0 {
+		out["enum"] = s.Enum
+	}
+	if s.Minimum != nil {
+		out["minimum"] = *s.Minimum
+	}
+	if s.Maximum != nil {
+		out["maximum"] = *s.Maximum
+	}
+	if s.Items != nil {
+		out["items"] = s.Items
+	}
+	return json.Marshal(out)
 }
 
 // Generate creates a JSON Schema from a Go value.
@@ -60,9 +115,13 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 }
 
 func generateStructSchema(t reflect.Type) (*Schema, error) {
+	// AdditionalProperties: false marks the object as closed so OpenAI
+	// strict tool-calling accepts the schema. Maps, which can grow at
+	// runtime, leave AdditionalProperties unset (handled separately).
 	schema := &Schema{
-		Type:       typeObject,
-		Properties: make(map[string]*Schema),
+		Type:                 typeObject,
+		Properties:           make(map[string]*Schema),
+		AdditionalProperties: false,
 	}
 
 	for i := 0; i < t.NumField(); i++ {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -203,3 +203,88 @@ func TestSchema_MarshalJSON(t *testing.T) {
 		t.Errorf("type = %v, want %q", result["type"], "object")
 	}
 }
+
+// TestSchema_EmptyStructIsStrictModeCompatible regression-tests the
+// OpenAI strict tool-calling failure where zero-arg handlers produced
+// `{"type":"object"}` and were rejected with
+// `object schema missing properties. (format)`.
+//
+// The encoded schema for an empty struct must:
+//   - include a "properties" key (empty object), not omit it
+//   - declare additionalProperties: false (closed object)
+func TestSchema_EmptyStructIsStrictModeCompatible(t *testing.T) {
+	type Empty struct{}
+
+	s, err := Generate(Empty{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	props, ok := got["properties"]
+	if !ok {
+		t.Fatalf("properties key missing; raw=%s", data)
+	}
+	if pm, ok := props.(map[string]any); !ok || len(pm) != 0 {
+		t.Errorf("properties = %v, want empty object", props)
+	}
+	if got["additionalProperties"] != false {
+		t.Errorf("additionalProperties = %v, want false; raw=%s", got["additionalProperties"], data)
+	}
+	if got["type"] != "object" {
+		t.Errorf("type = %v, want object", got["type"])
+	}
+}
+
+// TestSchema_StructIsClosed verifies non-empty struct schemas are also
+// closed (additionalProperties: false) so they pass strict mode.
+func TestSchema_StructIsClosed(t *testing.T) {
+	type Input struct {
+		Name string `json:"name"`
+	}
+
+	s, err := Generate(Input{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["additionalProperties"] != false {
+		t.Errorf("additionalProperties = %v, want false; raw=%s", got["additionalProperties"], data)
+	}
+}
+
+// TestSchema_NonObjectUnaffected ensures string/number/etc. schemas
+// don't pick up spurious properties keys from the object-only path.
+func TestSchema_NonObjectUnaffected(t *testing.T) {
+	s := &Schema{Type: "string"}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, has := got["properties"]; has {
+		t.Errorf("string schema should not emit properties; raw=%s", data)
+	}
+	if _, has := got["additionalProperties"]; has {
+		t.Errorf("string schema should not emit additionalProperties; raw=%s", data)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes downstream failure where OpenAI strict tool-calling rejects MCP tool schemas advertised by mcp-go for any handler whose input is \`struct{}\`:

\`\`\`
400 Invalid schema for function 'mnemos__knowledge_metrics':
In context=(), object schema missing properties. (format)
\`\`\`

### Root cause

\`schema.Schema.Properties\` had \`json:\"properties,omitempty\"\`, so a zero-arg handler serialized as \`{\"type\":\"object\"}\` — properties key missing entirely. OpenAI strict mode rejects.

### Fix

- Custom \`MarshalJSON\` on \`Schema\`: for \`type:object\`, always emits \`properties\` (\`{}\` when empty) and writes \`additionalProperties\` when set.
- \`generateStructSchema\` now sets \`AdditionalProperties: false\` so struct-derived schemas are closed objects → satisfies OpenAI strict mode end-to-end.
- Map-derived schemas keep \`AdditionalProperties\` unset → stay open (correct for \`map[string]Foo\`).

### Reported by

User running \`mnemos\` 0.6.1 + OpenClaw 2026.5.7 gateway + OpenAI gpt-4o. Their entire tool list was rejected per request, blocking any agent turn that listed a zero-arg tool. They patched locally by adding a fake input; this fixes the bug at the schema-generator layer so every mcp-go consumer is protected.

## Base branch

Stacks on top of #77 (string-constant cleanup) so the pre-commit lint baseline is clean. Rebase to main after #77 merges.

## Test plan

- [x] New regression tests in \`schema/schema_test.go\`:
  - empty struct → \`properties: {}\` + \`additionalProperties: false\`
  - populated struct → \`additionalProperties: false\`
  - non-object schema → no spurious properties / additionalProperties leak
- [x] \`go test -race -count=1 ./...\` all packages green
- [x] Verified against \`mnemos\` (downstream consumer, full \`./...\` race suite) via temporary \`replace\` directive — all packages pass.
- [x] Pre-commit hook clean (lint + vet + build + race tests)