### PR TITLE
fix(ci): pin nox version and fail fast on download error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,11 @@ jobs:
           go-version: '1.25'
 
       - name: Install nox
+        env:
+          NOX_VERSION: 0.10.0
         run: |
-          curl -sL https://github.com/nox-hq/nox/releases/latest/download/nox_0.9.5_linux_amd64.tar.gz | tar xz -C /usr/local/bin nox
+          curl -fsSL "https://github.com/nox-hq/nox/releases/download/v${NOX_VERSION}/nox_${NOX_VERSION}_linux_amd64.tar.gz" \
+            | tar xz -C /usr/local/bin nox
 
       - name: Run nox Security Scan
         run: nox scan . || true


### PR DESCRIPTION
## Summary

The Security Scan job hard-coded \`nox_0.9.5_linux_amd64.tar.gz\` under \`/releases/latest/download/\`, but the latest nox release is \`v0.10.0\` — its assets are named \`nox_0.10.0_*\`. The pinned-name request 404s, GitHub returns an HTML error page, and \`tar\` chokes with the misleading \`gzip: stdin: not in gzip format\`.

Result: every CI run on \`main\` (and every PR) has been failing the Security Scan check. See e.g. run on PR #77.

## Fix

- Pin \`NOX_VERSION\` env to \`0.10.0\` and use \`/releases/download/v\${VERSION}/\` directly — version bumps become deliberate single-line edits.
- Switch curl flags from \`-sL\` to \`-fsSL\`. \`-f\` surfaces HTTP failures instead of streaming error HTML into \`tar\`, so the next time a release URL drifts the failure is obvious.

## Test plan

- [x] Verified \`https://github.com/nox-hq/nox/releases/download/v0.10.0/nox_0.10.0_linux_amd64.tar.gz\` returns 200.
- [ ] CI run on this PR shows Security Scan passing (or at least passing the install step — \`nox scan\` itself is gated by \`|| true\`).