### PR TITLE
feat(client): typed call API + correctness hardening

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -94,6 +94,11 @@ type Tool struct {
 type ToolResult struct {
 	Content []ContentItem `json:"content"`
 	IsError bool          `json:"isError,omitempty"`
+	// StructuredContent is the canonical typed channel a server emits for
+	// tools that declare an output schema. When present it holds the typed
+	// result as raw JSON; typed decoders should prefer it over the display
+	// text content. It is nil when the server emits no structuredContent.
+	StructuredContent json.RawMessage `json:"structuredContent,omitempty"`
 }
 
 // ContentItem represents a content item in a tool result.
@@ -362,6 +367,17 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments any) (*Too
 
 	if isErr, ok := result["isError"].(bool); ok {
 		toolResult.IsError = isErr
+	}
+
+	// structuredContent is the canonical typed channel. Re-marshal the
+	// decoded object so typed callers can unmarshal it into their output
+	// type directly, preferring it over the display text content.
+	if sc, ok := result["structuredContent"]; ok && sc != nil {
+		structured, err := json.Marshal(sc)
+		if err != nil {
+			return nil, fmt.Errorf("call tool %q: marshal structuredContent: %w", name, err)
+		}
+		toolResult.StructuredContent = structured
 	}
 
 	if content, ok := result["content"].([]any); ok {

--- a/client/client.go
+++ b/client/client.go
@@ -19,6 +19,9 @@ var (
 	ErrInvalidResult = errors.New("invalid result type")
 	// ErrNoContent indicates the server returned no content for a resource.
 	ErrNoContent = errors.New("no content")
+	// ErrToolError indicates the server reported a tool execution failure via
+	// the MCP isError flag. The wrapping error carries the tool's error text.
+	ErrToolError = errors.New("tool reported an error")
 )
 
 // JSON field names used in MCP handshake payloads.

--- a/client/client.go
+++ b/client/client.go
@@ -22,6 +22,11 @@ var (
 	// ErrToolError indicates the server reported a tool execution failure via
 	// the MCP isError flag. The wrapping error carries the tool's error text.
 	ErrToolError = errors.New("tool reported an error")
+	// ErrNoToolContent indicates a typed tool call produced neither
+	// structuredContent nor a decodable text content block. It is the
+	// tool-domain counterpart to ErrNoContent (which covers resources), so
+	// callers can distinguish the two no-content cases.
+	ErrNoToolContent = errors.New("no decodable tool content")
 )
 
 // JSON field names used in MCP handshake payloads.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -442,10 +442,19 @@ type mockTransport struct {
 	responses []protocol.Response
 	requests  []protocol.Request
 	idx       int
+	// lastCtx records the context of the most recent Send so tests can assert
+	// that the caller's context propagates through to the transport.
+	lastCtx context.Context
 }
 
 func (m *mockTransport) Send(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	m.lastCtx = ctx
 	m.requests = append(m.requests, *req)
+	// Honor context cancellation/deadline so tests can assert that a
+	// cancelled context surfaces through the typed call layer.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if m.idx >= len(m.responses) {
 		return nil, context.DeadlineExceeded
 	}

--- a/client/typed.go
+++ b/client/typed.go
@@ -156,15 +156,28 @@ func (t *dynamicTool) Name() string {
 	return t.name
 }
 
-// Call invokes the tool with raw JSON arguments. The arguments are decoded so
-// they reach the server as a structured object, and the first text content
-// block of the result is returned as raw JSON.
+// Call invokes the tool with raw JSON arguments. The raw bytes are handed to
+// the underlying call verbatim, and the first text content block of the
+// result is returned as raw JSON.
+//
+// The arguments are passed through as a json.RawMessage rather than being
+// decoded into map[string]any and re-encoded. CallTool marshals its arguments,
+// and json.Marshal of a json.RawMessage emits the bytes unchanged, so this
+// path is lossless: large int64 values keep full precision (no float64
+// rounding) and object field ordering is preserved. Decoding to a map would
+// lose both, which defeats the purpose of a raw passthrough.
 func (t *dynamicTool) Call(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	// A nil/empty payload must remain nil so CallTool omits the arguments
+	// field entirely rather than sending a null. A non-empty payload is still
+	// validated as well-formed JSON to fail fast on malformed input (matching
+	// the previous behavior and preserving the syntax-error detail), but the
+	// original bytes are forwarded untouched rather than the re-encoded form.
 	var args any
 	if len(in) > 0 {
-		if err := json.Unmarshal(in, &args); err != nil {
+		if err := json.Unmarshal(in, new(json.RawMessage)); err != nil {
 			return nil, fmt.Errorf("call tool %q: decode arguments: %w", t.name, err)
 		}
+		args = in
 	}
 
 	result, err := t.client.CallTool(ctx, t.name, args)

--- a/client/typed.go
+++ b/client/typed.go
@@ -50,14 +50,21 @@ func Call[In, Out any](ctx context.Context, c *Client, name string, in In) (Out,
 		return out, nil
 	}
 
-	if len(result.Content) == 0 {
-		return out, fmt.Errorf("call tool %q: %w", name, ErrNoContent)
+	// Select the first text content block rather than blindly taking
+	// Content[0], which may be an image or other non-text block.
+	text, ok := firstTextContent(result)
+	if !ok {
+		return out, fmt.Errorf("call tool %q: %w", name, ErrNoToolContent)
 	}
-
-	text := result.Content[0].Text
 
 	// A string output receives the raw text directly so callers can opt out
 	// of JSON decoding for plain-text tools.
+	//
+	// WARNING: when the tool serialized a JSON value into the text block (the
+	// usual case for typed handlers), that block is a JSON-encoded string with
+	// surrounding quotes. Because the raw text is returned unchanged here, the
+	// quotes are included verbatim rather than JSON-decoded. Use a struct (or
+	// json.RawMessage) Out if you need decoded values.
 	if s, ok := any(&out).(*string); ok {
 		*s = text
 		return out, nil
@@ -68,6 +75,18 @@ func Call[In, Out any](ctx context.Context, c *Client, name string, in In) (Out,
 	}
 
 	return out, nil
+}
+
+// firstTextContent returns the text of the first content block whose type is
+// "text". The boolean is false when no such block exists, so callers can
+// distinguish "no text content" from a legitimately empty text body.
+func firstTextContent(result *ToolResult) (string, bool) {
+	for _, item := range result.Content {
+		if item.Type == "text" {
+			return item.Text, true
+		}
+	}
+	return "", false
 }
 
 // ClientTool is a reusable, typed handle bound to a single tool on a client.
@@ -154,11 +173,14 @@ func (t *dynamicTool) Call(ctx context.Context, in json.RawMessage) (json.RawMes
 		return nil, fmt.Errorf("call tool %q: %w: %s", t.name, ErrToolError, toolErrorText(result))
 	}
 
-	if len(result.Content) == 0 {
-		return nil, fmt.Errorf("call tool %q: %w", t.name, ErrNoContent)
+	// Select the first text content block rather than blindly taking
+	// Content[0], which may be an image or other non-text block.
+	text, ok := firstTextContent(result)
+	if !ok {
+		return nil, fmt.Errorf("call tool %q: %w", t.name, ErrNoToolContent)
 	}
 
-	return json.RawMessage(result.Content[0].Text), nil
+	return json.RawMessage(text), nil
 }
 
 // toolErrorText extracts a human-readable error message from a tool result

--- a/client/typed.go
+++ b/client/typed.go
@@ -40,6 +40,16 @@ func Call[In, Out any](ctx context.Context, c *Client, name string, in In) (Out,
 		return out, fmt.Errorf("call tool %q: %w: %s", name, ErrToolError, toolErrorText(result))
 	}
 
+	// Prefer the canonical typed channel: when the server emits
+	// structuredContent, decode that rather than the display text. This also
+	// covers results that carry structuredContent with empty Content.
+	if len(result.StructuredContent) > 0 {
+		if err := json.Unmarshal(result.StructuredContent, &out); err != nil {
+			return out, fmt.Errorf("call tool %q: decode structuredContent: %w", name, err)
+		}
+		return out, nil
+	}
+
 	if len(result.Content) == 0 {
 		return out, fmt.Errorf("call tool %q: %w", name, ErrNoContent)
 	}

--- a/client/typed.go
+++ b/client/typed.go
@@ -36,6 +36,10 @@ func Call[In, Out any](ctx context.Context, c *Client, name string, in In) (Out,
 		return out, err
 	}
 
+	if result.IsError {
+		return out, fmt.Errorf("call tool %q: %w: %s", name, ErrToolError, toolErrorText(result))
+	}
+
 	if len(result.Content) == 0 {
 		return out, fmt.Errorf("call tool %q: %w", name, ErrNoContent)
 	}
@@ -136,9 +140,25 @@ func (t *dynamicTool) Call(ctx context.Context, in json.RawMessage) (json.RawMes
 		return nil, err
 	}
 
+	if result.IsError {
+		return nil, fmt.Errorf("call tool %q: %w: %s", t.name, ErrToolError, toolErrorText(result))
+	}
+
 	if len(result.Content) == 0 {
 		return nil, fmt.Errorf("call tool %q: %w", t.name, ErrNoContent)
 	}
 
 	return json.RawMessage(result.Content[0].Text), nil
+}
+
+// toolErrorText extracts a human-readable error message from a tool result
+// flagged with isError. It returns the first text content block, falling back
+// to a generic phrase when the server provided no text.
+func toolErrorText(result *ToolResult) string {
+	for _, item := range result.Content {
+		if item.Type == "text" && item.Text != "" {
+			return item.Text
+		}
+	}
+	return "no error detail provided"
 }

--- a/client/typed.go
+++ b/client/typed.go
@@ -1,0 +1,144 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Call invokes a tool on the server with a typed input and decodes the typed
+// output. The input is marshaled to the tool arguments, the tool is invoked
+// over the standard CallTool path, and the first text content block of the
+// result is decoded into Out.
+//
+// When Out is a string, the raw text of the first content block is returned
+// unchanged; otherwise the text is treated as JSON and unmarshaled into Out.
+// This mirrors how the server serializes typed tool results.
+//
+// Call is the recommended primary API for invoking tools. For a reusable,
+// pre-bound handle, see NewClientTool.
+//
+// Example:
+//
+//	type GreetIn struct{ Name string `json:"name"` }
+//	type GreetOut struct{ Message string `json:"message"` }
+//
+//	out, err := client.Call[GreetIn, GreetOut](ctx, c, "greet", GreetIn{Name: "World"})
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println(out.Message)
+func Call[In, Out any](ctx context.Context, c *Client, name string, in In) (Out, error) {
+	var out Out
+
+	result, err := c.CallTool(ctx, name, in)
+	if err != nil {
+		return out, err
+	}
+
+	if len(result.Content) == 0 {
+		return out, fmt.Errorf("call tool %q: %w", name, ErrNoContent)
+	}
+
+	text := result.Content[0].Text
+
+	// A string output receives the raw text directly so callers can opt out
+	// of JSON decoding for plain-text tools.
+	if s, ok := any(&out).(*string); ok {
+		*s = text
+		return out, nil
+	}
+
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		return out, fmt.Errorf("call tool %q: decode result: %w", name, err)
+	}
+
+	return out, nil
+}
+
+// ClientTool is a reusable, typed handle bound to a single tool on a client.
+// Create one with NewClientTool and invoke it repeatedly via Call.
+type ClientTool[In, Out any] struct {
+	client *Client
+	name   string
+}
+
+// NewClientTool returns a reusable typed handle for the named tool. Each Call
+// on the handle delegates to the package-level Call, so the handle is safe to
+// reuse for the lifetime of the client.
+//
+// Example:
+//
+//	greet := client.NewClientTool[GreetIn, GreetOut](c, "greet")
+//	out, err := greet.Call(ctx, GreetIn{Name: "World"})
+func NewClientTool[In, Out any](c *Client, name string) *ClientTool[In, Out] {
+	return &ClientTool[In, Out]{client: c, name: name}
+}
+
+// Name returns the tool name this handle is bound to.
+func (t *ClientTool[In, Out]) Name() string {
+	return t.name
+}
+
+// Call invokes the bound tool with the typed input and returns the typed
+// output. It delegates to the package-level Call.
+func (t *ClientTool[In, Out]) Call(ctx context.Context, in In) (Out, error) {
+	return Call[In, Out](ctx, t.client, t.name, in)
+}
+
+// DynamicTool is a dynamically typed escape hatch for invoking a tool with raw
+// JSON arguments and receiving the raw JSON result.
+//
+// Prefer the typed Call and NewClientTool APIs. DynamicTool is provided only
+// for cases where the input and output shapes are not known at compile time
+// (for example, proxying tool calls). It forgoes the compile-time guarantees
+// that make the typed API the recommended choice.
+type DynamicTool interface {
+	// Name returns the tool name.
+	Name() string
+	// Call invokes the tool with raw JSON arguments and returns the first
+	// text content block of the result as raw JSON.
+	Call(ctx context.Context, in json.RawMessage) (json.RawMessage, error)
+}
+
+// dynamicTool is the default DynamicTool implementation backed by a Client.
+type dynamicTool struct {
+	client *Client
+	name   string
+}
+
+// NewDynamicTool returns a DynamicTool for the named tool.
+//
+// This is the dynamically typed escape hatch and is not recommended for
+// general use; prefer Call or NewClientTool.
+func NewDynamicTool(c *Client, name string) DynamicTool {
+	return &dynamicTool{client: c, name: name}
+}
+
+// Name returns the tool name this handle is bound to.
+func (t *dynamicTool) Name() string {
+	return t.name
+}
+
+// Call invokes the tool with raw JSON arguments. The arguments are decoded so
+// they reach the server as a structured object, and the first text content
+// block of the result is returned as raw JSON.
+func (t *dynamicTool) Call(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args any
+	if len(in) > 0 {
+		if err := json.Unmarshal(in, &args); err != nil {
+			return nil, fmt.Errorf("call tool %q: decode arguments: %w", t.name, err)
+		}
+	}
+
+	result, err := t.client.CallTool(ctx, t.name, args)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Content) == 0 {
+		return nil, fmt.Errorf("call tool %q: %w", t.name, ErrNoContent)
+	}
+
+	return json.RawMessage(result.Content[0].Text), nil
+}

--- a/client/typed.go
+++ b/client/typed.go
@@ -16,7 +16,7 @@ import (
 // This mirrors how the server serializes typed tool results.
 //
 // Call is the recommended primary API for invoking tools. For a reusable,
-// pre-bound handle, see NewClientTool.
+// pre-bound handle, see NewTypedTool.
 //
 // Example:
 //
@@ -89,40 +89,40 @@ func firstTextContent(result *ToolResult) (string, bool) {
 	return "", false
 }
 
-// ClientTool is a reusable, typed handle bound to a single tool on a client.
-// Create one with NewClientTool and invoke it repeatedly via Call.
-type ClientTool[In, Out any] struct {
+// TypedTool is a reusable, typed handle bound to a single tool on a client.
+// Create one with NewTypedTool and invoke it repeatedly via Call.
+type TypedTool[In, Out any] struct {
 	client *Client
 	name   string
 }
 
-// NewClientTool returns a reusable typed handle for the named tool. Each Call
+// NewTypedTool returns a reusable typed handle for the named tool. Each Call
 // on the handle delegates to the package-level Call, so the handle is safe to
 // reuse for the lifetime of the client.
 //
 // Example:
 //
-//	greet := client.NewClientTool[GreetIn, GreetOut](c, "greet")
+//	greet := client.NewTypedTool[GreetIn, GreetOut](c, "greet")
 //	out, err := greet.Call(ctx, GreetIn{Name: "World"})
-func NewClientTool[In, Out any](c *Client, name string) *ClientTool[In, Out] {
-	return &ClientTool[In, Out]{client: c, name: name}
+func NewTypedTool[In, Out any](c *Client, name string) *TypedTool[In, Out] {
+	return &TypedTool[In, Out]{client: c, name: name}
 }
 
 // Name returns the tool name this handle is bound to.
-func (t *ClientTool[In, Out]) Name() string {
+func (t *TypedTool[In, Out]) Name() string {
 	return t.name
 }
 
 // Call invokes the bound tool with the typed input and returns the typed
 // output. It delegates to the package-level Call.
-func (t *ClientTool[In, Out]) Call(ctx context.Context, in In) (Out, error) {
+func (t *TypedTool[In, Out]) Call(ctx context.Context, in In) (Out, error) {
 	return Call[In, Out](ctx, t.client, t.name, in)
 }
 
 // DynamicTool is a dynamically typed escape hatch for invoking a tool with raw
 // JSON arguments and receiving the raw JSON result.
 //
-// Prefer the typed Call and NewClientTool APIs. DynamicTool is provided only
+// Prefer the typed Call and NewTypedTool APIs. DynamicTool is provided only
 // for cases where the input and output shapes are not known at compile time
 // (for example, proxying tool calls). It forgoes the compile-time guarantees
 // that make the typed API the recommended choice.
@@ -143,7 +143,7 @@ type dynamicTool struct {
 // NewDynamicTool returns a DynamicTool for the named tool.
 //
 // This is the dynamically typed escape hatch and is not recommended for
-// general use; prefer Call or NewClientTool.
+// general use; prefer Call or NewTypedTool.
 func NewDynamicTool(c *Client, name string) DynamicTool {
 	return &dynamicTool{client: c, name: name}
 }

--- a/client/typed.go
+++ b/client/typed.go
@@ -33,7 +33,10 @@ func Call[In, Out any](ctx context.Context, c *Client, name string, in In) (Out,
 
 	result, err := c.CallTool(ctx, name, in)
 	if err != nil {
-		return out, err
+		// Add a frame for the typed-call layer so the error path is as
+		// self-describing as the decode path below; %w keeps the wrapped
+		// transport/server error inspectable via errors.As/errors.Is.
+		return out, fmt.Errorf("typed call tool %q: %w", name, err)
 	}
 
 	if result.IsError {

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -1,0 +1,398 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/mcp/client"
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// greetIn is a typed tool input used across the typed-client tests.
+type greetIn struct {
+	Name string `json:"name"`
+}
+
+// greetOut is a typed tool output used across the typed-client tests.
+type greetOut struct {
+	Message string `json:"message"`
+	Count   int    `json:"count"`
+}
+
+// textResponse builds a mock JSON-RPC response whose tool result carries a
+// single text content block, mirroring how the server serializes typed
+// results.
+func textResponse(text string) protocol.Response {
+	return protocol.Response{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result: map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "text",
+					"text": text,
+				},
+			},
+		},
+	}
+}
+
+func TestCall(t *testing.T) {
+	t.Run("happy path typed round-trip", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				textResponse(`{"message":"Hello, World!","count":2}`),
+			},
+		}
+		c := client.New(transport)
+
+		out, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "greet", greetIn{Name: "World"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Message != "Hello, World!" {
+			t.Errorf("message = %q, want %q", out.Message, "Hello, World!")
+		}
+		if out.Count != 2 {
+			t.Errorf("count = %d, want %d", out.Count, 2)
+		}
+
+		// The marshaled input must reach the server as the tool arguments.
+		if len(transport.requests) != 1 {
+			t.Fatalf("expected 1 request, got %d", len(transport.requests))
+		}
+		var params struct {
+			Name      string  `json:"name"`
+			Arguments greetIn `json:"arguments"`
+		}
+		if err := json.Unmarshal(transport.requests[0].Params, &params); err != nil {
+			t.Fatalf("unmarshal request params: %v", err)
+		}
+		if params.Name != "greet" {
+			t.Errorf("tool name = %q, want %q", params.Name, "greet")
+		}
+		if params.Arguments.Name != "World" {
+			t.Errorf("argument name = %q, want %q", params.Arguments.Name, "World")
+		}
+	})
+
+	t.Run("string output returns raw text", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{textResponse("Hello, World!")},
+		}
+		c := client.New(transport)
+
+		out, err := client.Call[greetIn, string](
+			context.Background(), c, "greet", greetIn{Name: "World"},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "Hello, World!" {
+			t.Errorf("out = %q, want %q", out, "Hello, World!")
+		}
+	})
+
+	t.Run("tool not found returns server error", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				{
+					JSONRPC: "2.0",
+					ID:      json.RawMessage(`1`),
+					Error:   &protocol.Error{Code: -32601, Message: "tool not found"},
+				},
+			},
+		}
+		c := client.New(transport)
+
+		_, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "unknown", greetIn{Name: "x"},
+		)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		var mcpErr *protocol.Error
+		if !errors.As(err, &mcpErr) {
+			t.Fatalf("expected *protocol.Error, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("server error result is reported", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				{
+					JSONRPC: "2.0",
+					ID:      json.RawMessage(`1`),
+					Error:   &protocol.Error{Code: -32000, Message: "boom"},
+				},
+			},
+		}
+		c := client.New(transport)
+
+		_, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "greet", greetIn{Name: "x"},
+		)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("output unmarshal mismatch returns error", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				// count is declared int but the server sends a string.
+				textResponse(`{"message":"hi","count":"not-a-number"}`),
+			},
+		}
+		c := client.New(transport)
+
+		_, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "greet", greetIn{Name: "x"},
+		)
+		if err == nil {
+			t.Fatal("expected unmarshal error")
+		}
+	})
+
+	t.Run("no content returns error", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				{
+					JSONRPC: "2.0",
+					ID:      json.RawMessage(`1`),
+					Result:  map[string]any{"content": []any{}},
+				},
+			},
+		}
+		c := client.New(transport)
+
+		_, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "greet", greetIn{Name: "x"},
+		)
+		if err == nil {
+			t.Fatal("expected error for empty content")
+		}
+		if !errors.Is(err, client.ErrNoContent) {
+			t.Errorf("error = %v, want ErrNoContent", err)
+		}
+	})
+
+	t.Run("input marshal edge cases", func(t *testing.T) {
+		type nested struct {
+			Tags  []string       `json:"tags"`
+			Meta  map[string]int `json:"meta"`
+			Inner *greetIn       `json:"inner"`
+			Empty *greetIn       `json:"empty"`
+		}
+
+		tests := []struct {
+			name string
+			in   nested
+		}{
+			{
+				name: "nested with null pointer",
+				in: nested{
+					Tags:  []string{"a", "b"},
+					Meta:  map[string]int{"x": 1},
+					Inner: &greetIn{Name: "deep"},
+					Empty: nil,
+				},
+			},
+			{
+				name: "empty array and map",
+				in: nested{
+					Tags: []string{},
+					Meta: map[string]int{},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				transport := &mockTransport{
+					responses: []protocol.Response{textResponse(`{"message":"ok","count":1}`)},
+				}
+				c := client.New(transport)
+
+				_, err := client.Call[nested, greetOut](
+					context.Background(), c, "complex", tt.in,
+				)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				var params struct {
+					Arguments nested `json:"arguments"`
+				}
+				if err := json.Unmarshal(transport.requests[0].Params, &params); err != nil {
+					t.Fatalf("unmarshal params: %v", err)
+				}
+				if len(params.Arguments.Tags) != len(tt.in.Tags) {
+					t.Errorf("tags len = %d, want %d", len(params.Arguments.Tags), len(tt.in.Tags))
+				}
+				if (params.Arguments.Inner == nil) != (tt.in.Inner == nil) {
+					t.Errorf("inner nullability mismatch")
+				}
+			})
+		}
+	})
+}
+
+func TestNewClientTool(t *testing.T) {
+	t.Run("reusable handle called multiple times", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				textResponse(`{"message":"first","count":1}`),
+				textResponse(`{"message":"second","count":2}`),
+			},
+		}
+		c := client.New(transport)
+
+		greet := client.NewClientTool[greetIn, greetOut](c, "greet")
+		if greet.Name() != "greet" {
+			t.Errorf("name = %q, want %q", greet.Name(), "greet")
+		}
+
+		out1, err := greet.Call(context.Background(), greetIn{Name: "a"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out1.Message != "first" {
+			t.Errorf("out1.Message = %q, want %q", out1.Message, "first")
+		}
+
+		out2, err := greet.Call(context.Background(), greetIn{Name: "b"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out2.Count != 2 {
+			t.Errorf("out2.Count = %d, want %d", out2.Count, 2)
+		}
+
+		if len(transport.requests) != 2 {
+			t.Fatalf("expected 2 requests, got %d", len(transport.requests))
+		}
+	})
+
+	t.Run("propagates errors", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				{
+					JSONRPC: "2.0",
+					ID:      json.RawMessage(`1`),
+					Error:   &protocol.Error{Code: -32601, Message: "tool not found"},
+				},
+			},
+		}
+		c := client.New(transport)
+
+		greet := client.NewClientTool[greetIn, greetOut](c, "missing")
+		if _, err := greet.Call(context.Background(), greetIn{Name: "x"}); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestDynamicTool(t *testing.T) {
+	t.Run("raw escape hatch round-trips json", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{textResponse(`{"message":"raw","count":7}`)},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		if tool.Name() != "greet" {
+			t.Errorf("name = %q, want %q", tool.Name(), "greet")
+		}
+
+		raw, err := tool.Call(context.Background(), json.RawMessage(`{"name":"World"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var out greetOut
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("unmarshal raw result: %v", err)
+		}
+		if out.Message != "raw" || out.Count != 7 {
+			t.Errorf("out = %+v, want {raw 7}", out)
+		}
+
+		// The raw input must arrive as the tool arguments unchanged.
+		var params struct {
+			Arguments greetIn `json:"arguments"`
+		}
+		if err := json.Unmarshal(transport.requests[0].Params, &params); err != nil {
+			t.Fatalf("unmarshal params: %v", err)
+		}
+		if params.Arguments.Name != "World" {
+			t.Errorf("argument name = %q, want %q", params.Arguments.Name, "World")
+		}
+	})
+
+	t.Run("propagates server error", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				{
+					JSONRPC: "2.0",
+					ID:      json.RawMessage(`1`),
+					Error:   &protocol.Error{Code: -32000, Message: "boom"},
+				},
+			},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		if _, err := tool.Call(context.Background(), json.RawMessage(`{}`)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("rejects malformed raw arguments", func(t *testing.T) {
+		c := client.New(&mockTransport{})
+
+		tool := client.NewDynamicTool(c, "greet")
+		if _, err := tool.Call(context.Background(), json.RawMessage(`{not json`)); err == nil {
+			t.Fatal("expected decode error")
+		}
+	})
+
+	t.Run("nil arguments are allowed", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{textResponse(`{"message":"ok","count":1}`)},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		raw, err := tool.Call(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(raw) == 0 {
+			t.Fatal("expected raw result")
+		}
+	})
+
+	t.Run("no content returns error", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				{
+					JSONRPC: "2.0",
+					ID:      json.RawMessage(`1`),
+					Result:  map[string]any{"content": []any{}},
+				},
+			},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		_, err := tool.Call(context.Background(), json.RawMessage(`{"name":"x"}`))
+		if !errors.Is(err, client.ErrNoContent) {
+			t.Errorf("error = %v, want ErrNoContent", err)
+		}
+	})
+}

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -560,6 +560,53 @@ func TestDynamicTool(t *testing.T) {
 		}
 	})
 
+	t.Run("passes raw json through without lossy re-encoding", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{textResponse(`{"message":"ok","count":1}`)},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "compute")
+
+		// 9007199254740993 (2^53 + 1) is not exactly representable as a
+		// float64, so any round-trip through map[string]any (which decodes
+		// JSON numbers into float64) would round it to 9007199254740992.
+		// The dynamic tool path must hand the raw bytes to the transport
+		// untouched. Field ordering is deliberately non-alphabetical to
+		// assert raw fidelity rather than re-encoded ordering.
+		in := json.RawMessage(`{"id":9007199254740993,"zeta":1,"alpha":2}`)
+		if _, err := tool.Call(context.Background(), in); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(transport.requests) != 1 {
+			t.Fatalf("requests = %d, want 1", len(transport.requests))
+		}
+
+		// Pull the exact bytes the transport received for "arguments" so we
+		// can assert no precision or ordering loss occurred.
+		var params struct {
+			Arguments json.RawMessage `json:"arguments"`
+		}
+		if err := json.Unmarshal(transport.requests[0].Params, &params); err != nil {
+			t.Fatalf("unmarshal params: %v", err)
+		}
+
+		// The large integer must survive verbatim, not rounded to 2^53.
+		if !strings.Contains(string(params.Arguments), "9007199254740993") {
+			t.Errorf("arguments = %s, want the int64 9007199254740993 intact (no float64 rounding)", params.Arguments)
+		}
+		if strings.Contains(string(params.Arguments), "9007199254740992") {
+			t.Errorf("arguments = %s, lost int64 precision (rounded to 2^53)", params.Arguments)
+		}
+
+		// Raw fidelity: the bytes must match the input exactly, preserving
+		// the original field order.
+		if string(params.Arguments) != string(in) {
+			t.Errorf("arguments = %s, want verbatim %s", params.Arguments, in)
+		}
+	})
+
 	t.Run("propagates server error", func(t *testing.T) {
 		transport := &mockTransport{
 			responses: []protocol.Response{

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"go.klarlabs.de/mcp/client"
@@ -37,6 +38,29 @@ func textResponse(text string) protocol.Response {
 			},
 		},
 	}
+}
+
+// resultResponse builds a mock JSON-RPC response from a raw tool result map,
+// allowing tests to exercise structuredContent, isError, and arbitrary
+// content shapes that the convenience helpers do not cover.
+func resultResponse(result map[string]any) protocol.Response {
+	return protocol.Response{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result:  result,
+	}
+}
+
+// errorResultResponse builds a mock tool result with isError set and a single
+// text content block carrying the error message, mirroring how the server
+// serializes a failed typed handler.
+func errorResultResponse(text string) protocol.Response {
+	return resultResponse(map[string]any{
+		"isError": true,
+		"content": []any{
+			map[string]any{"type": "text", "text": text},
+		},
+	})
 }
 
 func TestCall(t *testing.T) {
@@ -178,6 +202,31 @@ func TestCall(t *testing.T) {
 		}
 		if !errors.Is(err, client.ErrNoContent) {
 			t.Errorf("error = %v, want ErrNoContent", err)
+		}
+	})
+
+	t.Run("isError result surfaces as ErrToolError", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				errorResultResponse("tool blew up: bad input"),
+			},
+		}
+		c := client.New(transport)
+
+		out, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "greet", greetIn{Name: "x"},
+		)
+		if err == nil {
+			t.Fatal("expected error for isError result")
+		}
+		if !errors.Is(err, client.ErrToolError) {
+			t.Errorf("error = %v, want ErrToolError", err)
+		}
+		if (out != greetOut{}) {
+			t.Errorf("out = %+v, want zero value on error", out)
+		}
+		if !strings.Contains(err.Error(), "tool blew up: bad input") {
+			t.Errorf("error %q does not carry the tool error text", err.Error())
 		}
 	})
 
@@ -393,6 +442,27 @@ func TestDynamicTool(t *testing.T) {
 		_, err := tool.Call(context.Background(), json.RawMessage(`{"name":"x"}`))
 		if !errors.Is(err, client.ErrNoContent) {
 			t.Errorf("error = %v, want ErrNoContent", err)
+		}
+	})
+
+	t.Run("isError result surfaces as ErrToolError", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				errorResultResponse("dynamic boom"),
+			},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		raw, err := tool.Call(context.Background(), json.RawMessage(`{"name":"x"}`))
+		if !errors.Is(err, client.ErrToolError) {
+			t.Errorf("error = %v, want ErrToolError", err)
+		}
+		if raw != nil {
+			t.Errorf("raw = %s, want nil on error", raw)
+		}
+		if !strings.Contains(err.Error(), "dynamic boom") {
+			t.Errorf("error %q does not carry the tool error text", err.Error())
 		}
 	})
 }

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -200,8 +200,98 @@ func TestCall(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for empty content")
 		}
-		if !errors.Is(err, client.ErrNoContent) {
-			t.Errorf("error = %v, want ErrNoContent", err)
+		if !errors.Is(err, client.ErrNoToolContent) {
+			t.Errorf("error = %v, want ErrNoToolContent", err)
+		}
+	})
+
+	t.Run("content block selection", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			content     []any
+			wantMessage string
+			wantCount   int
+		}{
+			{
+				name: "image first, first text block selected",
+				content: []any{
+					map[string]any{"type": "image", "data": "deadbeef"},
+					map[string]any{"type": "text", "text": `{"message":"after-image","count":3}`},
+				},
+				wantMessage: "after-image",
+				wantCount:   3,
+			},
+			{
+				name: "multi-content, first text block selected",
+				content: []any{
+					map[string]any{"type": "text", "text": `{"message":"first-text","count":1}`},
+					map[string]any{"type": "text", "text": `{"message":"second-text","count":2}`},
+				},
+				wantMessage: "first-text",
+				wantCount:   1,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				transport := &mockTransport{
+					responses: []protocol.Response{resultResponse(map[string]any{"content": tt.content})},
+				}
+				c := client.New(transport)
+
+				out, err := client.Call[greetIn, greetOut](
+					context.Background(), c, "greet", greetIn{Name: "x"},
+				)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if out.Message != tt.wantMessage {
+					t.Errorf("message = %q, want %q", out.Message, tt.wantMessage)
+				}
+				if out.Count != tt.wantCount {
+					t.Errorf("count = %d, want %d", out.Count, tt.wantCount)
+				}
+			})
+		}
+	})
+
+	t.Run("non-text content without structuredContent returns ErrNoToolContent", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				resultResponse(map[string]any{
+					"content": []any{
+						map[string]any{"type": "image", "data": "deadbeef"},
+					},
+				}),
+			},
+		}
+		c := client.New(transport)
+
+		_, err := client.Call[greetIn, greetOut](
+			context.Background(), c, "greet", greetIn{Name: "x"},
+		)
+		if !errors.Is(err, client.ErrNoToolContent) {
+			t.Errorf("error = %v, want ErrNoToolContent", err)
+		}
+	})
+
+	t.Run("string output on non-text content returns ErrNoToolContent", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				resultResponse(map[string]any{
+					"content": []any{
+						map[string]any{"type": "image", "data": "deadbeef"},
+					},
+				}),
+			},
+		}
+		c := client.New(transport)
+
+		_, err := client.Call[greetIn, string](
+			context.Background(), c, "greet", greetIn{Name: "x"},
+		)
+		if !errors.Is(err, client.ErrNoToolContent) {
+			t.Errorf("error = %v, want ErrNoToolContent", err)
 		}
 	})
 
@@ -494,8 +584,54 @@ func TestDynamicTool(t *testing.T) {
 
 		tool := client.NewDynamicTool(c, "greet")
 		_, err := tool.Call(context.Background(), json.RawMessage(`{"name":"x"}`))
-		if !errors.Is(err, client.ErrNoContent) {
-			t.Errorf("error = %v, want ErrNoContent", err)
+		if !errors.Is(err, client.ErrNoToolContent) {
+			t.Errorf("error = %v, want ErrNoToolContent", err)
+		}
+	})
+
+	t.Run("selects first text block past non-text content", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				resultResponse(map[string]any{
+					"content": []any{
+						map[string]any{"type": "image", "data": "deadbeef"},
+						map[string]any{"type": "text", "text": `{"message":"raw","count":7}`},
+					},
+				}),
+			},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		raw, err := tool.Call(context.Background(), json.RawMessage(`{"name":"x"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var out greetOut
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("unmarshal raw result: %v", err)
+		}
+		if out.Message != "raw" || out.Count != 7 {
+			t.Errorf("out = %+v, want {raw 7}", out)
+		}
+	})
+
+	t.Run("non-text content returns ErrNoToolContent", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{
+				resultResponse(map[string]any{
+					"content": []any{
+						map[string]any{"type": "image", "data": "deadbeef"},
+					},
+				}),
+			},
+		}
+		c := client.New(transport)
+
+		tool := client.NewDynamicTool(c, "greet")
+		_, err := tool.Call(context.Background(), json.RawMessage(`{"name":"x"}`))
+		if !errors.Is(err, client.ErrNoToolContent) {
+			t.Errorf("error = %v, want ErrNoToolContent", err)
 		}
 	})
 

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -163,6 +163,13 @@ func TestCall(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
+		var mcpErr *protocol.Error
+		if !errors.As(err, &mcpErr) {
+			t.Fatalf("expected *protocol.Error, got %T: %v", err, err)
+		}
+		if mcpErr.Code != -32000 {
+			t.Errorf("error code = %d, want -32000", mcpErr.Code)
+		}
 	})
 
 	t.Run("output unmarshal mismatch returns error", func(t *testing.T) {
@@ -433,6 +440,32 @@ func TestCall(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("cancelled context surfaces through the transport", func(t *testing.T) {
+		transport := &mockTransport{
+			responses: []protocol.Response{textResponse(`{"message":"ok","count":1}`)},
+		}
+		c := client.New(transport)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel before the call so the transport sees a dead context
+
+		_, err := client.Call[greetIn, greetOut](ctx, c, "greet", greetIn{Name: "x"})
+		if err == nil {
+			t.Fatal("expected error for cancelled context")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("error = %v, want context.Canceled", err)
+		}
+
+		// The cancelled context must reach the transport, not be swallowed.
+		if transport.lastCtx == nil {
+			t.Fatal("transport never observed a context")
+		}
+		if transport.lastCtx.Err() == nil {
+			t.Error("transport observed a live context, want cancelled")
+		}
+	})
 }
 
 func TestNewTypedTool(t *testing.T) {
@@ -540,8 +573,13 @@ func TestDynamicTool(t *testing.T) {
 		c := client.New(transport)
 
 		tool := client.NewDynamicTool(c, "greet")
-		if _, err := tool.Call(context.Background(), json.RawMessage(`{}`)); err == nil {
+		_, err := tool.Call(context.Background(), json.RawMessage(`{}`))
+		if err == nil {
 			t.Fatal("expected error")
+		}
+		var mcpErr *protocol.Error
+		if !errors.As(err, &mcpErr) {
+			t.Fatalf("expected *protocol.Error, got %T: %v", err, err)
 		}
 	})
 

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -435,7 +435,7 @@ func TestCall(t *testing.T) {
 	})
 }
 
-func TestNewClientTool(t *testing.T) {
+func TestNewTypedTool(t *testing.T) {
 	t.Run("reusable handle called multiple times", func(t *testing.T) {
 		transport := &mockTransport{
 			responses: []protocol.Response{
@@ -445,7 +445,7 @@ func TestNewClientTool(t *testing.T) {
 		}
 		c := client.New(transport)
 
-		greet := client.NewClientTool[greetIn, greetOut](c, "greet")
+		greet := client.NewTypedTool[greetIn, greetOut](c, "greet")
 		if greet.Name() != "greet" {
 			t.Errorf("name = %q, want %q", greet.Name(), "greet")
 		}
@@ -483,7 +483,7 @@ func TestNewClientTool(t *testing.T) {
 		}
 		c := client.New(transport)
 
-		greet := client.NewClientTool[greetIn, greetOut](c, "missing")
+		greet := client.NewTypedTool[greetIn, greetOut](c, "missing")
 		if _, err := greet.Call(context.Background(), greetIn{Name: "x"}); err == nil {
 			t.Fatal("expected error")
 		}

--- a/client/typed_test.go
+++ b/client/typed_test.go
@@ -230,6 +230,60 @@ func TestCall(t *testing.T) {
 		}
 	})
 
+	t.Run("structuredContent is the typed channel", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			result      map[string]any
+			wantMessage string
+			wantCount   int
+		}{
+			{
+				name: "structuredContent only, empty content",
+				result: map[string]any{
+					"content":           []any{},
+					"structuredContent": map[string]any{"message": "from-sc", "count": 9},
+				},
+				wantMessage: "from-sc",
+				wantCount:   9,
+			},
+			{
+				name: "structuredContent preferred over display text",
+				result: map[string]any{
+					// Display text is intentionally different from the
+					// canonical typed channel to prove which one wins.
+					"content": []any{
+						map[string]any{"type": "text", "text": `{"message":"display-only","count":1}`},
+					},
+					"structuredContent": map[string]any{"message": "from-sc", "count": 9},
+				},
+				wantMessage: "from-sc",
+				wantCount:   9,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				transport := &mockTransport{
+					responses: []protocol.Response{resultResponse(tt.result)},
+				}
+				c := client.New(transport)
+
+				out, err := client.Call[greetIn, greetOut](
+					context.Background(), c, "greet", greetIn{Name: "x"},
+				)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if out.Message != tt.wantMessage {
+					t.Errorf("message = %q, want %q", out.Message, tt.wantMessage)
+				}
+				if out.Count != tt.wantCount {
+					t.Errorf("count = %d, want %d", out.Count, tt.wantCount)
+				}
+			})
+		}
+	})
+
 	t.Run("input marshal edge cases", func(t *testing.T) {
 		type nested struct {
 			Tags  []string       `json:"tags"`

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,14 @@ v1.1 features: sampling (LLM requests), roots (workspace awareness), and logging
 go run ./examples/session
 ```
 
+### [typed-client](./typed-client/)
+The typed client API: `client.Call`, reusable `NewClientTool` handles, and the
+`DynamicTool` raw-JSON escape hatch, against an in-process server.
+
+```bash
+go run ./examples/typed-client
+```
+
 ## Running Examples
 
 All examples use stdio transport by default (except `http`). To test with Claude Desktop or other MCP clients:

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,7 @@ go run ./examples/session
 ```
 
 ### [typed-client](./typed-client/)
-The typed client API: `client.Call`, reusable `NewClientTool` handles, and the
+The typed client API: `client.Call`, reusable `NewTypedTool` handles, and the
 `DynamicTool` raw-JSON escape hatch, against an in-process server.
 
 ```bash

--- a/examples/typed-client/main.go
+++ b/examples/typed-client/main.go
@@ -4,7 +4,7 @@
 // invokes a tool three ways:
 //
 //   - client.Call: the recommended one-shot typed call.
-//   - client.NewClientTool: a reusable, pre-bound typed handle.
+//   - client.NewTypedTool: a reusable, pre-bound typed handle.
 //   - client.NewDynamicTool: the raw JSON escape hatch (not recommended).
 //
 // Run it with:
@@ -62,13 +62,13 @@ func main() {
 	fmt.Printf("Call:          %s (length %d)\n", out.Message, out.Length)
 
 	// 2. Reusable, pre-bound typed handle.
-	greet := client.NewClientTool[GreetInput, GreetOutput](c, "greet")
+	greet := client.NewTypedTool[GreetInput, GreetOutput](c, "greet")
 	for _, name := range []string{"Grace", "Linus"} {
 		out, err := greet.Call(ctx, GreetInput{Name: name})
 		if err != nil {
 			log.Fatalf("handle call: %v", err)
 		}
-		fmt.Printf("NewClientTool: %s (length %d)\n", out.Message, out.Length)
+		fmt.Printf("NewTypedTool: %s (length %d)\n", out.Message, out.Length)
 	}
 
 	// 3. Escape hatch: raw JSON in, raw JSON out. Prefer the typed APIs above.

--- a/examples/typed-client/main.go
+++ b/examples/typed-client/main.go
@@ -1,0 +1,128 @@
+// Package main demonstrates the typed MCP client API.
+//
+// It starts an in-process MCP server over HTTP, connects a client, and then
+// invokes a tool three ways:
+//
+//   - client.Call: the recommended one-shot typed call.
+//   - client.NewClientTool: a reusable, pre-bound typed handle.
+//   - client.NewDynamicTool: the raw JSON escape hatch (not recommended).
+//
+// Run it with:
+//
+//	go run ./examples/typed-client
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"go.klarlabs.de/mcp"
+	"go.klarlabs.de/mcp/client"
+)
+
+// GreetInput is the input for the greet tool.
+type GreetInput struct {
+	Name string `json:"name" jsonschema:"required,description=Who to greet"`
+}
+
+// GreetOutput is the structured output of the greet tool.
+type GreetOutput struct {
+	Message string `json:"message"`
+	Length  int    `json:"length"`
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr := startServer(ctx)
+
+	tr, err := client.NewHTTPTransport("http://" + addr)
+	if err != nil {
+		log.Fatalf("transport: %v", err)
+	}
+	c := client.New(tr)
+	defer func() { _ = c.Close() }()
+
+	if _, err := c.Initialize(ctx); err != nil {
+		log.Fatalf("initialize: %v", err)
+	}
+
+	// 1. Recommended: one-shot typed call.
+	out, err := client.Call[GreetInput, GreetOutput](ctx, c, "greet", GreetInput{Name: "Ada"})
+	if err != nil {
+		log.Fatalf("call: %v", err)
+	}
+	fmt.Printf("Call:          %s (length %d)\n", out.Message, out.Length)
+
+	// 2. Reusable, pre-bound typed handle.
+	greet := client.NewClientTool[GreetInput, GreetOutput](c, "greet")
+	for _, name := range []string{"Grace", "Linus"} {
+		out, err := greet.Call(ctx, GreetInput{Name: name})
+		if err != nil {
+			log.Fatalf("handle call: %v", err)
+		}
+		fmt.Printf("NewClientTool: %s (length %d)\n", out.Message, out.Length)
+	}
+
+	// 3. Escape hatch: raw JSON in, raw JSON out. Prefer the typed APIs above.
+	dyn := client.NewDynamicTool(c, "greet")
+	raw, err := dyn.Call(ctx, json.RawMessage(`{"name":"Anonymous"}`))
+	if err != nil {
+		log.Fatalf("dynamic call: %v", err)
+	}
+	fmt.Printf("DynamicTool:   %s\n", raw)
+}
+
+// startServer launches an in-process MCP server over HTTP and returns its
+// address once it is ready to serve requests.
+func startServer(ctx context.Context) string {
+	srv := mcp.NewServer(mcp.ServerInfo{
+		Name:    "typed-client-example",
+		Version: "1.0.0",
+	})
+
+	srv.Tool("greet").
+		Description("Greet someone by name").
+		Handler(func(in GreetInput) (GreetOutput, error) {
+			msg := "Hello, " + in.Name + "!"
+			return GreetOutput{Message: msg, Length: len(msg)}, nil
+		})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	go func() {
+		if err := mcp.ServeHTTP(ctx, srv, addr); err != nil && ctx.Err() == nil {
+			log.Printf("server: %v", err)
+		}
+	}()
+
+	waitForHealth(addr)
+	return addr
+}
+
+// waitForHealth blocks until the server's /health endpoint answers.
+func waitForHealth(addr string) {
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + addr + "/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	fmt.Fprintln(os.Stderr, "server did not become healthy")
+	os.Exit(1)
+}


### PR DESCRIPTION
Adds the typed MCP client API and fixes correctness holes found in review.

- `client.Call[In,Out]`, `client.NewTypedTool[In,Out]`, `client.DynamicTool` escape hatch.
- Surfaces tool `isError` as `ErrToolError` (was silently decoded as success).
- Prefers canonical `structuredContent`; selects first text block (no panic on image/multi-content).
- Tool-domain `ErrNoToolContent` sentinel; ctx propagation tested.
- Dynamic calls pass raw JSON through losslessly (int64 precision preserved).
- No auth ownership, shared transport. go build/vet/test -race/gofmt/golangci clean; client cov 85.9%.

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9