### PR TITLE
feat(server): resource subscriptions (resources/subscribe + push)

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -462,6 +462,7 @@ func ServeStdio(ctx context.Context, srv *Server, opts ...ServeOption) error {
 // This blocks until the context is canceled or an error occurs.
 func ServeHTTP(ctx context.Context, srv *Server, addr string, opts ...HTTPOption) error {
 	t := transport.NewHTTP(addr, opts...)
+	wireResourceSubscriptions(srv, t)
 	handler := newRequestHandler(srv)
 	return t.Serve(ctx, handler)
 }
@@ -469,8 +470,20 @@ func ServeHTTP(ctx context.Context, srv *Server, addr string, opts ...HTTPOption
 // ServeHTTPWithMiddleware runs the server using HTTP transport with middleware support.
 func ServeHTTPWithMiddleware(ctx context.Context, srv *Server, addr string, httpOpts []HTTPOption, serveOpts ...ServeOption) error {
 	t := transport.NewHTTP(addr, httpOpts...)
+	wireResourceSubscriptions(srv, t)
 	handler := newRequestHandler(srv, serveOpts...)
 	return t.Serve(ctx, handler)
+}
+
+// wireResourceSubscriptions connects the HTTP transport's server-push and
+// disconnect lifecycle to the server's subscription registry, so resource
+// updates reach subscribers and closed connections release their state.
+func wireResourceSubscriptions(srv *Server, t *transport.HTTP) {
+	if !srv.ResourceSubscriptionsEnabled() {
+		return
+	}
+	srv.SetResourceNotifier(t)
+	t.SetDisconnectHook(srv.RemoveClientSubscriptions)
 }
 
 // WithReadTimeout sets the read timeout for HTTP requests.
@@ -679,14 +692,16 @@ func (h *requestHandler) HandleRequest(ctx context.Context, req *protocol.Reques
 // All handlers use the same signature (ctx, req) for uniform dispatch.
 func (h *requestHandler) methodHandlers() map[string]func(context.Context, *protocol.Request) (*protocol.Response, error) {
 	return map[string]func(context.Context, *protocol.Request) (*protocol.Response, error){
-		protocol.MethodInitialize:    h.handleInitialize,
-		protocol.MethodToolsList:     h.handleToolsList,
-		protocol.MethodToolsCall:     h.handleToolsCall,
-		protocol.MethodResourcesList: h.handleResourcesList,
-		protocol.MethodResourcesRead: h.handleResourcesRead,
-		protocol.MethodPromptsList:   h.handlePromptsList,
-		protocol.MethodPromptsGet:    h.handlePromptsGet,
-		protocol.MethodPing:          h.handlePing,
+		protocol.MethodInitialize:           h.handleInitialize,
+		protocol.MethodToolsList:            h.handleToolsList,
+		protocol.MethodToolsCall:            h.handleToolsCall,
+		protocol.MethodResourcesList:        h.handleResourcesList,
+		protocol.MethodResourcesRead:        h.handleResourcesRead,
+		protocol.MethodResourcesSubscribe:   h.handleResourcesSubscribe,
+		protocol.MethodResourcesUnsubscribe: h.handleResourcesUnsubscribe,
+		protocol.MethodPromptsList:          h.handlePromptsList,
+		protocol.MethodPromptsGet:           h.handlePromptsGet,
+		protocol.MethodPing:                 h.handlePing,
 	}
 }
 
@@ -708,7 +723,11 @@ func (h *requestHandler) handleInitialize(_ context.Context, req *protocol.Reque
 		capabilities["tools"] = map[string]any{fieldListChanged: true}
 	}
 	if manifest.Capabilities.Resources || len(h.srv.Resources()) > 0 {
-		capabilities["resources"] = map[string]any{fieldListChanged: true}
+		resourceCaps := map[string]any{fieldListChanged: true}
+		if manifest.Capabilities.ResourceSubscribe {
+			resourceCaps["subscribe"] = true
+		}
+		capabilities["resources"] = resourceCaps
 	}
 	if manifest.Capabilities.Prompts || len(h.srv.Prompts()) > 0 {
 		capabilities["prompts"] = map[string]any{fieldListChanged: true}
@@ -998,6 +1017,44 @@ func (h *requestHandler) handleResourcesRead(ctx context.Context, req *protocol.
 	}
 
 	return protocol.NewResponse(req.ID, result), nil
+}
+
+func (h *requestHandler) handleResourcesSubscribe(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	if !h.srv.ResourceSubscriptionsEnabled() {
+		return nil, protocol.NewMethodNotFound(req.Method)
+	}
+	var params struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	if params.URI == "" {
+		return nil, protocol.NewInvalidParams("subscribe requires a uri")
+	}
+	clientID := transport.ClientIDFromContext(ctx)
+	if clientID == "" {
+		return nil, protocol.NewInvalidParams("resources/subscribe requires a client stream (connect to /mcp/sse first)")
+	}
+	h.srv.SubscribeResource(clientID, params.URI)
+	return protocol.NewResponse(req.ID, map[string]any{}), nil
+}
+
+func (h *requestHandler) handleResourcesUnsubscribe(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	if !h.srv.ResourceSubscriptionsEnabled() {
+		return nil, protocol.NewMethodNotFound(req.Method)
+	}
+	var params struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	clientID := transport.ClientIDFromContext(ctx)
+	if clientID != "" {
+		h.srv.UnsubscribeResource(clientID, params.URI)
+	}
+	return protocol.NewResponse(req.ID, map[string]any{}), nil
 }
 
 func (h *requestHandler) handlePromptsList(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {

--- a/mcp_subscriptions_test.go
+++ b/mcp_subscriptions_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+	"go.klarlabs.de/mcp/transport"
+)
+
+type recordingNotifier struct {
+	mu    sync.Mutex
+	calls []struct{ clientID, method string }
+}
+
+func (r *recordingNotifier) NotifyClient(clientID, method string, _ any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, struct{ clientID, method string }{clientID, method})
+	return nil
+}
+
+func subscribeEnabledServer() *Server {
+	return NewServer(ServerInfo{
+		Name:         "test",
+		Version:      "1.0.0",
+		Capabilities: Capabilities{Resources: true, ResourceSubscribe: true},
+	})
+}
+
+func subscribeReq(t *testing.T, method, uri string) *protocol.Request {
+	t.Helper()
+	return &protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  json.RawMessage(`{"uri":"` + uri + `"}`),
+	}
+}
+
+func TestSubscribeRoutesAndNotifies(t *testing.T) {
+	srv := subscribeEnabledServer()
+	notifier := &recordingNotifier{}
+	srv.SetResourceNotifier(notifier)
+	h := newRequestHandler(srv)
+
+	ctx := transport.ContextWithClientID(context.Background(), "client-1")
+	resp, err := h.HandleRequest(ctx, subscribeReq(t, protocol.MethodResourcesSubscribe, "email://inbox"))
+	if err != nil || resp.Error != nil {
+		t.Fatalf("subscribe failed: err=%v respErr=%v", err, resp.Error)
+	}
+
+	if err := srv.NotifyResourceUpdated("email://inbox"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if len(notifier.calls) != 1 || notifier.calls[0].clientID != "client-1" {
+		t.Fatalf("notifications = %+v, want one to client-1", notifier.calls)
+	}
+	if notifier.calls[0].method != protocol.MethodResourceUpdated {
+		t.Errorf("method = %q, want %q", notifier.calls[0].method, protocol.MethodResourceUpdated)
+	}
+}
+
+func TestUnsubscribeStopsNotifications(t *testing.T) {
+	srv := subscribeEnabledServer()
+	notifier := &recordingNotifier{}
+	srv.SetResourceNotifier(notifier)
+	h := newRequestHandler(srv)
+	ctx := transport.ContextWithClientID(context.Background(), "client-1")
+
+	if _, err := h.HandleRequest(ctx, subscribeReq(t, protocol.MethodResourcesSubscribe, "email://inbox")); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if _, err := h.HandleRequest(ctx, subscribeReq(t, protocol.MethodResourcesUnsubscribe, "email://inbox")); err != nil {
+		t.Fatalf("unsubscribe: %v", err)
+	}
+	if err := srv.NotifyResourceUpdated("email://inbox"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if len(notifier.calls) != 0 {
+		t.Errorf("got %d notifications after unsubscribe, want 0", len(notifier.calls))
+	}
+}
+
+func TestSubscribeWithoutClientIDIsRejected(t *testing.T) {
+	srv := subscribeEnabledServer()
+	h := newRequestHandler(srv)
+	// No client id in context (no SSE stream).
+	resp, err := h.HandleRequest(context.Background(), subscribeReq(t, protocol.MethodResourcesSubscribe, "email://inbox"))
+	if err == nil && (resp == nil || resp.Error == nil) {
+		t.Fatal("expected subscribe without a client stream to be rejected")
+	}
+}
+
+func TestSubscribeDisabledReturnsMethodNotFound(t *testing.T) {
+	// Resources present but subscribe capability NOT enabled.
+	srv := NewServer(ServerInfo{Name: "t", Version: "1", Capabilities: Capabilities{Resources: true}})
+	h := newRequestHandler(srv)
+	ctx := transport.ContextWithClientID(context.Background(), "client-1")
+	resp, err := h.HandleRequest(ctx, subscribeReq(t, protocol.MethodResourcesSubscribe, "email://inbox"))
+	if err == nil && (resp == nil || resp.Error == nil) {
+		t.Fatal("expected method-not-found when subscriptions are disabled")
+	}
+}
+
+func TestInitializeAdvertisesSubscribeCapability(t *testing.T) {
+	srv := subscribeEnabledServer()
+	h := newRequestHandler(srv)
+	resp, err := h.HandleRequest(context.Background(), &protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodInitialize,
+		Params:  json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	result, _ := resp.Result.(map[string]any)
+	caps, _ := result["capabilities"].(map[string]any)
+	resources, _ := caps["resources"].(map[string]any)
+	if sub, _ := resources["subscribe"].(bool); !sub {
+		t.Errorf("resources capability did not advertise subscribe: %+v", resources)
+	}
+}

--- a/server/resource_subscriptions.go
+++ b/server/resource_subscriptions.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"errors"
+	"sync"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// ResourceNotifier delivers a server-initiated notification to one connected
+// client. Transports that support server push (HTTP+SSE, WebSocket) implement
+// it so the Server can deliver resource-updated notifications to exactly the
+// clients that subscribed — never broadcast to all (Secure By Default).
+type ResourceNotifier interface {
+	// NotifyClient sends a JSON-RPC notification to the given client.
+	NotifyClient(clientID, method string, params any) error
+}
+
+// resourceSubscriptions is the server-wide registry of resource subscriptions:
+// which client is subscribed to which URI. It is the bridge between the
+// resources/subscribe request handlers and an out-of-band watcher that calls
+// NotifyResourceUpdated.
+type resourceSubscriptions struct {
+	mu       sync.RWMutex
+	byURI    map[string]map[string]struct{} // uri -> set of client ids
+	notifier ResourceNotifier
+}
+
+func newResourceSubscriptions() *resourceSubscriptions {
+	return &resourceSubscriptions{byURI: make(map[string]map[string]struct{})}
+}
+
+func (r *resourceSubscriptions) setNotifier(n ResourceNotifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.notifier = n
+}
+
+func (r *resourceSubscriptions) subscribe(clientID, uri string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	set := r.byURI[uri]
+	if set == nil {
+		set = make(map[string]struct{})
+		r.byURI[uri] = set
+	}
+	set[clientID] = struct{}{}
+}
+
+func (r *resourceSubscriptions) unsubscribe(clientID, uri string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if set := r.byURI[uri]; set != nil {
+		delete(set, clientID)
+		if len(set) == 0 {
+			delete(r.byURI, uri)
+		}
+	}
+}
+
+// removeClient drops every subscription a client held — called when its
+// connection closes so the registry never leaks dead clients.
+func (r *resourceSubscriptions) removeClient(clientID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for uri, set := range r.byURI {
+		delete(set, clientID)
+		if len(set) == 0 {
+			delete(r.byURI, uri)
+		}
+	}
+}
+
+func (r *resourceSubscriptions) subscribers(uri string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	set := r.byURI[uri]
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// notifyUpdated pushes a resources/updated notification to every client
+// subscribed to uri. With no notifier wired (e.g. a transport without server
+// push) it is a no-op. Per-client delivery errors are joined and returned so
+// one dead client does not stop the rest.
+func (r *resourceSubscriptions) notifyUpdated(uri string) error {
+	r.mu.RLock()
+	notifier := r.notifier
+	clients := make([]string, 0, len(r.byURI[uri]))
+	for id := range r.byURI[uri] {
+		clients = append(clients, id)
+	}
+	r.mu.RUnlock()
+
+	if notifier == nil {
+		return nil
+	}
+	var errs []error
+	for _, id := range clients {
+		if err := notifier.NotifyClient(id, protocol.MethodResourceUpdated, ResourceUpdatedNotification{URI: uri}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/server/resource_subscriptions_test.go
+++ b/server/resource_subscriptions_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// captureNotifier records every NotifyClient call for assertions.
+type captureNotifier struct {
+	mu    sync.Mutex
+	calls []struct {
+		clientID, method, uri string
+	}
+	failClient string
+}
+
+func (c *captureNotifier) NotifyClient(clientID, method string, params any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	uri := ""
+	if n, ok := params.(ResourceUpdatedNotification); ok {
+		uri = n.URI
+	}
+	c.calls = append(c.calls, struct{ clientID, method, uri string }{clientID, method, uri})
+	if clientID == c.failClient {
+		return errors.New("delivery failed")
+	}
+	return nil
+}
+
+func TestResourceSubscriptionsNotifyTargetsOnlySubscribers(t *testing.T) {
+	r := newResourceSubscriptions()
+	notifier := &captureNotifier{}
+	r.setNotifier(notifier)
+
+	r.subscribe("client-a", "email://inbox")
+	r.subscribe("client-b", "email://inbox")
+	r.subscribe("client-c", "email://outbox") // different URI, must not be notified
+
+	if err := r.notifyUpdated("email://inbox"); err != nil {
+		t.Fatalf("notifyUpdated: %v", err)
+	}
+
+	if len(notifier.calls) != 2 {
+		t.Fatalf("got %d notifications, want 2 (only inbox subscribers)", len(notifier.calls))
+	}
+	for _, c := range notifier.calls {
+		if c.method != protocol.MethodResourceUpdated {
+			t.Errorf("method = %q, want %q", c.method, protocol.MethodResourceUpdated)
+		}
+		if c.uri != "email://inbox" {
+			t.Errorf("uri = %q, want email://inbox", c.uri)
+		}
+		if c.clientID == "client-c" {
+			t.Error("non-subscriber client-c was notified")
+		}
+	}
+}
+
+func TestResourceSubscriptionsUnsubscribe(t *testing.T) {
+	r := newResourceSubscriptions()
+	notifier := &captureNotifier{}
+	r.setNotifier(notifier)
+
+	r.subscribe("client-a", "email://inbox")
+	r.unsubscribe("client-a", "email://inbox")
+
+	if err := r.notifyUpdated("email://inbox"); err != nil {
+		t.Fatalf("notifyUpdated: %v", err)
+	}
+	if len(notifier.calls) != 0 {
+		t.Errorf("unsubscribed client still notified: %d calls", len(notifier.calls))
+	}
+}
+
+func TestResourceSubscriptionsRemoveClient(t *testing.T) {
+	r := newResourceSubscriptions()
+	notifier := &captureNotifier{}
+	r.setNotifier(notifier)
+
+	r.subscribe("client-a", "email://inbox")
+	r.subscribe("client-a", "email://outbox")
+	r.subscribe("client-b", "email://inbox")
+
+	r.removeClient("client-a") // connection closed
+
+	if got := r.subscribers("email://inbox"); len(got) != 1 || got[0] != "client-b" {
+		t.Errorf("inbox subscribers after removeClient = %v, want [client-b]", got)
+	}
+	if got := r.subscribers("email://outbox"); len(got) != 0 {
+		t.Errorf("outbox subscribers after removeClient = %v, want empty", got)
+	}
+}
+
+func TestResourceSubscriptionsNoNotifierIsNoOp(t *testing.T) {
+	r := newResourceSubscriptions()
+	r.subscribe("client-a", "email://inbox")
+	if err := r.notifyUpdated("email://inbox"); err != nil {
+		t.Errorf("notifyUpdated with no notifier should be a no-op, got %v", err)
+	}
+}
+
+func TestResourceSubscriptionsJoinsDeliveryErrors(t *testing.T) {
+	r := newResourceSubscriptions()
+	notifier := &captureNotifier{failClient: "client-bad"}
+	r.setNotifier(notifier)
+
+	r.subscribe("client-good", "email://inbox")
+	r.subscribe("client-bad", "email://inbox")
+
+	err := r.notifyUpdated("email://inbox")
+	if err == nil {
+		t.Fatal("expected a delivery error from the failing client")
+	}
+	// The good client must still have been notified despite the bad one.
+	if len(notifier.calls) != 2 {
+		t.Errorf("got %d notifications, want 2 (both attempted)", len(notifier.calls))
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -40,6 +40,10 @@ type Capabilities struct {
 	Resources   bool
 	Prompts     bool
 	Completions bool
+	// ResourceSubscribe advertises resources.subscribe: clients may subscribe
+	// to a resource URI and receive notifications/resources/updated when it
+	// changes. Requires a transport with server push (HTTP+SSE).
+	ResourceSubscribe bool
 }
 
 // Manifest represents the server manifest returned to clients.
@@ -80,15 +84,17 @@ type Server struct {
 	middleware   []Middleware
 	completions  *completionRegistry
 	tasks        *TaskManager
+	resourceSubs *resourceSubscriptions
 }
 
 // New creates a new MCP server with the given info and options.
 func New(info Info, opts ...Option) *Server {
 	s := &Server{
-		info:      info,
-		tools:     make(map[string]*Tool),
-		resources: make(map[string]*Resource),
-		prompts:   make(map[string]*Prompt),
+		info:         info,
+		tools:        make(map[string]*Tool),
+		resources:    make(map[string]*Resource),
+		prompts:      make(map[string]*Prompt),
+		resourceSubs: newResourceSubscriptions(),
 	}
 
 	for _, opt := range opts {
@@ -96,6 +102,42 @@ func New(info Info, opts ...Option) *Server {
 	}
 
 	return s
+}
+
+// ResourceSubscriptionsEnabled reports whether the server advertises and
+// handles resource subscriptions.
+func (s *Server) ResourceSubscriptionsEnabled() bool {
+	return s.info.Capabilities.ResourceSubscribe
+}
+
+// SetResourceNotifier wires the transport's server-push mechanism so the
+// server can deliver resources/updated notifications to subscribed clients.
+// Transports with server push (HTTP+SSE) call this during Serve.
+func (s *Server) SetResourceNotifier(n ResourceNotifier) {
+	s.resourceSubs.setNotifier(n)
+}
+
+// SubscribeResource records that a client is interested in a resource URI.
+func (s *Server) SubscribeResource(clientID, uri string) {
+	s.resourceSubs.subscribe(clientID, uri)
+}
+
+// UnsubscribeResource drops a client's interest in a resource URI.
+func (s *Server) UnsubscribeResource(clientID, uri string) {
+	s.resourceSubs.unsubscribe(clientID, uri)
+}
+
+// RemoveClientSubscriptions drops every subscription a client held — call it
+// when the client's connection closes.
+func (s *Server) RemoveClientSubscriptions(clientID string) {
+	s.resourceSubs.removeClient(clientID)
+}
+
+// NotifyResourceUpdated pushes a notifications/resources/updated to every
+// client subscribed to uri. Safe to call from any goroutine (e.g. a file
+// watcher). A no-op when no notifier is wired.
+func (s *Server) NotifyResourceUpdated(uri string) error {
+	return s.resourceSubs.notifyUpdated(uri)
 }
 
 // WithInstructions sets the server instructions that provide context to AI models

--- a/transport/clientid.go
+++ b/transport/clientid.go
@@ -1,0 +1,21 @@
+package transport
+
+import "context"
+
+type clientIDKey struct{}
+
+// ContextWithClientID attaches the connection's client id to the context so
+// request handlers can correlate a request (e.g. resources/subscribe) with the
+// client's server-push stream.
+func ContextWithClientID(ctx context.Context, clientID string) context.Context {
+	return context.WithValue(ctx, clientIDKey{}, clientID)
+}
+
+// ClientIDFromContext returns the client id attached by the transport, or ""
+// when the transport does not track clients.
+func ClientIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(clientIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/transport/http.go
+++ b/transport/http.go
@@ -35,6 +35,40 @@ type HTTP struct {
 
 	sseClients   map[string]chan []byte
 	sseClientsMu sync.RWMutex
+
+	onDisconnect func(clientID string)
+}
+
+// SetDisconnectHook registers a callback invoked when an SSE client
+// disconnects, so the server can release per-client state (e.g. resource
+// subscriptions). Safe to call before Serve.
+func (h *HTTP) SetDisconnectHook(fn func(clientID string)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.onDisconnect = fn
+}
+
+// NotifyClient delivers a JSON-RPC notification to one connected SSE client.
+// It satisfies the server's ResourceNotifier contract structurally, letting
+// the server push resources/updated to subscribers. Returns an error if the
+// client is not connected or its buffer is full.
+func (h *HTTP) NotifyClient(clientID, method string, params any) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("notify %s: marshal params: %w", clientID, err)
+	}
+	msg, err := json.Marshal(protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		Method:  method,
+		Params:  raw,
+	})
+	if err != nil {
+		return fmt.Errorf("notify %s: marshal notification: %w", clientID, err)
+	}
+	if !h.SendTo(clientID, msg) {
+		return fmt.Errorf("notify %s: client not connected or buffer full", clientID)
+	}
+	return nil
 }
 
 type HTTPOption func(*HTTP)
@@ -258,6 +292,12 @@ func (h *HTTP) handleMCP(w http.ResponseWriter, r *http.Request, handler Handler
 	if h.requestContextFn != nil {
 		ctx = h.requestContextFn(ctx, r)
 	}
+	// Correlate this request with the client's server-push stream so handlers
+	// like resources/subscribe can target it. The client echoes the clientId
+	// it received on its SSE connection.
+	if clientID := r.URL.Query().Get("clientId"); clientID != "" {
+		ctx = ContextWithClientID(ctx, clientID)
+	}
 
 	var req protocol.Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -298,6 +338,12 @@ func (h *HTTP) handleSSE(w http.ResponseWriter, r *http.Request) {
 		h.sseClientsMu.Lock()
 		delete(h.sseClients, clientID)
 		h.sseClientsMu.Unlock()
+		h.mu.RLock()
+		hook := h.onDisconnect
+		h.mu.RUnlock()
+		if hook != nil {
+			hook(clientID)
+		}
 	}()
 
 	w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## What

Completes server-side MCP **resource subscriptions**. The per-session primitives (`Session.Subscribe`, `NotifyResourceUpdated`, `SubscriptionManager`) already existed but were never wired into the high-level request router or capability advertisement. This connects them end to end.

## Changes

- **Capability** — `Capabilities.ResourceSubscribe` advertises `resources.subscribe: true` in the `initialize` response.
- **Handlers** — `resources/subscribe` and `resources/unsubscribe` request handlers record `(clientId, uri)` in a new server-wide registry (`server/resource_subscriptions.go`). The `clientId` is correlated from the HTTP transport's SSE stream via the request context (`transport.ContextWithClientID` / `ClientIDFromContext`, set in `handleMCP` from the `clientId` query param).
- **Broadcast** — `Server.NotifyResourceUpdated(uri)` pushes `notifications/resources/updated` to **exactly the subscribed clients** (never broadcast to all — Secure By Default), safe to call from any goroutine (e.g. a file watcher).
- **Transport** — the HTTP transport implements the `ResourceNotifier` contract (`NotifyClient` over the existing `SendTo`) and fires a disconnect hook so closed SSE connections release their subscriptions. `ServeHTTP`/`ServeHTTPWithMiddleware` wire both automatically when the capability is enabled.

## Behavior

- Subscribe/unsubscribe are no-ops (method-not-found) unless `ResourceSubscribe` is set, so existing servers are unaffected.
- Subscribe without a client stream (no SSE) is rejected with invalid-params.
- Per-client delivery errors are isolated and joined — one dead client doesn't stop the rest.

## Tests

- `server/resource_subscriptions_test.go` — registry: targeted delivery, unsubscribe, client removal, no-notifier no-op, error joining.
- `mcp_subscriptions_test.go` — handler integration: subscribe→notify, unsubscribe stops delivery, no-clientId rejection, disabled→method-not-found, capability advertised in initialize.

Full suite + `go vet` + `golangci-lint` (0 issues) green; no regressions across server/transport/client/e2e.

## Why

Unblocks new-mail push notifications in briefkasten (watch the maildir / IMAP IDLE → `NotifyResourceUpdated("email://inbox")`) so MCP hosts learn about new mail without polling.