### PR TITLE
feat(client): resource subscriptions over HTTP+SSE

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -41,9 +41,10 @@ type Client struct {
 	transport Transport
 	opts      clientOptions
 
-	mu         sync.RWMutex
-	serverInfo *ServerInfo
-	requestID  atomic.Int64
+	mu                      sync.RWMutex
+	serverInfo              *ServerInfo
+	resourceUpdatedHandlers []func(uri string)
+	requestID               atomic.Int64
 }
 
 // Icon represents an icon for UI display.

--- a/client/http.go
+++ b/client/http.go
@@ -3,8 +3,10 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +31,9 @@ type HTTPTransport struct {
 	endpoint   string
 	httpClient *http.Client
 	headers    http.Header
+	// clientID correlates this transport's POSTs with its server-push (SSE)
+	// stream so the server can target resource-updated notifications.
+	clientID string
 }
 
 // HTTPTransportOption configures an HTTPTransport.
@@ -153,7 +158,18 @@ func NewHTTPTransport(baseURL string, opts ...HTTPTransportOption) (*HTTPTranspo
 		endpoint:   endpoint,
 		httpClient: client,
 		headers:    headers,
+		clientID:   newClientID(),
 	}, nil
+}
+
+// newClientID mints a random identifier correlating POSTs with the SSE stream.
+func newClientID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read never fails on supported platforms; fall back defensively.
+		return "client"
+	}
+	return hex.EncodeToString(b[:])
 }
 
 func buildHTTPClient(o httpTransportOptions) *http.Client {
@@ -194,7 +210,7 @@ func (t *HTTPTransport) Send(ctx context.Context, req *protocol.Request) (*proto
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, t.endpoint, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, t.postURL(), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}

--- a/client/http_notifications.go
+++ b/client/http_notifications.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// NotificationHandler receives a server-initiated JSON-RPC notification: a
+// message with a method but no id (e.g. notifications/resources/updated).
+type NotificationHandler func(method string, params json.RawMessage)
+
+// StreamingTransport is an optional Transport that also receives
+// server-initiated notifications over a persistent channel (HTTP+SSE). The
+// Client uses it to deliver subscription updates.
+type StreamingTransport interface {
+	Transport
+	// Stream opens the server-push channel and delivers notifications to
+	// handler until ctx is cancelled or the connection drops. It blocks;
+	// callers run it in a goroutine.
+	Stream(ctx context.Context, handler NotificationHandler) error
+}
+
+// postURL is the JSON-RPC POST endpoint with the correlation clientId so the
+// server can target this transport's SSE stream.
+func (t *HTTPTransport) postURL() string {
+	sep := "?"
+	if strings.Contains(t.endpoint, "?") {
+		sep = "&"
+	}
+	return t.endpoint + sep + "clientId=" + t.clientID
+}
+
+// streamURL is the SSE endpoint sibling of the POST endpoint (…/mcp → …/mcp/sse).
+func (t *HTTPTransport) streamURL() string {
+	return t.endpoint + "/sse?clientId=" + t.clientID
+}
+
+// Stream connects to the server's SSE endpoint and dispatches each inbound
+// JSON-RPC notification (a message with a method and no id) to handler. It
+// returns when ctx is cancelled or the stream ends/fails.
+func (t *HTTPTransport) Stream(ctx context.Context, handler NotificationHandler) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, t.streamURL(), nil)
+	if err != nil {
+		return fmt.Errorf("build stream request: %w", err)
+	}
+	for k, vs := range t.headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("open stream: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("open stream: unexpected status %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line := scanner.Text()
+		data, ok := strings.CutPrefix(line, "data: ")
+		if !ok || data == "" {
+			continue // event lines, comments, blank separators, the connected frame
+		}
+		var msg protocol.Request
+		if err := json.Unmarshal([]byte(data), &msg); err != nil {
+			continue // not a JSON-RPC frame (e.g. the {"clientId":...} hello)
+		}
+		// Only notifications (method, no id) are dispatched here.
+		if msg.Method != "" && msg.IsNotification() {
+			handler(msg.Method, msg.Params)
+		}
+	}
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		return fmt.Errorf("read stream: %w", err)
+	}
+	return ctx.Err()
+}

