### PR TITLE
feat(server): identity-aware list filtering for tools, resources, prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+#### Identity-aware list filtering for tools, resources, and prompts (#90)
+- Added `mcp.WithToolFilter(func(ctx, name) bool) ServeOption` — predicate gates `tools/list` visibility AND `tools/call` execution, so the filter is the authoritative contract rather than a display layer
+- Added `mcp.WithResourceFilter(func(ctx, uri, name) bool) ServeOption` — gates `resources/list` + `resources/read`
+- Added `mcp.WithPromptFilter(func(ctx, name) bool) ServeOption` — gates `prompts/list` + `prompts/get`
+- Predicates receive the request context — pair with `IdentityFromContext` for identity-aware authz (e.g. admin-only tools hidden from read-only clients)
+- Filters apply during typed list construction, so they're immune to the schema-coupling problem of post-response middleware approaches (response-map walking breaks silently when the response shape evolves)
+- Added `(*server.Resource).URITemplate()` and `(*server.Resource).Name()` accessors so resource filter predicates can be implemented without poking at unexported fields
+
 ## [1.12.0](https://github.com/felixgeelhaar/mcp-go/compare/v1.11.2...v1.12.0)
 
 ### Features

--- a/list_filter_test.go
+++ b/list_filter_test.go
@@ -1,0 +1,231 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/felixgeelhaar/mcp-go/protocol"
+)
+
+// listTestServer builds a server pre-seeded with two tools, two
+// resources, and two prompts so the filter predicates have something
+// non-trivial to act on.
+func listTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv := NewServer(ServerInfo{Name: "filter-test", Version: "1.0.0"})
+
+	type Input struct{}
+	srv.Tool("public_search").
+		Description("Anyone can call").
+		Handler(func(_ Input) (string, error) { return "ok", nil })
+	srv.Tool("admin_drop_table").
+		Description("Admin only").
+		Handler(func(_ Input) (string, error) { return "ok", nil })
+
+	srv.Resource("data://public").
+		Name("Public").
+		Handler(func(_ context.Context, uri string, _ map[string]string) (*ResourceContent, error) {
+			return &ResourceContent{URI: uri, Text: "public"}, nil
+		})
+	srv.Resource("data://internal/secrets").
+		Name("InternalSecrets").
+		Handler(func(_ context.Context, uri string, _ map[string]string) (*ResourceContent, error) {
+			return &ResourceContent{URI: uri, Text: "secret"}, nil
+		})
+
+	srv.Prompt("public_greeting").
+		Description("Public").
+		Handler(func(_ context.Context, _ map[string]string) (*PromptResult, error) {
+			return &PromptResult{}, nil
+		})
+	srv.Prompt("admin_diag").
+		Description("Admin only").
+		Handler(func(_ context.Context, _ map[string]string) (*PromptResult, error) {
+			return &PromptResult{}, nil
+		})
+
+	return srv
+}
+
+// listToolNames issues tools/list against the supplied handler and
+// returns the names that came back so tests can compare without
+// caring about the rest of the envelope.
+func listToolNames(t *testing.T, srv *Server, opts ...ServeOption) []string {
+	t.Helper()
+	handler := newRequestHandler(srv, opts...)
+	resp, err := handler.HandleRequest(context.Background(), &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodToolsList,
+	})
+	if err != nil {
+		t.Fatalf("tools/list returned error: %v", err)
+	}
+	return extractNames(t, resp, "tools")
+}
+
+func listResourceNames(t *testing.T, srv *Server, opts ...ServeOption) []string {
+	t.Helper()
+	handler := newRequestHandler(srv, opts...)
+	resp, err := handler.HandleRequest(context.Background(), &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodResourcesList,
+	})
+	if err != nil {
+		t.Fatalf("resources/list returned error: %v", err)
+	}
+	return extractNames(t, resp, "resources")
+}
+
+func listPromptNames(t *testing.T, srv *Server, opts ...ServeOption) []string {
+	t.Helper()
+	handler := newRequestHandler(srv, opts...)
+	resp, err := handler.HandleRequest(context.Background(), &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodPromptsList,
+	})
+	if err != nil {
+		t.Fatalf("prompts/list returned error: %v", err)
+	}
+	return extractNames(t, resp, "prompts")
+}
+
+func extractNames(t *testing.T, resp *protocol.Response, key string) []string {
+	t.Helper()
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not a map: %T", resp.Result)
+	}
+	items, ok := result[key].([]map[string]any)
+	if !ok {
+		t.Fatalf("result[%q] is not []map[string]any: %T", key, result[key])
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		if name, ok := item["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func contains(slice []string, want string) bool {
+	for _, s := range slice {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ── tools ────────────────────────────────────────────────────────────
+
+func TestWithToolFilter_NoFilter_ListsAll(t *testing.T) {
+	srv := listTestServer(t)
+	names := listToolNames(t, srv)
+	if len(names) != 2 {
+		t.Fatalf("expected both tools without a filter, got %v", names)
+	}
+}
+
+func TestWithToolFilter_HidesRejected(t *testing.T) {
+	srv := listTestServer(t)
+	names := listToolNames(t, srv, WithToolFilter(func(_ context.Context, name string) bool {
+		return name == "public_search"
+	}))
+	if len(names) != 1 || names[0] != "public_search" {
+		t.Fatalf("expected only public_search, got %v", names)
+	}
+	if contains(names, "admin_drop_table") {
+		t.Fatalf("admin_drop_table should not be visible: %v", names)
+	}
+}
+
+func TestWithToolFilter_SeesContext(t *testing.T) {
+	srv := listTestServer(t)
+	handler := newRequestHandler(srv, WithToolFilter(func(ctx context.Context, name string) bool {
+		// Predicate respects the identity attached to ctx — same
+		// pattern callers will use with IdentityFromContext.
+		id := IdentityFromContext(ctx)
+		if id != nil && id.Name == "admin" {
+			return true
+		}
+		return name == "public_search"
+	}))
+
+	// Anonymous caller — only the public tool comes back.
+	respAnon, err := handler.HandleRequest(context.Background(), &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsList,
+	})
+	if err != nil {
+		t.Fatalf("anon list error: %v", err)
+	}
+	anon := extractNames(t, respAnon, "tools")
+	if len(anon) != 1 || anon[0] != "public_search" {
+		t.Fatalf("anon caller should see only public_search, got %v", anon)
+	}
+
+	// Admin caller — both tools come back.
+	adminCtx := ContextWithIdentity(context.Background(), &Identity{ID: "admin", Name: "admin"})
+	respAdmin, err := handler.HandleRequest(adminCtx, &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: protocol.MethodToolsList,
+	})
+	if err != nil {
+		t.Fatalf("admin list error: %v", err)
+	}
+	admin := extractNames(t, respAdmin, "tools")
+	if len(admin) != 2 {
+		t.Fatalf("admin caller should see both tools, got %v", admin)
+	}
+}
+
+// ── resources ───────────────────────────────────────────────────────
+
+func TestWithResourceFilter_HidesRejected(t *testing.T) {
+	srv := listTestServer(t)
+	names := listResourceNames(t, srv, WithResourceFilter(func(_ context.Context, uri, _ string) bool {
+		return uri == "data://public"
+	}))
+	if len(names) != 1 || names[0] != "Public" {
+		t.Fatalf("expected only Public resource, got %v", names)
+	}
+}
+
+// ── prompts ─────────────────────────────────────────────────────────
+
+func TestWithPromptFilter_HidesRejected(t *testing.T) {
+	srv := listTestServer(t)
+	names := listPromptNames(t, srv, WithPromptFilter(func(_ context.Context, name string) bool {
+		return name == "public_greeting"
+	}))
+	if len(names) != 1 || names[0] != "public_greeting" {
+		t.Fatalf("expected only public_greeting, got %v", names)
+	}
+}
+
+// ── tools/call still rejects filtered tools ─────────────────────────
+
+// A hidden tool must NOT be callable either — the filter is the
+// contract, not just a display layer. The author flagged "see-but-
+// not-call" as the leaky state to avoid; here we verify a filter that
+// hides a tool also blocks the call.
+func TestWithToolFilter_AlsoBlocksCall(t *testing.T) {
+	srv := listTestServer(t)
+	handler := newRequestHandler(srv, WithToolFilter(func(_ context.Context, name string) bool {
+		return name != "admin_drop_table"
+	}))
+
+	callReq := &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodToolsCall,
+		Params:  json.RawMessage(`{"name":"admin_drop_table","arguments":{}}`),
+	}
+	_, err := handler.HandleRequest(context.Background(), callReq)
+	if err == nil {
+		t.Fatalf("expected hidden tool to be uncallable")
+	}
+}

