### PR TITLE
ci(lint): drop gosec — security owned by nox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - unconvert
     - unparam
     - gocritic     # org engineering bar — do not drop
-    - gosec
     # --- repo-specific opt-ins ---
     - bodyclose
     - dogsled
@@ -59,7 +58,6 @@ linters:
         linters:
           - dupl
           - goconst
-          - gosec
           - noctx
           - errcheck
           - gocritic
@@ -71,7 +69,6 @@ linters:
       - path: examples/
         linters:
           - errcheck
-          - gosec
           - gocritic
           - errorlint
           - goconst

--- a/client/http.go
+++ b/client/http.go
@@ -161,7 +161,7 @@ func buildHTTPClient(o httpTransportOptions) *http.Client {
 	if o.caBundle != nil || o.insecure {
 		tr.TLSClientConfig = &tls.Config{
 			RootCAs:            o.caBundle,
-			InsecureSkipVerify: o.insecure, //nolint:gosec // Opt-in via WithInsecureSkipVerify.
+			InsecureSkipVerify: o.insecure,
 			MinVersion:         tls.VersionTLS12,
 		}
 	}

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -56,7 +56,7 @@ func NewUnsafeStdioTransport(command string, args ...string) (*StdioTransport, e
 }
 
 func newStdioTransport(command string, args []string) (*StdioTransport, error) {
-	cmd := exec.Command(command, args...) //nolint:gosec // Caller is responsible for validation.
+	cmd := exec.Command(command, args...)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -129,7 +129,7 @@ func responseToProto(requestID string, resp *protocol.Response) *pb.Message {
 
 	if resp.Error != nil {
 		msg.Error = &pb.Error{
-			Code:    int32(resp.Error.Code), //nolint:gosec // Error codes are JSON-RPC spec constants, always fit in int32
+			Code:    int32(resp.Error.Code),
 			Message: resp.Error.Message,
 		}
 		if resp.Error.Data != nil {
@@ -152,7 +152,7 @@ func errorToProto(requestID string, err *protocol.Error) *pb.Message {
 		Type:      pb.MessageType_MESSAGE_TYPE_RESPONSE,
 		RequestId: requestID,
 		Error: &pb.Error{
-			Code:    int32(err.Code), //nolint:gosec // Error codes are JSON-RPC spec constants, always fit in int32
+			Code:    int32(err.Code),
 			Message: err.Message,
 		},
 	}

--- a/transport/tls_test.go
+++ b/transport/tls_test.go
@@ -93,7 +93,7 @@ func TestHTTP_ServesOverTLSWhenConfigured(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 		Timeout: 2 * time.Second,
 	}


### PR DESCRIPTION
## Drop gosec — security is owned by nox

The org has standardized on **nox** for security scanning (secrets + IaC + dependency + AI + taint-analysis SAST), replacing gosec at the code-lint layer. The golden config in `klarlabs-studio/.github` (`golangci.reference.yml`) already dropped gosec; this PR brings `mcp-go` in line.

### Changes
- **`.golangci.yml`**: removed `gosec` from `linters.enable`, removed the `linters.settings.gosec` block (where present), and pruned gosec from `exclusions.rules` (dropping gosec-only rules entirely, removing the `gosec` token from mixed rules). Everything else — gocritic, the standard set, formatters, repo-specific config — is preserved unchanged.
- **Dead suppressions**: removed 5 now-unused gosec lint directives (`//nolint:gosec` / `// #nosec Gxxx`) that become dead once gosec is gone. For mixed `//nolint:errcheck,gosec` directives, only the `gosec` token was removed; the rest is kept.

### Verification
- `.golangci.yml` parses; no residual gosec references.
- `golangci-lint run ./...` (v2.12.2, the CI-pinned version) and `go build ./...` run locally.
- Removing gosec + its suppressions can only reduce lint findings.

No merge intended — opening for the Lint CI gate to confirm green.