### PR TITLE
fix(protocol): depth-limit untrusted JSON, spec-correct ids, escape gRPC ids

### DIFF
--- a/protocol/messages.go
+++ b/protocol/messages.go
@@ -19,11 +19,50 @@ func (r *Request) IsNotification() bool {
 }
 
 // Response represents a JSON-RPC 2.0 response.
+//
+// Marshaling is handled by MarshalJSON to guarantee JSON-RPC 2.0 compliance:
+// "id" is always present (null when unset, per §5), and exactly one of
+// "result" or "error" is emitted — a success response always carries "result"
+// (null when the result value is nil), an error response never does.
 type Response struct {
 	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id,omitempty"`
+	ID      json.RawMessage `json:"id"`
 	Result  any             `json:"result,omitempty"`
 	Error   *Error          `json:"error,omitempty"`
+}
+
+// MarshalJSON implements json.Marshaler for spec-compliant JSON-RPC 2.0 output.
+//
+// JSON-RPC 2.0 §5 requires the "id" member on every response — it MUST be null
+// when the request id could not be determined (e.g. a parse error). A nil ID is
+// therefore emitted as an explicit null rather than omitted. Per the same
+// section, a response is either a success (with "result") or a failure (with
+// "error"), never both and never neither: when Error is set only "error" is
+// emitted; otherwise "result" is always present (nil marshals to null).
+func (r Response) MarshalJSON() ([]byte, error) {
+	id := r.ID
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+
+	if r.Error != nil {
+		return json.Marshal(struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Error   *Error          `json:"error"`
+		}{JSONRPC: r.JSONRPC, ID: id, Error: r.Error})
+	}
+
+	result, err := json.Marshal(r.Result)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result"`
+	}{JSONRPC: r.JSONRPC, ID: id, Result: result})
 }
 
 // NewResponse creates a successful response.

--- a/protocol/messages_test.go
+++ b/protocol/messages_test.go
@@ -193,3 +193,73 @@ func TestNewErrorResponse(t *testing.T) {
 		t.Errorf("Error.Code = %d, want %d", resp.Error.Code, CodeInternalError)
 	}
 }
+
+func TestResponse_MarshalJSON_SpecCompliance(t *testing.T) {
+	t.Run("parse-error response emits id null", func(t *testing.T) {
+		// JSON-RPC 2.0 §5: id MUST be present, null when it can't be determined.
+		resp := NewErrorResponse(nil, NewParseError("bad json"))
+
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("failed to parse marshaled response: %v", err)
+		}
+
+		idRaw, ok := raw["id"]
+		if !ok {
+			t.Fatal("id member missing from error response")
+		}
+		if string(idRaw) != "null" {
+			t.Errorf("id = %s, want null", idRaw)
+		}
+		if _, hasResult := raw["result"]; hasResult {
+			t.Error("error response must not carry a result member")
+		}
+	})
+
+	t.Run("success response always carries result", func(t *testing.T) {
+		// Even a nil result must yield an explicit result member (null).
+		resp := NewResponse(json.RawMessage(`7`), nil)
+
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("failed to parse marshaled response: %v", err)
+		}
+
+		if _, hasResult := raw["result"]; !hasResult {
+			t.Error("success response must carry a result member")
+		}
+		if _, hasErr := raw["error"]; hasErr {
+			t.Error("success response must not carry an error member")
+		}
+		if string(raw["id"]) != "7" {
+			t.Errorf("id = %s, want 7", raw["id"])
+		}
+	})
+
+	t.Run("non-empty result is preserved", func(t *testing.T) {
+		resp := NewResponse(json.RawMessage(`1`), map[string]string{"status": "ok"})
+
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("failed to parse: %v", err)
+		}
+		if string(raw["result"]) != `{"status":"ok"}` {
+			t.Errorf("result = %s, want {\"status\":\"ok\"}", raw["result"])
+		}
+	})
+}

--- a/schema/validation.go
+++ b/schema/validation.go
@@ -17,6 +17,53 @@ const (
 	typeBoolean = "boolean"
 )
 
