### PR TITLE
feat(transport): expose TLS configuration for HTTP/gRPC/WebSocket

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -29,6 +29,7 @@ package mcp
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -403,6 +404,14 @@ func WithDiscovery(discovery *transport.ServerDiscovery) HTTPOption {
 	return transport.WithDiscovery(discovery)
 }
 
+// WithTLSConfig enables HTTPS termination on the HTTP transport. The
+// supplied *tls.Config is used verbatim — bring your own certificate
+// loading + rotation strategy (LoadX509KeyPair, autocert, SPIFFE,
+// etc.). Set ClientCAs + ClientAuth for mTLS.
+func WithTLSConfig(cfg *tls.Config) HTTPOption {
+	return transport.WithTLSConfig(cfg)
+}
+
 // WebSocketOption configures the WebSocket transport.
 type WebSocketOption = transport.WebSocketOption
 
@@ -429,6 +438,12 @@ func WithWebSocketReadTimeout(d time.Duration) WebSocketOption {
 // WithWebSocketWriteTimeout sets the write timeout for WebSocket messages.
 func WithWebSocketWriteTimeout(d time.Duration) WebSocketOption {
 	return transport.WithWebSocketWriteTimeout(d)
+}
+
+// WithWebSocketTLSConfig enables wss:// on the WebSocket transport.
+// Same caller-owned cert strategy as WithTLSConfig.
+func WithWebSocketTLSConfig(cfg *tls.Config) WebSocketOption {
+	return transport.WithWebSocketTLSConfig(cfg)
 }
 
 // GRPCOption configures the gRPC transport.
@@ -460,6 +475,15 @@ func WithGRPCShutdownTimeout(d time.Duration) GRPCOption {
 // This allows load balancers to remove the server from rotation.
 func WithGRPCDrainDelay(d time.Duration) GRPCOption {
 	return grpctransport.WithDrainDelay(d)
+}
+
+// WithGRPCTLSConfig is a shorthand for embedded TLS on the gRPC
+// transport. Equivalent to passing grpc.Creds(credentials.NewTLS(cfg))
+// through grpctransport.WithServerOptions. Use the underlying
+// grpctransport.WithServerOptions when you need credentials that
+// aren't a static *tls.Config (SPIFFE, ALTS, etc.).
+func WithGRPCTLSConfig(cfg *tls.Config) GRPCOption {
+	return grpctransport.WithTLSConfig(cfg)
 }
 
 // Middleware re-exports

--- a/transport/grpc/grpc.go
+++ b/transport/grpc/grpc.go
@@ -17,11 +17,13 @@ package grpc
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"sync"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/felixgeelhaar/mcp-go/transport"
 	pb "github.com/felixgeelhaar/mcp-go/transport/grpc/mcpv1"
@@ -64,10 +66,25 @@ func WithDrainDelay(d time.Duration) Option {
 }
 
 // WithServerOptions sets additional gRPC server options.
-// Use this to configure TLS, interceptors, max message sizes, etc.
+// Use this to configure interceptors, max message sizes, custom
+// credentials, etc.
 func WithServerOptions(opts ...grpc.ServerOption) Option {
 	return func(g *GRPC) {
 		g.serverOpts = append(g.serverOpts, opts...)
+	}
+}
+
+// WithTLSConfig is a shorthand for embedded TLS termination. It is
+// equivalent to passing grpc.Creds(credentials.NewTLS(cfg)) through
+// WithServerOptions. Bring your own certificate loading + rotation
+// strategy; set ClientCAs + ClientAuth on the config for mTLS, which
+// is the common case for service-mesh and regulated deployments.
+//
+// Use the underlying WithServerOptions when you need credentials that
+// aren't a static *tls.Config (SPIFFE workload API, ALTS, etc.).
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(g *GRPC) {
+		g.serverOpts = append(g.serverOpts, grpc.Creds(credentials.NewTLS(cfg)))
 	}
 }
 

--- a/transport/grpc/tls_test.go
+++ b/transport/grpc/tls_test.go
@@ -1,0 +1,27 @@
+package grpc
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestWithTLSConfig_AppendsCredsServerOption(t *testing.T) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	g := NewGRPC(":0", WithTLSConfig(cfg))
+	// We can't introspect grpc.ServerOption directly (opaque type), but
+	// the shorthand must append exactly one entry to serverOpts.
+	if len(g.serverOpts) != 1 {
+		t.Errorf("expected exactly one server option from WithTLSConfig, got %d", len(g.serverOpts))
+	}
+}
+
+func TestWithTLSConfig_ComposesWithServerOptions(t *testing.T) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	g := NewGRPC(":0",
+		WithTLSConfig(cfg),
+		WithServerOptions(),
+	)
+	if len(g.serverOpts) != 1 {
+		t.Errorf("expected 1 server option (TLS only), got %d", len(g.serverOpts))
+	}
+}

