### PR TITLE
feat(middleware): ToolFilter for identity-aware tools/list visibility

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -298,6 +298,12 @@ var (
 	ContextWithIdentity      = middleware.ContextWithIdentity
 )
 
+// ToolFilter re-exports for identity-aware tools/list filtering.
+// See middleware.ToolFilter doc + issue #90 for the rationale.
+type ToolPredicate = middleware.ToolPredicate
+
+var ToolFilter = middleware.ToolFilter
+
 // BearerAuth returns a Middleware that requires clients to present one
 // of the given tokens as a Bearer credential in the Authorization
 // header.

--- a/middleware/toolfilter.go
+++ b/middleware/toolfilter.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/felixgeelhaar/mcp-go/protocol"
+)
+
+// ToolPredicate decides whether a tool should be visible to a caller.
+// Returns true to keep the tool in the tools/list response, false to
+// hide it.
+//
+// The predicate sees the request context — use IdentityFromContext
+// (when paired with the Auth middleware) to make authz-aware
+// decisions. The name argument is the tool's `name` field exactly
+// as the server registered it.
+type ToolPredicate func(ctx context.Context, name string) bool
+
+// ToolFilter returns a Middleware that wraps the tools/list handler
+// and removes entries the predicate rejects. Other methods pass
+// through untouched.
+//
+// Typical use: hide destructive tools (query_execute, auth_login,
+// etc.) from clients whose transport credential grants only
+// read-only scope. The agent's planner picks from the advertised
+// catalog, so filtering at list time avoids the "tool exists but
+// call returns permission_denied" round trip.
+//
+// Resources/Prompts get sibling functions (ResourceFilter,
+// PromptFilter — TODO) when consumers ask for them; ToolFilter
+// covers the common case.
+func ToolFilter(allow ToolPredicate) Middleware {
+	if allow == nil {
+		// Nil predicate is a programming mistake. Refuse-to-filter
+		// — every tool passes through — so a forgotten wiring step
+		// fails open rather than silently hiding everything.
+		return func(next HandlerFunc) HandlerFunc { return next }
+	}
+	return func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			resp, err := next(ctx, req)
+			if err != nil || resp == nil || resp.Result == nil {
+				return resp, err
+			}
+			if req.Method != protocol.MethodToolsList {
+				return resp, err
+			}
+			// Result shape from handleToolsList:
+			// map[string]any{"tools": []map[string]any{...}}.
+			// Defensive: if either type assertion fails we leave
+			// the response untouched so a future schema tweak
+			// doesn't silently re-leak the full catalog.
+			m, ok := resp.Result.(map[string]any)
+			if !ok {
+				return resp, err
+			}
+			rawTools, ok := m["tools"].([]map[string]any)
+			if !ok {
+				return resp, err
+			}
+			filtered := make([]map[string]any, 0, len(rawTools))
+			for _, t := range rawTools {
+				name, _ := t["name"].(string)
+				if allow(ctx, name) {
+					filtered = append(filtered, t)
+				}
+			}
+			m["tools"] = filtered
+			return resp, err
+		}
+	}
+}