--- a/client/subscriptions.go
+++ b/client/subscriptions.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// ErrNotificationsUnsupported is returned by StartNotifications when the
+// transport has no server-push channel (e.g. plain stdio or an HTTP transport
+// against a server without SSE).
+var ErrNotificationsUnsupported = errors.New("mcp-go/client: transport does not support notifications")
+
+// uriParam is the JSON key for a resource URI in subscribe/unsubscribe params.
+const uriParam = "uri"
+
+// Subscribe registers interest in a resource URI. The server pushes
+// notifications/resources/updated when the resource changes; call
+// StartNotifications (HTTP+SSE) and register OnResourceUpdated to receive them.
+func (c *Client) Subscribe(ctx context.Context, uri string) error {
+	_, err := c.call(ctx, protocol.MethodResourcesSubscribe, map[string]string{uriParam: uri})
+	return err
+}
+
+// Unsubscribe stops the server pushing updates for a resource URI.
+func (c *Client) Unsubscribe(ctx context.Context, uri string) error {
+	_, err := c.call(ctx, protocol.MethodResourcesUnsubscribe, map[string]string{uriParam: uri})
+	return err
+}
+
+// OnResourceUpdated registers a callback invoked for each
+// notifications/resources/updated the client receives. Register before
+// StartNotifications. Safe for concurrent use.
+func (c *Client) OnResourceUpdated(handler func(uri string)) {
+	c.mu.Lock()
+	c.resourceUpdatedHandlers = append(c.resourceUpdatedHandlers, handler)
+	c.mu.Unlock()
+}
+
+// StartNotifications opens the transport's server-push channel and dispatches
+// inbound notifications to registered handlers until ctx is cancelled. It
+// blocks; run it in a goroutine. Returns ErrNotificationsUnsupported when the
+// transport cannot receive server-initiated messages.
+func (c *Client) StartNotifications(ctx context.Context) error {
+	st, ok := c.transport.(StreamingTransport)
+	if !ok {
+		return ErrNotificationsUnsupported
+	}
+	return st.Stream(ctx, c.dispatchNotification)
+}
+
+// dispatchNotification routes one inbound notification to the relevant
+// handlers. Currently only resources/updated is surfaced.
+func (c *Client) dispatchNotification(method string, params json.RawMessage) {
+	if method != protocol.MethodResourceUpdated {
+		return
+	}
+	var payload struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &payload); err != nil || payload.URI == "" {
+		return
+	}
+	c.mu.RLock()
+	handlers := make([]func(string), len(c.resourceUpdatedHandlers))
+	copy(handlers, c.resourceUpdatedHandlers)
+	c.mu.RUnlock()
+	for _, h := range handlers {
+		h(payload.URI)
+	}
+}

--- a/e2e/subscriptions_test.go
+++ b/e2e/subscriptions_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/mcp"
+	"go.klarlabs.de/mcp/client"
+)
+
+// freePort returns a currently-unused localhost address.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// waitForHealth blocks until the server's /health endpoint answers.
+func waitForHealth(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + addr + "/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("server did not become healthy")
+}
+
+func TestResourceSubscriptionPushE2E(t *testing.T) {
+	srv := mcp.NewServer(mcp.ServerInfo{
+		Name:         "push-test",
+		Version:      "1.0.0",
+		Capabilities: mcp.Capabilities{Resources: true, ResourceSubscribe: true},
+	})
+	srv.Resource("email://inbox").
+		Description("inbox").
+		Handler(func(_ context.Context, uri string, _ map[string]string) (*mcp.ResourceContent, error) {
+			return &mcp.ResourceContent{URI: uri, MimeType: "application/json", Text: "{}"}, nil
+		})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr := freePort(t)
+	go func() { _ = mcp.ServeHTTP(ctx, srv, addr) }()
+	waitForHealth(t, addr)
+
+	tr, err := client.NewHTTPTransport("http://" + addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := client.New(tr)
+	if _, err := c.Initialize(ctx); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	updates := make(chan string, 4)
+	c.OnResourceUpdated(func(uri string) { updates <- uri })
+	go func() { _ = c.StartNotifications(ctx) }()
+
+	// Let the SSE stream connect and register on the server.
+	time.Sleep(250 * time.Millisecond)
+
+	if err := c.Subscribe(ctx, "email://inbox"); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Let the subscription register before pushing.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := srv.NotifyResourceUpdated("email://inbox"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+
+	select {
+	case uri := <-updates:
+		if uri != "email://inbox" {
+			t.Errorf("updated uri = %q, want email://inbox", uri)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("client did not receive the resource-updated push")
+	}
+}
+
+func TestHTTPTransportIsStreaming(t *testing.T) {
+	// The HTTP transport must expose the server-push channel so the client can
+	// receive notifications; a transport without it returns
+	// ErrNotificationsUnsupported from StartNotifications.
+	tr, err := client.NewHTTPTransport("http://127.0.0.1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := any(tr).(client.StreamingTransport); !ok {
+		t.Fatal("HTTPTransport should implement client.StreamingTransport")
+	}
+}


### PR DESCRIPTION
## What

Completes the resource-subscription round-trip from the **client** side. v1.16.0 added server-side push (`resources/subscribe` + `NotifyResourceUpdated`); this lets the Go client actually receive those notifications.

## Changes

- **HTTPTransport** mints a `clientId`, echoes it on every POST (`?clientId=`), and implements `Stream(ctx, handler)`: it opens the `/mcp/sse` channel and dispatches each inbound JSON-RPC notification. `StreamingTransport` is an optional `Transport` interface — non-streaming transports are unaffected.
- **Client API**:
  - `Subscribe(ctx, uri)` / `Unsubscribe(ctx, uri)` — send `resources/subscribe` / `unsubscribe`.
  - `OnResourceUpdated(func(uri))` — register a callback.
  - `StartNotifications(ctx)` — open the stream and route `notifications/resources/updated` to callbacks (blocks; run in a goroutine). Returns `ErrNotificationsUnsupported` for transports without server push.

## Tests

- **End-to-end** (`e2e/subscriptions_test.go`): a real HTTP server with subscriptions enabled; the client connects, subscribes, the server calls `NotifyResourceUpdated`, and the client's `OnResourceUpdated` handler fires over SSE.
- `HTTPTransport` satisfies `StreamingTransport`.

Full suite + `go vet` + `golangci-lint` (0) green; no regressions.

## Why

Lets Nexa's document service subscribe to briefkasten's `email://inbox` and ingest on push instead of polling.