--- a/transport/http.go
+++ b/transport/http.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -25,6 +26,7 @@ type HTTP struct {
 	corsConfig      *CORSConfig
 	sessionStore    SessionStore
 	discovery       *ServerDiscovery
+	tlsConfig       *tls.Config
 
 	mu         sync.RWMutex
 	listenAddr string
@@ -57,6 +59,24 @@ func WithSessionStore(store SessionStore) HTTPOption {
 func WithDiscovery(discovery *ServerDiscovery) HTTPOption {
 	return func(h *HTTP) {
 		h.discovery = discovery
+	}
+}
+
+// WithTLSConfig enables embedded TLS termination. When set, the
+// transport serves over HTTPS using the supplied *tls.Config — bring
+// your own certificate loading, rotation, and verification strategy
+// (crypto/tls.LoadX509KeyPair, autocert, SPIFFE workload API, etc.).
+//
+// Set Certificates or GetCertificate on the config for plain HTTPS;
+// add ClientCAs and ClientAuth for mTLS. mcp-go does not validate the
+// config — pass tls.Config.Clone() if you want to keep mutating the
+// original after handing it off.
+//
+// When TLS is enabled, the WebSocket upgrade path inherits HTTPS
+// automatically since both share the same *http.Server.
+func WithTLSConfig(cfg *tls.Config) HTTPOption {
+	return func(h *HTTP) {
+		h.tlsConfig = cfg
 	}
 }
 
@@ -101,13 +121,24 @@ func (h *HTTP) Serve(ctx context.Context, handler Handler) error {
 		Handler:      httpHandler,
 		ReadTimeout:  h.readTimeout,
 		WriteTimeout: h.writeTimeout,
+		TLSConfig:    h.tlsConfig,
 	}
+	tlsEnabled := h.tlsConfig != nil
 	h.mu.Unlock()
 
 	errCh := make(chan error, 1)
 	go func() {
-		if err := h.server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			errCh <- err
+		var srvErr error
+		if tlsEnabled {
+			// ServeTLS reads cert/key from h.server.TLSConfig.Certificates
+			// (or GetCertificate) — the empty filename args are
+			// intentional and required by the stdlib API.
+			srvErr = h.server.ServeTLS(listener, "", "")
+		} else {
+			srvErr = h.server.Serve(listener)
+		}
+		if srvErr != nil && srvErr != http.ErrServerClosed {
+			errCh <- srvErr
 		}
 		close(errCh)
 	}()

--- a/transport/tls_test.go
+++ b/transport/tls_test.go
@@ -1,0 +1,160 @@
+package transport
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/felixgeelhaar/mcp-go/protocol"
+)
+
+// generateTestCert builds an in-memory ECDSA cert + key valid for
+// "localhost" + "127.0.0.1". Lets the TLS option tests run hermetic
+// without filesystem fixtures.
+func generateTestCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  nil,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	return cert
+}
+
+func TestWithTLSConfig_StoresConfig(t *testing.T) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	tr := NewHTTP(":0", WithTLSConfig(cfg))
+	if tr.tlsConfig != cfg {
+		t.Errorf("WithTLSConfig did not store the supplied config")
+	}
+}
+
+func TestHTTP_ServesOverTLSWhenConfigured(t *testing.T) {
+	cert := generateTestCert(t)
+	cfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	tr := NewHTTP("127.0.0.1:0",
+		WithTLSConfig(cfg),
+		WithReadTimeout(2*time.Second),
+		WithWriteTimeout(2*time.Second),
+	)
+	handler := HandlerFunc(func(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, "ok"), nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Serve(ctx, handler) }()
+
+	// Wait until the listener has bound.
+	deadline := time.Now().Add(2 * time.Second)
+	for tr.ListenAddr() == "" && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if tr.ListenAddr() == "" {
+		t.Fatal("server never bound an address")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	resp, err := client.Post("https://"+tr.ListenAddr()+"/mcp", "application/json", body)
+	if err != nil {
+		t.Fatalf("https POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("https status %d, body=%s", resp.StatusCode, raw)
+	}
+	// Verify the response is parseable JSON-RPC — proves TLS handshake
+	// + handler chain completed end-to-end.
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out["jsonrpc"] != "2.0" {
+		t.Errorf("unexpected response: %v", out)
+	}
+
+	cancel()
+	<-errCh
+}
+
+func TestHTTP_ServesPlainWhenNoTLS(t *testing.T) {
+	// Regression: ensure the non-TLS path still works after the
+	// ServeTLS branch was added.
+	tr := NewHTTP("127.0.0.1:0")
+	handler := HandlerFunc(func(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, "ok"), nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Serve(ctx, handler) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for tr.ListenAddr() == "" && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	resp, err := http.Post("http://"+tr.ListenAddr()+"/mcp", "application/json", body)
+	if err != nil {
+		t.Fatalf("http POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("plain status %d", resp.StatusCode)
+	}
+	cancel()
+	<-errCh
+}
+
+func TestWithWebSocketTLSConfig_StoresConfig(t *testing.T) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	ws := NewWebSocket(":0", WithWebSocketTLSConfig(cfg))
+	if ws.tlsConfig != cfg {
+		t.Errorf("WithWebSocketTLSConfig did not store the supplied config")
+	}
+}

--- a/transport/websocket.go
+++ b/transport/websocket.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -21,6 +22,7 @@ type WebSocket struct {
 
 	readTimeout  time.Duration
 	writeTimeout time.Duration
+	tlsConfig    *tls.Config
 
 	mu      sync.RWMutex
 	clients map[*wsClient]struct{}
@@ -53,6 +55,15 @@ func WithWebSocketWriteTimeout(d time.Duration) WebSocketOption {
 func WithWebSocketCheckOrigin(fn func(r *http.Request) bool) WebSocketOption {
 	return func(ws *WebSocket) {
 		ws.upgrader.CheckOrigin = fn
+	}
+}
+
+// WithWebSocketTLSConfig enables wss:// by terminating TLS at the
+// transport. Bring your own certificate strategy — mcp-go does not
+// load or rotate certs. Set ClientCAs + ClientAuth for mTLS.
+func WithWebSocketTLSConfig(cfg *tls.Config) WebSocketOption {
+	return func(ws *WebSocket) {
+		ws.tlsConfig = cfg
 	}
 }
 
@@ -94,12 +105,21 @@ func (ws *WebSocket) Serve(ctx context.Context, handler Handler) error {
 		Handler:      mux,
 		ReadTimeout:  ws.readTimeout,
 		WriteTimeout: ws.writeTimeout,
+		TLSConfig:    ws.tlsConfig,
 	}
 
 	errChan := make(chan error, 1)
 	go func() {
-		if err := ws.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errChan <- err
+		var srvErr error
+		if ws.tlsConfig != nil {
+			// ListenAndServeTLS reads from server.TLSConfig when given
+			// empty cert/key filenames.
+			srvErr = ws.server.ListenAndServeTLS("", "")
+		} else {
+			srvErr = ws.server.ListenAndServe()
+		}
+		if srvErr != nil && !errors.Is(srvErr, http.ErrServerClosed) {
+			errChan <- srvErr
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Adds \`mcp.WithTLSConfig\` (HTTP), \`mcp.WithWebSocketTLSConfig\`, and \`mcp.WithGRPCTLSConfig\`
- HTTP transport switches to \`ServeTLS\` when a config is supplied; WebSocket inherits via \`ListenAndServeTLS\`
- gRPC option wraps \`grpc.Creds(credentials.NewTLS(cfg))\` and composes with the existing \`WithServerOptions\`
- All three options re-exported from the top-level \`mcp\` package

## Why
Today operators must run a reverse proxy in front of mcp-go to terminate TLS. Three scenarios make that painful: single-binary internal deployments, mTLS-for-client-identity in service meshes, and embedded sidecar/on-device contexts. Exposing \`*tls.Config\` keeps the surface narrow — callers bring their own cert loading/rotation strategy (\`LoadX509KeyPair\`, \`autocert\`, SPIFFE, etc.).

## Closes
Closes #86

## Test plan
- [x] \`go test -race ./...\` — full suite passes
- [x] New \`transport/tls_test.go\` — end-to-end HTTPS request through HTTP transport with self-signed ECDSA cert; regression for plain HTTP; option-storage assertions for HTTP + WebSocket
- [x] New \`transport/grpc/tls_test.go\` — verifies the TLS option appends exactly one ServerOption and composes correctly with \`WithServerOptions\`