--- a/middleware/toolfilter_test.go
+++ b/middleware/toolfilter_test.go
@@ -1,0 +1,115 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/felixgeelhaar/mcp-go/protocol"
+)
+
+// stubToolsListHandler returns a fixed tools/list result so the
+// middleware can be tested without booting a real server.
+func stubToolsListHandler(toolNames []string) HandlerFunc {
+	return func(_ context.Context, _ *protocol.Request) (*protocol.Response, error) {
+		tools := make([]map[string]any, 0, len(toolNames))
+		for _, n := range toolNames {
+			tools = append(tools, map[string]any{
+				"name":        n,
+				"description": "stub for " + n,
+			})
+		}
+		return &protocol.Response{Result: map[string]any{"tools": tools}}, nil
+	}
+}
+
+func toolNamesFrom(t *testing.T, resp *protocol.Response) []string {
+	t.Helper()
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result not a map: %+v", resp.Result)
+	}
+	tools, ok := m["tools"].([]map[string]any)
+	if !ok {
+		t.Fatalf("tools not []map[string]any: %+v", m["tools"])
+	}
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		n, _ := tool["name"].(string)
+		names = append(names, n)
+	}
+	return names
+}
+
+func TestToolFilterDropsRejectedTools(t *testing.T) {
+	allow := func(_ context.Context, name string) bool {
+		return name == "schema_search" || name == "list_servers"
+	}
+	mw := ToolFilter(allow)
+	h := mw(stubToolsListHandler([]string{
+		"schema_search", "list_servers", "query_execute", "auth_login",
+	}))
+	resp, err := h(context.Background(), &protocol.Request{Method: protocol.MethodToolsList})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got := toolNamesFrom(t, resp)
+	want := map[string]bool{"schema_search": true, "list_servers": true}
+	if len(got) != len(want) {
+		t.Errorf("got %d tools, want %d (%v)", len(got), len(want), got)
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("unexpected tool %q passed the filter", n)
+		}
+	}
+}
+
+func TestToolFilterPassesThroughForOtherMethods(t *testing.T) {
+	allowNone := func(_ context.Context, _ string) bool { return false }
+	mw := ToolFilter(allowNone)
+	called := false
+	inner := HandlerFunc(func(_ context.Context, _ *protocol.Request) (*protocol.Response, error) {
+		called = true
+		return &protocol.Response{Result: map[string]any{"hello": "world"}}, nil
+	})
+	h := mw(inner)
+	resp, err := h(context.Background(), &protocol.Request{Method: protocol.MethodToolsCall})
+	if err != nil || !called {
+		t.Fatalf("non-list method should pass through unchanged; called=%v err=%v", called, err)
+	}
+	if resp.Result.(map[string]any)["hello"] != "world" {
+		t.Errorf("response body mutated for non-list method")
+	}
+}
+
+func TestToolFilterNilPredicateFailsOpen(t *testing.T) {
+	mw := ToolFilter(nil)
+	h := mw(stubToolsListHandler([]string{"a", "b", "c"}))
+	resp, err := h(context.Background(), &protocol.Request{Method: protocol.MethodToolsList})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if got := toolNamesFrom(t, resp); len(got) != 3 {
+		t.Errorf("nil predicate should fail open (no filtering), got %v", got)
+	}
+}
+
+func TestToolFilterTolerantToUnknownShapes(t *testing.T) {
+	// Future mcp-go schema changes might rewrite the result shape.
+	// The filter must NOT panic or silently empty the response in
+	// that case — leave it untouched so the rest of the response
+	// keeps working until the middleware is updated.
+	allowNone := func(_ context.Context, _ string) bool { return false }
+	mw := ToolFilter(allowNone)
+	inner := HandlerFunc(func(_ context.Context, _ *protocol.Request) (*protocol.Response, error) {
+		return &protocol.Response{Result: "unexpected string result"}, nil
+	})
+	h := mw(inner)
+	resp, err := h(context.Background(), &protocol.Request{Method: protocol.MethodToolsList})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.Result != "unexpected string result" {
+		t.Errorf("non-map result mutated: %+v", resp.Result)
+	}
+}


### PR DESCRIPTION
Closes #90.

## Motivation

Hosted-MCP deployments with multi-tier transport credentials (admin / read-only / per-client allowlists) want `tools/list` responses scoped to what each caller can actually invoke. Without this, agents see destructive tools in their advertised catalog, plan calls against them, and only discover the policy boundary after the \`permission_denied\` envelope comes back from the handler. That's a leaky contract — the agent's planner picks from what's advertised.

## API

\`\`\`go
mw := mcp.ToolFilter(func(ctx context.Context, name string) bool {
    id := mcp.IdentityFromContext(ctx)
    if id == nil || id.Name == \"admin\" {
        return true
    }
    return readOnlyAllowlist[name]
})
opts := []mcp.ServeOption{mcp.WithMiddleware(mw)}
\`\`\`

Re-exported at the top level (\`mcp.ToolFilter\` + \`mcp.ToolPredicate\`) so consumers don't need the middleware import.

## Behaviour

- Wraps tools/list responses; walks \`result[\"tools\"]\`, drops entries where the predicate returns false.
- Other methods pass through unchanged.
- Nil predicate fails open (no filtering) — a forgotten wiring step doesn't silently empty the catalog.
- Schema-drift tolerant: when the result shape isn't \`map[string]any{\"tools\": []map[string]any{...}}\` the middleware leaves the response untouched. Future result-shape changes won't silently re-leak the catalog.

## Tests

Four cases in \`middleware/toolfilter_test.go\`:

- Predicate filters by name.
- Non-list methods pass through.
- Nil predicate fails open.
- Unknown result shape passes through untouched.

All pass: \`go test ./middleware/... -run TestToolFilter\` → 4/4.

## Follow-ups

- \`ResourceFilter\` + \`PromptFilter\` follow the same pattern; shipping them now would be speculative since no consumer has asked. Happy to add in a follow-up PR if useful.
- The \`Session.NotifyToolListChangedForIdentity\` hint from #90 would let consumers push the updated filtered list to one client without broadcasting. Out of scope for this PR — separate issue?

## Use case (scry)

Built scry's hosted-MCP deployment around an internal middleware that does exactly this — see \`internal/server/tool_filter.go\` at https://github.com/felixgeelhaar/scry/blob/main/internal/server/tool_filter.go. The internal wrapper relies on the \`map[string]any\` shape and would break on a schema tweak; this PR moves the typed handling into mcp-go where it belongs.