### PR TITLE
fix: spec-compliant structuredContent for typed-struct tool results

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -713,50 +713,9 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 	}
 
 	// Format result based on type
-	response := make(map[string]any)
-
-	switch v := result.(type) {
-	case server.StructuredResult:
-		if len(v.Content) > 0 {
-			response["content"] = v.Content
-		} else {
-			response["content"] = []map[string]any{}
-		}
-		response["structuredContent"] = v.StructuredContent
-		if v.IsError {
-			response["isError"] = true
-		}
-	case *server.StructuredResult:
-		if v != nil {
-			if len(v.Content) > 0 {
-				response["content"] = v.Content
-			} else {
-				response["content"] = []map[string]any{}
-			}
-			response["structuredContent"] = v.StructuredContent
-			if v.IsError {
-				response["isError"] = true
-			}
-		}
-	default:
-		// Legacy: serialize to text content block
-		var textContent string
-		switch tv := result.(type) {
-		case string:
-			textContent = tv
-		default:
-			data, err := json.Marshal(tv)
-			if err != nil {
-				return nil, protocol.NewInternalError(fmt.Sprintf("failed to serialize tool result: %v", err))
-			}
-			textContent = string(data)
-		}
-		response["content"] = []map[string]any{
-			{
-				"type":    fieldText,
-				fieldText: textContent,
-			},
-		}
+	response, err := buildToolCallResponse(tool, result)
+	if err != nil {
+		return nil, err
 	}
 
 	if tool.Meta() != nil {
@@ -764,6 +723,78 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 	}
 
 	return protocol.NewResponse(req.ID, response), nil
+}
+
+// buildToolCallResponse converts a handler's return value into the MCP
+// tools/call response body. Three shapes are accepted:
+//
+//   - server.StructuredResult / *server.StructuredResult: explicit
+//     content + structuredContent + optional isError flag.
+//   - string: legacy single text content block.
+//   - any other typed value: serialized to a text content block, and
+//     (when the tool declares an outputSchema) promoted to
+//     structuredContent so strict MCP clients accept the response.
+//
+// Extracted from handleToolsCall to keep that function under the
+// project's cyclomatic-complexity ceiling.
+func buildToolCallResponse(tool *server.Tool, result any) (map[string]any, error) {
+	response := make(map[string]any)
+
+	switch v := result.(type) {
+	case server.StructuredResult:
+		applyStructuredResult(response, &v)
+		return response, nil
+	case *server.StructuredResult:
+		if v != nil {
+			applyStructuredResult(response, v)
+		}
+		return response, nil
+	}
+
+	// Legacy: serialize to a single text content block. Typed structs
+	// also feed structuredContent when an outputSchema is declared so
+	// the response satisfies strict MCP clients.
+	var textContent string
+	var marshaled []byte
+	switch tv := result.(type) {
+	case string:
+		textContent = tv
+	default:
+		data, err := json.Marshal(tv)
+		if err != nil {
+			return nil, protocol.NewInternalError(fmt.Sprintf("failed to serialize tool result: %v", err))
+		}
+		textContent = string(data)
+		marshaled = data
+	}
+	response["content"] = []map[string]any{
+		{
+			"type":    fieldText,
+			fieldText: textContent,
+		},
+	}
+	if tool.OutputSchema() != nil && marshaled != nil {
+		var structured map[string]any
+		if err := json.Unmarshal(marshaled, &structured); err == nil && structured != nil {
+			response["structuredContent"] = structured
+		}
+	}
+	return response, nil
+}
+
+// applyStructuredResult writes a StructuredResult into the response map.
+// Empty Content is normalized to [] (per MCP spec) so clients never see
+// a missing content field.
+func applyStructuredResult(response map[string]any, v *server.StructuredResult) {
+	if len(v.Content) > 0 {
+		response["content"] = v.Content
+	} else {
+		response["content"] = []map[string]any{}
+	}
+	response["structuredContent"] = v.StructuredContent
+	if v.IsError {
+		response["isError"] = true
+	}
 }
 
 func (h *requestHandler) handleResourcesList(_ context.Context, req *protocol.Request) (*protocol.Response, error) {

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -694,6 +694,104 @@ func TestHandleToolsCall_StructuredResult(t *testing.T) {
 	}
 }
 
