### PR TITLE
fix(server): secure middleware defaults — apply Use(), Recover on by default

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -635,12 +635,25 @@ func newRequestHandler(srv *Server, opts ...ServeOption) *requestHandler {
 	// Build the handler function
 	baseHandler := middleware.HandlerFunc(h.handle)
 
-	// Apply middleware if any
-	if len(options.middleware) > 0 {
-		h.handleFunc = middleware.Chain(options.middleware...)(baseHandler)
-	} else {
-		h.handleFunc = baseHandler
-	}
+	// Assemble the middleware chain, outermost first:
+	//   Recover (always on) -> Server.Use() middleware -> WithMiddleware() -> handler
+	//
+	// Two correctness fixes live here:
+	//   1. Server.Use() middleware is now actually applied. Previously only
+	//      options.middleware (from WithMiddleware) was read, so everything
+	//      registered via srv.Use(...) — including Recover/SizeLimit — was
+	//      silently dropped, leaving servers unprotected while appearing hardened.
+	//   2. Recover is forced OUTERMOST and on by default, so a panic in any
+	//      middleware or handler is converted to an error instead of unwinding
+	//      the transport read-loop and crashing the whole server process. A
+	//      caller that adds its own Recover (e.g. RecoverWithHandler) still runs
+	//      inner-first, so custom panic handling is preserved.
+	serverMW := srv.Middleware()
+	chain := make([]Middleware, 0, len(serverMW)+len(options.middleware)+1)
+	chain = append(chain, middleware.Recover())
+	chain = append(chain, serverMW...)
+	chain = append(chain, options.middleware...)
+	h.handleFunc = middleware.Chain(chain...)(baseHandler)
 
 	return h
 }

