### PR TITLE
feat(transport): add WithRequestContextFn HTTP hook

### DIFF
--- a/transport/http.go
+++ b/transport/http.go
@@ -18,15 +18,16 @@ import (
 const healthStatusField = "status"
 
 type HTTP struct {
-	addr            string
-	readTimeout     time.Duration
-	writeTimeout    time.Duration
-	shutdownTimeout time.Duration
-	drainDelay      time.Duration
-	corsConfig      *CORSConfig
-	sessionStore    SessionStore
-	discovery       *ServerDiscovery
-	tlsConfig       *tls.Config
+	addr             string
+	readTimeout      time.Duration
+	writeTimeout     time.Duration
+	shutdownTimeout  time.Duration
+	drainDelay       time.Duration
+	corsConfig       *CORSConfig
+	sessionStore     SessionStore
+	discovery        *ServerDiscovery
+	tlsConfig        *tls.Config
+	requestContextFn func(context.Context, *http.Request) context.Context
 
 	mu         sync.RWMutex
 	listenAddr string
@@ -77,6 +78,36 @@ func WithDiscovery(discovery *ServerDiscovery) HTTPOption {
 func WithTLSConfig(cfg *tls.Config) HTTPOption {
 	return func(h *HTTP) {
 		h.tlsConfig = cfg
+	}
+}
+
+// WithRequestContextFn registers a function that runs once per HTTP
+// request, before mcp-go unwraps the JSON-RPC payload into a
+// protocol.Request. The returned context propagates through the
+// handler and middleware chain via normal context semantics.
+//
+// This is the place to derive request-scoped identity from transport
+// details that middleware (operating on the unwrapped protocol.Request)
+// cannot see. The canonical use is mTLS: read the verified client
+// certificate and stash a derived identity for downstream authz.
+//
+//	NewHTTP(addr,
+//	    WithTLSConfig(mtlsCfg),
+//	    WithRequestContextFn(func(ctx context.Context, r *http.Request) context.Context {
+//	        if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+//	            cn := r.TLS.PeerCertificates[0].Subject.CommonName
+//	            ctx = mcp.ContextWithIdentity(ctx, &mcp.Identity{ID: cn, Name: cn})
+//	        }
+//	        return ctx
+//	    }),
+//	)
+//
+// The function must return a non-nil context derived from the one
+// passed in; returning a context unrelated to the request breaks
+// cancellation and deadlines.
+func WithRequestContextFn(fn func(context.Context, *http.Request) context.Context) HTTPOption {
+	return func(h *HTTP) {
+		h.requestContextFn = fn
 	}
 }
 
@@ -223,6 +254,11 @@ func (h *HTTP) handleMCP(w http.ResponseWriter, r *http.Request, handler Handler
 
 	w.Header().Set("Content-Type", "application/json")
 
+	ctx := r.Context()
+	if h.requestContextFn != nil {
+		ctx = h.requestContextFn(ctx, r)
+	}
+
 	var req protocol.Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		resp := protocol.NewErrorResponse(nil, protocol.NewParseError("Invalid JSON"))
@@ -230,7 +266,7 @@ func (h *HTTP) handleMCP(w http.ResponseWriter, r *http.Request, handler Handler
 		return
 	}
 
-	resp, err := handler.HandleRequest(r.Context(), &req)
+	resp, err := handler.HandleRequest(ctx, &req)
 	if err != nil {
 		resp = protocol.NewErrorResponse(req.ID, protocol.NewInternalError(err.Error()))
 	}

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -367,3 +367,36 @@ func TestHTTP_Serve(t *testing.T) {
 		cancel()
 	})
 }
+
+func TestHTTP_RequestContextFn(t *testing.T) {
+	type ctxKey string
+	const subjectKey ctxKey = "subject"
+
+	var seen string
+	handler := HandlerFunc(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+		if v, ok := ctx.Value(subjectKey).(string); ok {
+			seen = v
+		}
+		return protocol.NewResponse(req.ID, map[string]string{"status": "ok"}), nil
+	})
+
+	transport := NewHTTP(":0", WithRequestContextFn(func(ctx context.Context, r *http.Request) context.Context {
+		return context.WithValue(ctx, subjectKey, r.Header.Get("X-Cert-Subject"))
+	}))
+	httpHandler := transport.createHandler(handler)
+
+	req := protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "test/method"}
+	reqBytes, _ := json.Marshal(req)
+	httpReq := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(reqBytes))
+	httpReq.Header.Set("X-Cert-Subject", "CN=svc-a")
+	rec := httptest.NewRecorder()
+
+	httpHandler.ServeHTTP(rec, httpReq)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if seen != "CN=svc-a" {
+		t.Errorf("handler ctx subject = %q, want %q", seen, "CN=svc-a")
+	}
+}


### PR DESCRIPTION
Closes #93.

Adds `WithRequestContextFn(func(ctx, *http.Request) context.Context)` to the HTTP transport. Runs once per request in `handleMCP` before the JSON-RPC payload is unwrapped, so consumers can derive request-scoped context from transport details middleware can't see — canonical case: an `Identity` from the mTLS client-cert subject.

Option A from the issue (no leaking `*http.Request` into protocol-level middleware). Test `TestHTTP_RequestContextFn` asserts the derived value reaches the handler ctx. No behavior change when unset.