+// TestHandleToolsCall_TypedStructResultPopulatesStructuredContent
+// regression-tests strict-client failures of the form
+// `Tool ... has an output schema but did not return structured content`.
+//
+// When a tool declares OutputSchema and the handler returns a typed
+// struct (not StructuredResult), the server must populate
+// structuredContent on the response so the payload satisfies the spec.
+// Text content is preserved for backward compatibility with clients that
+// only read content[].text.
+func TestHandleToolsCall_TypedStructResultPopulatesStructuredContent(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	type Input struct{}
+	type Output struct {
+		Answer string   `json:"answer"`
+		Tags   []string `json:"tags"`
+	}
+
+	srv.Tool("query").
+		OutputSchema(Output{}).
+		Handler(func(input Input) (Output, error) {
+			return Output{Answer: "42", Tags: []string{"a", "b"}}, nil
+		})
+
+	handler := newRequestHandler(srv)
+
+	callReq := &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"query","arguments":{}}`),
+	}
+
+	resp, err := handler.HandleRequest(context.Background(), callReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result, _ := json.Marshal(resp.Result)
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, result)
+	}
+
+	sc, ok := parsed["structuredContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected structuredContent object; raw=%s", result)
+	}
+	if sc["answer"] != "42" {
+		t.Errorf("structuredContent.answer = %v, want %q; raw=%s", sc["answer"], "42", result)
+	}
+	tags, ok := sc["tags"].([]any)
+	if !ok || len(tags) != 2 {
+		t.Errorf("structuredContent.tags = %v, want 2-element array; raw=%s", sc["tags"], result)
+	}
+
+	// Text content is still present for legacy clients.
+	if !strings.Contains(string(result), `"content"`) {
+		t.Errorf("expected content array for backward compat; raw=%s", result)
+	}
+}
+
+// TestHandleToolsCall_TypedStructResultWithoutSchemaOmitsStructured
+// guards against regressions in the other direction: when no
+// OutputSchema is declared the legacy text-only path must remain.
+func TestHandleToolsCall_TypedStructResultWithoutSchemaOmitsStructured(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	type Input struct{}
+	type Output struct {
+		Answer string `json:"answer"`
+	}
+
+	srv.Tool("query_no_schema").
+		Handler(func(input Input) (Output, error) {
+			return Output{Answer: "42"}, nil
+		})
+
+	handler := newRequestHandler(srv)
+
+	callReq := &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"query_no_schema","arguments":{}}`),
+	}
+
+	resp, err := handler.HandleRequest(context.Background(), callReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result, _ := json.Marshal(resp.Result)
+	if strings.Contains(string(result), `"structuredContent"`) {
+		t.Errorf("no outputSchema declared, should not emit structuredContent; raw=%s", result)
+	}
+}
+
 func TestHandleToolsCall_LegacyStringResult(t *testing.T) {
 	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -5,7 +5,17 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"time"
 )
+
+// timeType is cached so the time.Time special case in generateFromType
+// is a single pointer comparison rather than a string compare on every
+// field traversal.
+var timeType = reflect.TypeOf(time.Time{})
+
+// formatDateTime is the JSON Schema "format" annotation used for
+// time.Time values, which marshal as RFC3339 strings.
+const formatDateTime = "date-time"
 
 const tagRequired = "required"
 