--- a/mcp_defaults_test.go
+++ b/mcp_defaults_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// TestServerUseMiddlewareIsApplied proves that middleware registered via
+// Server.Use is actually executed. Previously s.middleware was never read by
+// the serve path, so Use(...) was a silent no-op.
+func TestServerUseMiddlewareIsApplied(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	called := false
+	srv.Use(func(next MiddlewareHandlerFunc) MiddlewareHandlerFunc {
+		return func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			called = true
+			return next(ctx, req)
+		}
+	})
+
+	type Input struct{}
+	srv.Tool("ping").Handler(func(_ Input) (string, error) { return "pong", nil })
+
+	handler := newRequestHandler(srv)
+	req := &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ping","arguments":{}}`),
+	}
+	if _, err := handler.HandleRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("middleware registered via Server.Use was not applied")
+	}
+}
+
+// TestRecoverIsOnByDefault proves a panicking handler no longer crashes the
+// process on a plain server (no explicitly-added middleware), and that the
+// panic detail is not leaked to the peer.
+func TestRecoverIsOnByDefault(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	type Input struct{}
+	srv.Tool("boom").Handler(func(_ Input) (string, error) {
+		panic("secret detail: /etc/shadow")
+	})
+
+	handler := newRequestHandler(srv) // no WithMiddleware, no Use
+	req := &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"boom","arguments":{}}`),
+	}
+
+	// Must not panic (the test process would crash); must return an error.
+	_, err := handler.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected an error from a panicking handler, got nil")
+	}
+	// The panic value must not reach the client.
+	if strings.Contains(err.Error(), "shadow") || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("panic detail leaked to client: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "internal error") {
+		t.Fatalf("expected a generic internal error, got: %v", err)
+	}
+}

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -2,7 +2,8 @@ package middleware
 
 import (
 	"context"
-	"fmt"
+	"log"
+	"runtime/debug"
 
 	"go.klarlabs.de/mcp/protocol"
 )
@@ -31,16 +32,18 @@ func RecoverWithHandler(handler PanicHandler) Middleware {
 	}
 }
 
-// defaultPanicHandler converts a panic value to an internal error.
-func defaultPanicHandler(_ context.Context, _ *protocol.Request, panicVal any) (*protocol.Response, error) {
-	var msg string
-	switch v := panicVal.(type) {
-	case error:
-		msg = fmt.Sprintf("panic: %v", v)
-	case string:
-		msg = fmt.Sprintf("panic: %s", v)
-	default:
-		msg = fmt.Sprintf("panic: %v", v)
+// defaultPanicHandler logs the panic (with stack) server-side and returns a
+// GENERIC internal error to the peer.
+//
+// The panic value is deliberately NOT included in the response: it routinely
+// embeds internal paths, state, or secret-adjacent values, and the peer may be
+// untrusted. Detail goes to the standard logger (stderr — never stdout, which
+// would corrupt stdio framing). Use RecoverWithHandler for custom reporting.
+func defaultPanicHandler(_ context.Context, req *protocol.Request, panicVal any) (*protocol.Response, error) {
+	method := ""
+	if req != nil {
+		method = req.Method
 	}
-	return nil, protocol.NewInternalError(msg)
+	log.Printf("mcp: recovered panic handling %q: %v\n%s", method, panicVal, debug.Stack())
+	return nil, protocol.NewInternalError("internal error")
 }

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -8,14 +8,38 @@ import (
 )
 
 // Timeout returns middleware that enforces a request deadline.
-// If the handler does not complete within the specified duration,
-// the context is canceled and context.DeadlineExceeded is returned.
+//
+// The handler runs on its own goroutine and is raced against the deadline. If
+// it does not finish in time, the request returns a timeout error immediately
+// (rather than blocking until the handler happens to return). The handler's
+// context is canceled, so a cooperative handler stops promptly; a handler that
+// ignores its context keeps running on the detached goroutine until it returns
+// — the buffered result channel ensures that goroutine does not leak.
 func Timeout(d time.Duration) Middleware {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 			ctx, cancel := context.WithTimeout(ctx, d)
 			defer cancel()
-			return next(ctx, req)
+
+			type result struct {
+				resp *protocol.Response
+				err  error
+			}
+			done := make(chan result, 1) // buffered so the goroutine never blocks
+			go func() {
+				resp, err := next(ctx, req)
+				done <- result{resp, err}
+			}()
+
+			select {
+			case r := <-done:
+				return r.resp, r.err
+			case <-ctx.Done():
+				// Deadline hit (or parent canceled) before the handler
+				// returned. Surface the context error so callers can
+				// distinguish DeadlineExceeded from Canceled.
+				return nil, ctx.Err()
+			}
 		}
 	}
 }

--- a/middleware/timeout_test.go
+++ b/middleware/timeout_test.go
@@ -97,6 +97,27 @@ func TestTimeout(t *testing.T) {
 		}
 	})
 
+	t.Run("bounds a non-cooperative handler", func(t *testing.T) {
+		// A handler that ignores ctx entirely. The old implementation blocked
+		// until it returned (500ms); the fixed one returns at the deadline.
+		handler := HandlerFunc(func(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+			time.Sleep(500 * time.Millisecond)
+			return protocol.NewResponse(req.ID, "slow"), nil
+		})
+
+		wrapped := Timeout(50 * time.Millisecond)(handler)
+		start := time.Now()
+		_, err := wrapped(context.Background(), &protocol.Request{Method: "test"})
+		elapsed := time.Since(start)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+		}
+		if elapsed > 250*time.Millisecond {
+			t.Fatalf("timeout did not bound a non-cooperative handler: took %v", elapsed)
+		}
+	})
+
 	t.Run("passes through handler errors", func(t *testing.T) {
 		expectedErr := protocol.NewInvalidParams("bad params")
 		handler := HandlerFunc(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,23 +1,22 @@
 package server
 
-import (
-	"context"
-
-	"go.klarlabs.de/mcp/protocol"
-)
+import "go.klarlabs.de/mcp/middleware"
 
 // HandlerFunc is the signature for request handlers.
-type HandlerFunc func(ctx context.Context, req *protocol.Request) (*protocol.Response, error)
+//
+// It is an alias of middleware.HandlerFunc so the server's Use()-registered
+// middleware and the framework's middleware package (Recover, Timeout, …) share
+// a single type. Previously the server defined its own parallel HandlerFunc /
+// Middleware / Chain, which were incompatible with middleware.* — so middleware
+// passed to Server.Use could not even be the standard ones, and the field was
+// never applied.
+type HandlerFunc = middleware.HandlerFunc
 
-// Middleware wraps a handler with additional behavior.
-type Middleware func(next HandlerFunc) HandlerFunc
+// Middleware wraps a handler with additional behavior. Alias of
+// middleware.Middleware (see HandlerFunc).
+type Middleware = middleware.Middleware
 
-// Chain composes middleware in order, executing first middleware first.
-func Chain(middlewares ...Middleware) Middleware {
-	return func(final HandlerFunc) HandlerFunc {
-		for i := len(middlewares) - 1; i >= 0; i-- {
-			final = middlewares[i](final)
-		}
-		return final
-	}
+// Chain composes middleware in order, executing the first middleware first.
+func Chain(m ...Middleware) Middleware {
+	return middleware.Chain(m...)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -207,6 +207,18 @@ func (s *Server) Use(middleware ...Middleware) {
 	s.middleware = append(s.middleware, middleware...)
 }
 
+// Middleware returns a copy of the middleware registered via Use. The serve
+// path composes this with any serve-scoped middleware (WithMiddleware). It is
+// exported so the handler builder can read it; previously s.middleware was
+// never consulted, silently dropping everything passed to Use.
+func (s *Server) Middleware() []Middleware {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Middleware, len(s.middleware))
+	copy(out, s.middleware)
+	return out
+}
+
 // Tool starts building a new tool with the given name.
 func (s *Server) Tool(name string) *ToolBuilder {
 	return &ToolBuilder{


### PR DESCRIPTION
## Summary

First PR of a deep-review-and-harden pass on mcp-go. A 6-agent review found the framework's **production defaults are unsafe, and some of the safety knobs are broken**. This PR fixes the foundational middleware-core issues; transport/protocol/dispatch/tasks batches follow.

## Fixes

| Severity | Issue | Fix |
|---|---|---|
| HIGH | **`Server.Use()` was a dead no-op** — `newRequestHandler` only read the `WithMiddleware` serve option; `s.middleware` (populated by `Use`) was never consulted, so middleware added via the documented fluent API (incl. `Recover`/`SizeLimit`) silently didn't run. And `server.Middleware` was a *distinct type* from `middleware.Middleware`, so the standard middleware couldn't even be passed to `Use`. | Unified the types (`server.HandlerFunc`/`Middleware`/`Chain` are now aliases of the `middleware` package) and wired `srv.Middleware()` into the chain. |
| HIGH | **No default panic recovery** — a handler panic unwound the stdio/WebSocket read-loop and crashed the **whole server process** (all sessions). | `Recover` is now forced **outermost and on by default**. A caller's own `Recover` still runs inner-first, so custom panic handling is preserved. |
| MED | Default panic handler **leaked the panic value** (internal paths/state) to the peer. | Logs detail + stack server-side (stderr — safe for stdio); returns a generic `"internal error"` to the client. |
| MED | **`Timeout` middleware never enforced the deadline** — it called `next()` synchronously, so a handler that ignores `ctx` ran to completion. | Races the handler against `ctx.Done()` (buffered result channel — no goroutine leak); returns `ctx.Err()` on expiry. |

## Behavior change (secure-by-default, minor bump)

Recover being on by default means a panicking handler now returns a JSON-RPC internal error instead of crashing — strictly safer. Existing callers that added their own Recover are unaffected (it just runs inner). The `Timeout` change makes it behave as its doc always claimed.

## Tests

- `TestServerUseMiddlewareIsApplied` — middleware via `Use` actually runs.
- `TestRecoverIsOnByDefault` — a plain server survives a panicking handler; panic detail does **not** leak (generic error).
- `Timeout` "bounds a non-cooperative handler" — a ctx-ignoring 500ms handler returns at the 50ms deadline with `DeadlineExceeded`.

Full suite green under `go test -race ./...`, gofmt, golangci-lint (0 issues).

## Remaining (tracked, follow-up PRs)

Transport security (SSE `clientId` hijack, Origin validation, WS `CheckOrigin`, body/read/connection limits), protocol (error-message leak, `id:null`, gRPC id injection, notification 202), resource-URI determinism + registration collisions, task-registry leak + cancellation wiring, JSON-nesting DoS, framing resilience, client hardening.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
