### PR TITLE
ci(security): enable nox taint-analysis SAST

### DIFF
--- a/.nox.yaml
+++ b/.nox.yaml
@@ -26,3 +26,9 @@ scan:
     - "*_test.go"
     - ".github/workflows/*.yml"
     - ".nox/"
+
+# Activate nox code-level taint SAST (source-to-sink: SSRF, injection,
+# path traversal). nox scan auto-installs (cosign-verified) + runs it.
+plugins:
+  required:
+    - nox/taint-analysis


### PR DESCRIPTION
Declares `nox/taint-analysis` in `.nox.yaml` plugins.required so nox scan runs source-to-sink taint SAST (SSRF, injection, path traversal). Part of klarlabs-studio/.github#14 (nox owns taint -> drop gosec). Any net-new taint findings the gate surfaces need triage before merge.