@@ -17,6 +27,7 @@ const tagRequired = "required"
 // leave it unset so they remain open.
 type Schema struct {
 	Type                 string             `json:"type,omitempty"`
+	Format               string             `json:"format,omitempty"`
 	Properties           map[string]*Schema `json:"properties,omitempty"`
 	AdditionalProperties any                `json:"-"`
 	Required             []string           `json:"required,omitempty"`
@@ -44,6 +55,9 @@ func (s Schema) MarshalJSON() ([]byte, error) {
 	}
 
 	out := map[string]any{"type": typeObject}
+	if s.Format != "" {
+		out["format"] = s.Format
+	}
 	props := s.Properties
 	if props == nil {
 		props = map[string]*Schema{}
@@ -91,6 +105,16 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 	// Handle pointers
 	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
+	}
+
+	// time.Time marshals as an RFC3339 string, not as a struct of its
+	// internal fields. Treat it as a string-format date-time so the
+	// generated schema agrees with the actual JSON output. Without this
+	// special case, time.Time fields produce object schemas that any
+	// strict MCP client rejects (`structuredContent does not match the
+	// tool's output schema: data/... must be object`).
+	if t == timeType {
+		return &Schema{Type: typeString, Format: formatDateTime}, nil
 	}
 
 	switch t.Kind() {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestGenerate(t *testing.T) {
@@ -267,6 +268,97 @@ func TestSchema_StructIsClosed(t *testing.T) {
 	if got["additionalProperties"] != false {
 		t.Errorf("additionalProperties = %v, want false; raw=%s", got["additionalProperties"], data)
 	}
+}
+
+// TestGenerate_TimeIsStringDateTime regression-tests the strict
+// outputSchema failure where time.Time fields generated nested object
+// schemas (one property per internal time field) but encoded as RFC3339
+// strings at runtime. Strict clients rejected the mismatch with
+// `structuredContent does not match the tool's output schema:
+// data/.../CreatedAt must be object`.
+//
+// time.Time must render as a string/date-time schema, both as a top-level
+// type and when embedded as a struct field.
+func TestGenerate_TimeIsStringDateTime(t *testing.T) {
+	t.Run("top-level time.Time", func(t *testing.T) {
+		s, err := Generate(time.Time{})
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		if s.Type != "string" {
+			t.Errorf("Type = %q, want %q", s.Type, "string")
+		}
+		if s.Format != "date-time" {
+			t.Errorf("Format = %q, want %q", s.Format, "date-time")
+		}
+	})
+
+	t.Run("time.Time field is string, not nested object", func(t *testing.T) {
+		type Event struct {
+			Name      string    `json:"name"`
+			CreatedAt time.Time `json:"created_at"`
+		}
+
+		s, err := Generate(Event{})
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+
+		createdAt, ok := s.Properties["created_at"]
+		if !ok {
+			t.Fatal("expected 'created_at' property")
+		}
+		if createdAt.Type != "string" {
+			t.Errorf("created_at.Type = %q, want %q", createdAt.Type, "string")
+		}
+		if createdAt.Format != "date-time" {
+			t.Errorf("created_at.Format = %q, want %q", createdAt.Format, "date-time")
+		}
+		if len(createdAt.Properties) != 0 {
+			t.Errorf("created_at should not have nested properties, got %d", len(createdAt.Properties))
+		}
+	})
+
+	t.Run("format survives MarshalJSON", func(t *testing.T) {
+		type Event struct {
+			At time.Time `json:"at"`
+		}
+		s, err := Generate(Event{})
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		data, err := json.Marshal(s.Properties["at"])
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got["type"] != "string" {
+			t.Errorf("type = %v, want string; raw=%s", got["type"], data)
+		}
+		if got["format"] != "date-time" {
+			t.Errorf("format = %v, want date-time; raw=%s", got["format"], data)
+		}
+	})
+
+	t.Run("pointer to time.Time", func(t *testing.T) {
+		type Event struct {
+			DeletedAt *time.Time `json:"deleted_at"`
+		}
+		s, err := Generate(Event{})
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		deletedAt := s.Properties["deleted_at"]
+		if deletedAt.Type != "string" {
+			t.Errorf("deleted_at.Type = %q, want %q", deletedAt.Type, "string")
+		}
+		if deletedAt.Format != "date-time" {
+			t.Errorf("deleted_at.Format = %q, want %q", deletedAt.Format, "date-time")
+		}
+	})
 }
 
 // TestSchema_NonObjectUnaffected ensures string/number/etc. schemas


### PR DESCRIPTION
## Summary

Two related fixes so tools that declare `OutputSchema` and return plain typed structs produce spec-compliant responses. Strict MCP clients (e.g. openclaw's MCP runner) previously rejected those responses with:

- `-32600 Tool query_knowledge has an output schema but did not return structured content`, and once that was fixed,
- `-32602 Structured content does not match the tool's output schema: data/claims/0/CreatedAt must be object` (every `time.Time` field tripped this).

### 1. `fix(schema): emit string/date-time for time.Time fields`

`time.Time` is a struct, so the generator recursed into its unexported fields and produced an object schema. But `time.Time.MarshalJSON` emits a single RFC3339 string. Schema and runtime disagreed.

- Special-case `time.Time` in `generateFromType` before the struct branch → `{type:"string",format:"date-time"}`.
- Add `Format` to `Schema` and wire through `MarshalJSON` for object schemas (non-object schemas already round-tripped via default `encoding/json`).
- Covers top-level `time.Time`, struct fields, and `*time.Time` pointer fields.

### 2. `fix(server): emit structuredContent for typed-struct tool results`

When the handler returns a plain typed struct (not `server.StructuredResult`) and the tool declares `OutputSchema`, the legacy path serialized to a text content block only and never populated `structuredContent`. Per MCP spec, declaring an output schema obligates the response to carry `structuredContent`.

- In the default branch, also unmarshal the JSON-serialized payload into a `map[string]any` and set `structuredContent` when `tool.OutputSchema() != nil`.
- Text content stays intact for legacy clients.
- String results are left text-only (no JSON object shape to promote).
- Extracted `buildToolCallResponse` + `applyStructuredResult` helpers so `handleToolsCall` stays under the project's cyclomatic complexity ceiling.

## Test plan

- [x] `go test -race -count=1 ./...` passes (added regression tests for both fixes).
- [x] `golangci-lint run` clean (`--new-from-rev=origin/main` → 0 issues).
- [x] `.githooks/pre-commit` (vet + lint + build + race tests) green on both commits.
- [x] End-to-end verified against a mnemos MCP server: `query_knowledge` now returns spec-compliant `structuredContent` with `CreatedAt` as an RFC3339 string; openclaw client accepts it.

### Backward compatibility

- Tools returning `server.StructuredResult` are unchanged.
- Tools returning `string` are unchanged (no `structuredContent` emitted).
- Tools returning a typed struct without `OutputSchema` are unchanged (no `structuredContent` emitted — covered by `TestHandleToolsCall_TypedStructResultWithoutSchemaOmitsStructured`).
- `time.Time` schema change is strictly tightening — old schema was structurally wrong, no caller can have been relying on it because real payloads were strings.