+// maxJSONDepth bounds the nesting depth of untrusted JSON before it is handed
+// to encoding/json. encoding/json decodes with unbounded recursion, so a
+// deeply nested payload (e.g. "[[[[…") can exhaust the goroutine stack and
+// crash the process with a fatal error that recover cannot catch. Rejecting
+// over-deep input up front turns that DoS into an ordinary parse error.
+const maxJSONDepth = 100
+
+// checkJSONDepth performs a fast, allocation-free pre-scan of raw JSON,
+// rejecting input whose container nesting ({ or [) exceeds maxJSONDepth.
+// Bytes inside string literals (including escaped quotes) are ignored so that
+// braces or brackets within strings do not count toward depth.
+func checkJSONDepth(data []byte) error {
+	depth := 0
+	inString := false
+	escaped := false
+
+	for _, c := range data {
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch c {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+			if depth > maxJSONDepth {
+				return &ValidationError{
+					Message: fmt.Sprintf("invalid JSON: nesting depth exceeds maximum of %d", maxJSONDepth),
+				}
+			}
+		case '}', ']':
+			depth--
+		}
+	}
+
+	return nil
+}
+
 // ValidationError represents a schema validation error.
 type ValidationError struct {
 	Path    string // JSON path to the invalid field (e.g., "user.email")
@@ -56,6 +103,12 @@ func (e ValidationErrors) Error() string {
 // Validate validates JSON data against a schema.
 // Returns nil if valid, or ValidationErrors if invalid.
 func (s *Schema) Validate(data json.RawMessage) error {
+	// Reject pathologically nested input before encoding/json's recursive
+	// decoder can exhaust the stack (uncatchable fatal error).
+	if err := checkJSONDepth(data); err != nil {
+		return err
+	}
+
 	var value any
 	if err := json.Unmarshal(data, &value); err != nil {
 		return &ValidationError{Message: fmt.Sprintf("invalid JSON: %s", err)}

--- a/schema/validation_test.go
+++ b/schema/validation_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -319,4 +320,52 @@ func TestValidationErrors(t *testing.T) {
 			t.Errorf("expected empty string, got %q", errs.Error())
 		}
 	})
+}
+
+func TestCheckJSONDepth(t *testing.T) {
+	t.Run("accepts moderately nested JSON", func(t *testing.T) {
+		data := []byte(`{"a":{"b":{"c":[1,2,3]}}}`)
+		if err := checkJSONDepth(data); err != nil {
+			t.Errorf("unexpected error for shallow JSON: %v", err)
+		}
+	})
+
+	t.Run("ignores braces inside strings", func(t *testing.T) {
+		// A string full of brackets must not count toward nesting depth.
+		data := []byte(`{"note":"[[[[[[[[[[ not real nesting ]]]]]]]]]]"}`)
+		if err := checkJSONDepth(data); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("handles escaped quotes inside strings", func(t *testing.T) {
+		data := []byte(`{"q":"a \" [ b"}`)
+		if err := checkJSONDepth(data); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects input beyond max depth", func(t *testing.T) {
+		data := append(bytes.Repeat([]byte("["), maxJSONDepth+1), bytes.Repeat([]byte("]"), maxJSONDepth+1)...)
+		if err := checkJSONDepth(data); err == nil {
+			t.Fatal("expected error for over-deep JSON, got nil")
+		}
+	})
+}
+
+func TestSchema_Validate_DeepNesting(t *testing.T) {
+	// A frame of deeply nested arrays must be rejected as a parse error rather
+	// than driving encoding/json into stack exhaustion (an uncatchable fatal).
+	schema := &Schema{Type: typeObject}
+
+	deep := 5000
+	data := append(bytes.Repeat([]byte("["), deep), bytes.Repeat([]byte("]"), deep)...)
+
+	err := schema.Validate(data)
+	if err == nil {
+		t.Fatal("expected validation error for deeply nested JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "nesting depth") {
+		t.Errorf("expected nesting-depth error, got: %v", err)
+	}
 }

--- a/server/progress.go
+++ b/server/progress.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"sync"
@@ -118,9 +119,12 @@ func ExtractProgressToken(params json.RawMessage) ProgressToken {
 		return ""
 	}
 
+	// MCP allows progressToken to be a string OR an integer, so it is decoded
+	// as a raw token and normalized rather than forced into a string (which
+	// would fail the whole unmarshal for a numeric token, silently dropping it).
 	var meta struct {
 		Meta struct {
-			ProgressToken string `json:"progressToken"`
+			ProgressToken json.RawMessage `json:"progressToken"`
 		} `json:"_meta"`
 	}
 
@@ -128,5 +132,27 @@ func ExtractProgressToken(params json.RawMessage) ProgressToken {
 		return ""
 	}
 
-	return ProgressToken(meta.Meta.ProgressToken)
+	return parseProgressToken(meta.Meta.ProgressToken)
+}
+
+// parseProgressToken converts a raw progressToken (string or number, per the
+// MCP spec) into an opaque ProgressToken. A JSON string is unquoted; a numeric
+// token is preserved verbatim as its digits. Absent, null, or malformed tokens
+// yield the empty token.
+func parseProgressToken(raw json.RawMessage) ProgressToken {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return ""
+		}
+		return ProgressToken(s)
+	}
+
+	// Numeric (or other scalar) token: keep the raw JSON as an opaque token.
+	return ProgressToken(raw)
 }

--- a/server/progress_test.go
+++ b/server/progress_test.go
@@ -211,3 +211,38 @@ func TestExtractProgressToken(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractProgressToken_AcceptsBothTypes(t *testing.T) {
+	t.Run("accepts integer token", func(t *testing.T) {
+		// MCP permits progressToken to be an integer; it must not be dropped.
+		params := json.RawMessage(`{"_meta": {"progressToken": 42}, "name": "test"}`)
+		token := ExtractProgressToken(params)
+		if token != "42" {
+			t.Errorf("expected token '42', got %q", token)
+		}
+	})
+
+	t.Run("accepts string token", func(t *testing.T) {
+		params := json.RawMessage(`{"_meta": {"progressToken": "abc"}}`)
+		token := ExtractProgressToken(params)
+		if token != "abc" {
+			t.Errorf("expected token 'abc', got %q", token)
+		}
+	})
+
+	t.Run("returns empty for null token", func(t *testing.T) {
+		params := json.RawMessage(`{"_meta": {"progressToken": null}}`)
+		token := ExtractProgressToken(params)
+		if token != "" {
+			t.Errorf("expected empty token, got %q", token)
+		}
+	})
+
+	t.Run("returns empty for absent token", func(t *testing.T) {
+		params := json.RawMessage(`{"_meta": {}}`)
+		token := ExtractProgressToken(params)
+		if token != "" {
+			t.Errorf("expected empty token, got %q", token)
+		}
+	})
+}

--- a/transport/grpc/grpc_test.go
+++ b/transport/grpc/grpc_test.go
@@ -480,3 +480,34 @@ func TestGRPC_GracefulShutdown(t *testing.T) {
 		t.Error("timeout waiting for shutdown")
 	}
 }
+
+func TestProtoToRequest_EscapesSpecialCharsInID(t *testing.T) {
+	tests := []struct {
+		name      string
+		requestID string
+	}{
+		{name: "quote", requestID: `a"b`},
+		{name: "backslash", requestID: `a\b`},
+		{name: "control char", requestID: "a\nb"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := protoToRequest(&pb.Message{RequestId: tt.requestID, Method: "m"})
+
+			// The id must be well-formed JSON that round-trips to the original.
+			var decoded string
+			if err := json.Unmarshal(req.ID, &decoded); err != nil {
+				t.Fatalf("request id is not valid JSON (%s): %v", req.ID, err)
+			}
+			if decoded != tt.requestID {
+				t.Errorf("decoded id = %q, want %q", decoded, tt.requestID)
+			}
+
+			// It must also survive being embedded in a full Request marshal.
+			if _, err := json.Marshal(req); err != nil {
+				t.Fatalf("marshaling request with id failed: %v", err)
+			}
+		})
+	}
+}

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -108,8 +108,12 @@ func handleNotification(ctx context.Context, handler transport.Handler, sender *
 func protoToRequest(msg *pb.Message) *protocol.Request {
 	var id json.RawMessage
 	if msg.RequestId != "" {
-		// Wrap string ID in quotes for JSON
-		id = json.RawMessage(`"` + msg.RequestId + `"`)
+		// Encode the request id as a JSON string with proper escaping. Manual
+		// quote-wrapping would emit malformed JSON for ids containing quotes,
+		// backslashes, or control characters.
+		if encoded, err := json.Marshal(msg.RequestId); err == nil {
+			id = encoded
+		}
 	}
 
 	return &protocol.Request{


### PR DESCRIPTION
## Protocol correctness & DoS hardening

Four deep-review findings on the JSON-RPC / MCP protocol layer, each TDD-covered.

### 1. [MED->HIGH] Unbounded JSON nesting DoS — `schema/validation.go`
Untrusted params were parsed bounded only by the 16 MB frame cap. A frame of `[[[[…` drives `encoding/json`'s recursive descent into stack exhaustion — a **fatal** error in Go that `recover` cannot catch, crashing the whole process. Added a `maxJSONDepth` (100) constant and an allocation-free `checkJSONDepth` pre-scan (string- and escape-aware) that runs before every untrusted `Unmarshal` in `Schema.Validate`, returning an ordinary parse error on exceed.

### 2. [MED] `omitempty` dropped spec-required response fields — `protocol/messages.go`
`Response.ID` used `omitempty`, so a parse-error response built with `NewErrorResponse(nil, …)` omitted `id` entirely — but JSON-RPC 2.0 §5 mandates `"id": null`. `Result` used `omitempty` too, so a nil-result success emitted neither `result` nor `error`. Added a `Response.MarshalJSON` that always emits `id` (null when unset) and emits exactly one of `result` (always, on success — null when nil) or `error` (never both).

### 3. [MED] gRPC injected the request id unescaped — `transport/grpc/stream.go`
`protoToRequest` built the id with `json.RawMessage("\"" + msg.RequestId + "\"")`; a `request_id` containing a quote, backslash, or control char produced malformed JSON. Now built with `json.Marshal(msg.RequestId)` for proper escaping.

### 4. [LOW] Integer `progressToken` silently dropped — `server/progress.go`
MCP allows `progressToken` to be string **or** integer, but it was decoded into a `string`, so a numeric token failed the whole unmarshal and yielded `""`. Now decoded as `json.RawMessage` and normalized (string unquoted, number kept verbatim) into an opaque token.

### Verification
- New tests: deep-nesting rejected without crash; parse-error response serializes `"id":null`; success always carries `result`; gRPC request_id with quote/backslash/control char round-trips; numeric progressToken accepted.
- `go vet` + `golangci-lint` (0 issues) + `go build` + `go test` + `go test -race ./...` all green (pre-commit hook + manual).

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