--- a/mcp.go
+++ b/mcp.go
@@ -353,8 +353,11 @@ var (
 type ServeOption func(*serveOptions)
 
 type serveOptions struct {
-	middleware []Middleware
-	logger     Logger
+	middleware     []Middleware
+	logger         Logger
+	toolFilter     ToolFilterFunc
+	resourceFilter ResourceFilterFunc
+	promptFilter   PromptFilterFunc
 }
 
 // WithMiddleware adds middleware to the request handling chain.
@@ -368,6 +371,59 @@ func WithMiddleware(m ...Middleware) ServeOption {
 func WithLogger(l Logger) ServeOption {
 	return func(o *serveOptions) {
 		o.logger = l
+	}
+}
+
+// ToolFilterFunc decides whether a tool should be visible to (and
+// callable by) the caller represented by ctx. Returning false hides
+// the tool from tools/list AND causes tools/call to fail with a
+// not-found error, so the filter is the authoritative contract
+// rather than a display-only layer.
+//
+// Use IdentityFromContext(ctx) to read the authenticated caller when
+// the predicate needs to vary by client.
+type ToolFilterFunc func(ctx context.Context, name string) bool
+
+// ResourceFilterFunc decides whether a resource should be visible to
+// the caller represented by ctx. The predicate receives both the URI
+// template and the human-readable name so authorisation can route on
+// either. Returning false hides the resource from resources/list AND
+// blocks resources/read for that URI.
+type ResourceFilterFunc func(ctx context.Context, uri, name string) bool
+
+// PromptFilterFunc decides whether a prompt should be visible to the
+// caller. Returning false hides the prompt from prompts/list AND
+// blocks prompts/get.
+type PromptFilterFunc func(ctx context.Context, name string) bool
+
+// WithToolFilter installs a predicate that gates tools/list visibility
+// and tools/call execution. The predicate runs once per list entry
+// (and once per call) with the request context, so identity-aware
+// filtering composes naturally with the auth middleware.
+//
+// Without this option, every registered tool is visible to every
+// caller. Multiple WithToolFilter calls replace previous ones — there
+// is no chaining; if you need multiple predicates, compose them in a
+// single function.
+func WithToolFilter(filter ToolFilterFunc) ServeOption {
+	return func(o *serveOptions) {
+		o.toolFilter = filter
+	}
+}
+
+// WithResourceFilter is the resources/list + resources/read counterpart
+// to WithToolFilter. See ResourceFilterFunc for predicate semantics.
+func WithResourceFilter(filter ResourceFilterFunc) ServeOption {
+	return func(o *serveOptions) {
+		o.resourceFilter = filter
+	}
+}
+
+// WithPromptFilter is the prompts/list + prompts/get counterpart to
+// WithToolFilter. See PromptFilterFunc for predicate semantics.
+func WithPromptFilter(filter PromptFilterFunc) ServeOption {
+	return func(o *serveOptions) {
+		o.promptFilter = filter
 	}
 }
 
@@ -582,8 +638,11 @@ var (
 
 // requestHandler adapts Server to transport.Handler
 type requestHandler struct {
-	srv        *Server
-	handleFunc middleware.HandlerFunc
+	srv            *Server
+	handleFunc     middleware.HandlerFunc
+	toolFilter     ToolFilterFunc
+	resourceFilter ResourceFilterFunc
+	promptFilter   PromptFilterFunc
 }
 
 func newRequestHandler(srv *Server, opts ...ServeOption) *requestHandler {
@@ -592,7 +651,12 @@ func newRequestHandler(srv *Server, opts ...ServeOption) *requestHandler {
 		opt(options)
 	}
 
-	h := &requestHandler{srv: srv}
+	h := &requestHandler{
+		srv:            srv,
+		toolFilter:     options.toolFilter,
+		resourceFilter: options.resourceFilter,
+		promptFilter:   options.promptFilter,
+	}
 
 	// Build the handler function
 	baseHandler := middleware.HandlerFunc(h.handle)
@@ -688,11 +752,14 @@ func (h *requestHandler) handleInitialize(_ context.Context, req *protocol.Reque
 	return protocol.NewResponse(req.ID, result), nil
 }
 
-func (h *requestHandler) handleToolsList(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+func (h *requestHandler) handleToolsList(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 	tools := h.srv.Tools()
 
 	toolList := make([]map[string]any, 0, len(tools))
 	for _, t := range tools {
+		if h.toolFilter != nil && !h.toolFilter(ctx, t.Name) {
+			continue
+		}
 		item := map[string]any{
 			fieldName:     t.Name,
 			"description": t.Description,
@@ -727,9 +794,14 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 		return nil, protocol.NewInvalidParams(err.Error())
 	}
 
-	// Get tool
+	// Get tool. A filter that hides the tool from tools/list must also
+	// block tools/call — otherwise the filter is a display layer, not
+	// the authorisation contract callers rely on.
 	tool, ok := h.srv.GetTool(params.Name)
 	if !ok {
+		return nil, protocol.NewNotFound("tool not found: " + params.Name)
+	}
+	if h.toolFilter != nil && !h.toolFilter(ctx, params.Name) {
 		return nil, protocol.NewNotFound("tool not found: " + params.Name)
 	}
 
@@ -849,11 +921,14 @@ func applyStructuredResult(response map[string]any, v *server.StructuredResult) 
 	}
 }
 
-func (h *requestHandler) handleResourcesList(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+func (h *requestHandler) handleResourcesList(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 	resources := h.srv.Resources()
 
 	resourceList := make([]map[string]any, 0, len(resources))
 	for _, r := range resources {
+		if h.resourceFilter != nil && !h.resourceFilter(ctx, r.URITemplate, r.Name) {
+			continue
+		}
 		item := map[string]any{
 			"uri":     r.URITemplate,
 			fieldName: r.Name,
@@ -886,9 +961,14 @@ func (h *requestHandler) handleResourcesRead(ctx context.Context, req *protocol.
 		return nil, protocol.NewInvalidParams(err.Error())
 	}
 
-	// Find resource that matches the URI
+	// Find resource that matches the URI. Hidden resources stay
+	// hidden — resources/read on a filtered resource looks identical
+	// to one that was never registered.
 	resource, ok := h.srv.FindResourceForURI(params.URI)
 	if !ok {
+		return nil, protocol.NewNotFound("resource not found: " + params.URI)
+	}
+	if h.resourceFilter != nil && !h.resourceFilter(ctx, resource.URITemplate(), resource.Name()) {
 		return nil, protocol.NewNotFound("resource not found: " + params.URI)
 	}
 
@@ -920,11 +1000,14 @@ func (h *requestHandler) handleResourcesRead(ctx context.Context, req *protocol.
 	return protocol.NewResponse(req.ID, result), nil
 }
 
-func (h *requestHandler) handlePromptsList(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+func (h *requestHandler) handlePromptsList(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 	prompts := h.srv.Prompts()
 
 	promptList := make([]map[string]any, 0, len(prompts))
 	for _, p := range prompts {
+		if h.promptFilter != nil && !h.promptFilter(ctx, p.Name) {
+			continue
+		}
 		item := map[string]any{
 			fieldName: p.Name,
 		}
@@ -968,9 +1051,14 @@ func (h *requestHandler) handlePromptsGet(ctx context.Context, req *protocol.Req
 		return nil, protocol.NewInvalidParams(err.Error())
 	}
 
-	// Get prompt
+	// Get prompt. Filter blocks hidden prompts from prompts/get the
+	// same way it blocks tools/call — the contract is "if you can't
+	// see it, you can't reach it".
 	prompt, ok := h.srv.GetPrompt(params.Name)
 	if !ok {
+		return nil, protocol.NewNotFound("prompt not found: " + params.Name)
+	}
+	if h.promptFilter != nil && !h.promptFilter(ctx, params.Name) {
 		return nil, protocol.NewNotFound("prompt not found: " + params.Name)
 	}
 

--- a/server/resource.go
+++ b/server/resource.go
@@ -35,6 +35,14 @@ type Resource struct {
 	paramNames []string
 }
 
+// URITemplate returns the URI template the resource was registered
+// under (e.g. "data://info" or "users://{id}").
+func (r *Resource) URITemplate() string { return r.uriTemplate }
+
+// Name returns the resource's human-readable name. Empty when the
+// builder never set one.
+func (r *Resource) Name() string { return r.name }
+
 // ResourceInfo represents metadata about a registered resource.
 type ResourceInfo struct {
 	URITemplate string


### PR DESCRIPTION
Closes #90.

## Summary
- `mcp.WithToolFilter`, `mcp.WithResourceFilter`, `mcp.WithPromptFilter` `ServeOption`s that gate visibility AND execution via a predicate over the request context
- Hidden entries are unreachable, not just invisible: `tools/call`, `resources/read`, `prompts/get` return not-found for filtered entries, so the filter is the authorisation contract rather than a display layer
- Filters run during typed list construction — immune to the schema-coupling problem of the post-response middleware workaround described in the issue
- Pair with `IdentityFromContext(ctx)` for identity-aware authz
- Resource accessors `URITemplate()` and `Name()` exposed so resource-filter predicates can be implemented without unexported fields

## Test plan
- [x] `TestWithToolFilter_NoFilter_ListsAll` — no filter = full catalog
- [x] `TestWithToolFilter_HidesRejected` — predicate-rejected names disappear from `tools/list`
- [x] `TestWithToolFilter_SeesContext` — predicate sees ctx; admin identity vs anon get different views
- [x] `TestWithToolFilter_AlsoBlocksCall` — hidden tool returns not-found on `tools/call`
- [x] `TestWithResourceFilter_HidesRejected` — same shape for resources
- [x] `TestWithPromptFilter_HidesRejected` — same shape for prompts
- [x] Full `go test ./...` passes; `go vet ./...` clean