### PR TITLE
fix(server): deterministic resource matching + reject duplicate registration

### DIFF
--- a/server/completion.go
+++ b/server/completion.go
@@ -83,13 +83,17 @@ func (r *completionRegistry) Handle(ctx context.Context, ref CompletionRef, arg 
 		handler = r.promptHandlers[ref.Name]
 	case CompletionRefResource:
 		handler = r.resourceHandlers[ref.URI]
-		// Try to match by URI template pattern if exact match fails
+		// Fall back to template matching when there is no exact match. When
+		// several templates match the same URI, selection is deterministic and
+		// most-specific-wins (see moreSpecific) rather than depending on the
+		// randomized map-iteration order.
 		if handler == nil {
-			for template, h := range r.resourceHandlers {
-				if _, ok := matchURITemplate(template, ref.URI); ok {
-					handler = h
-					break
-				}
+			templates := make([]string, 0, len(r.resourceHandlers))
+			for template := range r.resourceHandlers {
+				templates = append(templates, template)
+			}
+			if template, ok := mostSpecificMatchingTemplate(templates, ref.URI); ok {
+				handler = r.resourceHandlers[template]
 			}
 		}
 	}

--- a/server/completion_test.go
+++ b/server/completion_test.go
@@ -224,3 +224,35 @@ func TestResourceTemplates(t *testing.T) {
 		}
 	})
 }
+
+func TestCompletionRegistry_DeterministicResourceMatch(t *testing.T) {
+	reg := newCompletionRegistry()
+	// Overlapping templates: a specific single-param template and a broader
+	// two-param one both match "github://acme/config".
+	reg.RegisterResourceCompletion("github://{owner}/config", func(_ context.Context, _ CompletionRef, _ CompletionArgument) (*CompletionResult, error) {
+		return &CompletionResult{Values: []string{"specific"}}, nil
+	})
+	reg.RegisterResourceCompletion("github://{owner}/{repo}", func(_ context.Context, _ CompletionRef, _ CompletionArgument) (*CompletionResult, error) {
+		return &CompletionResult{Values: []string{"broad"}}, nil
+	})
+
+	ref := CompletionRef{Type: CompletionRefResource, URI: "github://acme/config"}
+	for i := 0; i < 1000; i++ {
+		res, err := reg.Handle(context.Background(), ref, CompletionArgument{Name: "x"})
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+		if len(res.Values) != 1 || res.Values[0] != "specific" {
+			t.Fatalf("iteration %d: expected most-specific handler, got %v", i, res.Values)
+		}
+	}
+
+	// The broader template still handles non-overlapping URIs.
+	res, err := reg.Handle(context.Background(), CompletionRef{Type: CompletionRefResource, URI: "github://acme/tokenops"}, CompletionArgument{Name: "x"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Values) != 1 || res.Values[0] != "broad" {
+		t.Fatalf("expected broad handler, got %v", res.Values)
+	}
+}

--- a/server/resource.go
+++ b/server/resource.go
@@ -3,7 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -202,4 +205,153 @@ func (r *Resource) matchURI(uri string) (map[string]string, bool) {
 	}
 
 	return params, true
+}
+
+// countTemplateParams returns the number of {param} placeholders in a template.
+func countTemplateParams(tmpl string) int {
+	return len(templateParamRegex.FindAllStringIndex(tmpl, -1))
+}
+
+// literalPrefixLen returns the length of the literal prefix of a template —
+// the run of characters before the first {param} placeholder. A concrete URI
+// with no parameters has a prefix equal to its whole length.
+func literalPrefixLen(tmpl string) int {
+	if i := strings.IndexByte(tmpl, '{'); i >= 0 {
+		return i
+	}
+	return len(tmpl)
+}
+
+// literalLen returns the number of literal (non-placeholder) characters in a
+// template, used as a tiebreak when two templates share the same parameter
+// count and literal prefix.
+func literalLen(tmpl string) int {
+	return len(templateParamRegex.ReplaceAllString(tmpl, ""))
+}
+
+// moreSpecific reports whether template a is strictly more specific than
+// template b, giving a total, deterministic ordering for most-specific-wins
+// dispatch. An exact/literal template (no parameters) always beats a
+// parameterized one; among templates the tie-break order is: fewer parameters,
+// then longer literal prefix, then more literal characters, then the lexically
+// smaller template. The final lexical tie-break guarantees a stable result
+// regardless of registration or map-iteration order.
+func moreSpecific(a, b string) bool {
+	if pa, pb := countTemplateParams(a), countTemplateParams(b); pa != pb {
+		return pa < pb
+	}
+	if la, lb := literalPrefixLen(a), literalPrefixLen(b); la != lb {
+		return la > lb
+	}
+	if la, lb := literalLen(a), literalLen(b); la != lb {
+		return la > lb
+	}
+	return a < b
+}
+
+// selectResource returns the most specific resource whose template matches uri,
+// deterministically. It iterates a sorted copy of the template keys (never the
+// randomized map) and keeps the most specific match per moreSpecific, so
+// overlapping templates always resolve to the same resource.
+func selectResource(resources map[string]*Resource, uri string) (*Resource, bool) {
+	keys := make([]string, 0, len(resources))
+	for k := range resources {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var best *Resource
+	for _, k := range keys {
+		r := resources[k]
+		if _, ok := r.matchURI(uri); !ok {
+			continue
+		}
+		if best == nil || moreSpecific(r.uriTemplate, best.uriTemplate) {
+			best = r
+		}
+	}
+	return best, best != nil
+}
+
+// mostSpecificMatchingTemplate returns the most specific template from
+// templates that matches uri, deterministically (see moreSpecific). It is used
+// where only template strings are available (e.g. completion handlers keyed by
+// template) rather than pre-compiled resources.
+func mostSpecificMatchingTemplate(templates []string, uri string) (string, bool) {
+	sorted := make([]string, len(templates))
+	copy(sorted, templates)
+	sort.Strings(sorted)
+
+	best := ""
+	found := false
+	for _, t := range sorted {
+		if _, ok := matchURITemplate(t, uri); !ok {
+			continue
+		}
+		if !found || moreSpecific(t, best) {
+			best = t
+			found = true
+		}
+	}
+	return best, found
+}
+
+// ContainedPath safely resolves an untrusted resource parameter to a filesystem
+// path guaranteed to stay within root, for file-style resources whose {param}
+// maps onto a path under a base directory.
+//
+// IMPORTANT: resource parameters are untrusted and arrive URL-undecoded. A
+// {param} capture group forbids "/", but a value of ".." — or a percent-encoded
+// or otherwise crafted segment that a handler decodes — can still escape the
+// base directory. Handlers that turn a parameter into a path MUST route it
+// through this helper (or an equivalent check) before touching the filesystem;
+// the framework does not do so automatically.
+//
+// The parameter must be relative (an absolute value is rejected). The joined
+// path is cleaned and checked for lexical containment under root, then symlinks
+// are resolved and containment is re-checked so a symlink inside root cannot
+// point outside it. root must exist. On success it returns the cleaned,
+// symlink-resolved absolute path; on any escape it returns a non-nil error.
+func ContainedPath(root, param string) (string, error) {
+	if param == "" {
+		return "", fmt.Errorf("empty path parameter")
+	}
+	if filepath.IsAbs(param) {
+		return "", fmt.Errorf("path parameter %q must be relative to root %q", param, root)
+	}
+
+	cleaned := filepath.Clean(filepath.Join(root, param))
+	if !withinRoot(root, cleaned) {
+		return "", fmt.Errorf("path parameter %q escapes root %q", param, root)
+	}
+
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve root %q: %w", root, err)
+	}
+
+	realPath, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		// A not-yet-existing target has nothing to resolve; the lexical
+		// containment check above already guarantees it is under root.
+		if os.IsNotExist(err) {
+			return cleaned, nil
+		}
+		return "", fmt.Errorf("resolve path %q: %w", cleaned, err)
+	}
+
+	if !withinRoot(realRoot, realPath) {
+		return "", fmt.Errorf("path parameter %q escapes root %q via symlink", param, root)
+	}
+	return realPath, nil
+}
+
+// withinRoot reports whether path is root itself or lies beneath it, using a
+// lexical relative-path check (no filesystem access).
+func withinRoot(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/server/resource_test.go
+++ b/server/resource_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -237,4 +239,90 @@ func TestMatchURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestContainedPath(t *testing.T) {
+	root := t.TempDir()
+	// Create a real file inside root and a directory to symlink from.
+	if err := os.WriteFile(filepath.Join(root, "data.txt"), []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("accepts a contained relative path", func(t *testing.T) {
+		got, err := ContainedPath(root, "data.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantReal, _ := filepath.EvalSymlinks(filepath.Join(root, "data.txt"))
+		if got != wantReal {
+			t.Fatalf("expected %q, got %q", wantReal, got)
+		}
+	})
+
+	t.Run("accepts a not-yet-existing contained path", func(t *testing.T) {
+		got, err := ContainedPath(root, "subdir/new.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != filepath.Join(root, "subdir/new.txt") {
+			t.Fatalf("unexpected path %q", got)
+		}
+	})
+
+	t.Run("rejects dot-dot traversal", func(t *testing.T) {
+		if _, err := ContainedPath(root, "../etc/passwd"); err == nil {
+			t.Fatal("expected traversal to be rejected")
+		}
+	})
+
+	t.Run("rejects deep dot-dot traversal that escapes", func(t *testing.T) {
+		if _, err := ContainedPath(root, "a/b/../../../secret"); err == nil {
+			t.Fatal("expected escaping traversal to be rejected")
+		}
+	})
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		if _, err := ContainedPath(root, "/etc/passwd"); err == nil {
+			t.Fatal("expected absolute path to be rejected")
+		}
+	})
+
+	t.Run("rejects empty parameter", func(t *testing.T) {
+		if _, err := ContainedPath(root, ""); err == nil {
+			t.Fatal("expected empty parameter to be rejected")
+		}
+	})
+
+	t.Run("rejects symlink escape", func(t *testing.T) {
+		// A symlink inside root pointing outside it must be rejected once
+		// symlinks are resolved.
+		outside := t.TempDir()
+		if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		linkPath := filepath.Join(root, "escape")
+		if err := os.Symlink(outside, linkPath); err != nil {
+			t.Skipf("symlinks unsupported: %v", err)
+		}
+		if _, err := ContainedPath(root, "escape/secret.txt"); err == nil {
+			t.Fatal("expected symlink escape to be rejected")
+		}
+	})
+
+	t.Run("accepts symlink that stays within root", func(t *testing.T) {
+		sub := filepath.Join(root, "real")
+		if err := os.MkdirAll(sub, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sub, "inside.txt"), []byte("hi"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		linkPath := filepath.Join(root, "alias")
+		if err := os.Symlink(sub, linkPath); err != nil {
+			t.Skipf("symlinks unsupported: %v", err)
+		}
+		if _, err := ContainedPath(root, "alias/inside.txt"); err != nil {
+			t.Fatalf("expected contained symlink to be accepted, got %v", err)
+		}
+	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
 	"go.klarlabs.de/mcp/protocol"
@@ -85,6 +87,12 @@ type Server struct {
 	completions  *completionRegistry
 	tasks        *TaskManager
 	resourceSubs *resourceSubscriptions
+
+	// regErrs accumulates registration collisions. The fluent builder API
+	// returns the builder rather than an error, so a duplicate tool/resource/
+	// prompt name (which is rejected, not silently overwritten) is recorded
+	// here and surfaced via Err().
+	regErrs []error
 }
 
 // New creates a new MCP server with the given info and options.
@@ -272,11 +280,30 @@ func (s *Server) Manifest() Manifest {
 	}
 }
 
-// registerTool adds a tool to the server.
+// registerTool adds a tool to the server. A duplicate name is rejected (the
+// first registration wins) and recorded on the server rather than silently
+// overwriting the earlier tool; check Err() to surface the collision. To
+// intentionally replace a tool, call RemoveTool first, then re-register.
 func (s *Server) registerTool(t *Tool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, exists := s.tools[t.name]; exists {
+		s.regErrs = append(s.regErrs,
+			fmt.Errorf("duplicate tool registration: %q is already registered", t.name))
+		return
+	}
 	s.tools[t.name] = t
+}
+
+// Err returns any errors accumulated while wiring up the server, joined into a
+// single error (nil when there were none). Because the fluent builder API
+// returns the builder — not an error — registration collisions (duplicate
+// tool, resource, or prompt names) are recorded and reported here. Check it
+// once after registering everything: if err := srv.Err(); err != nil { ... }.
+func (s *Server) Err() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return errors.Join(s.regErrs...)
 }
 
 // GetTool retrieves a tool by name.
@@ -326,10 +353,19 @@ func (s *Server) Resources() []ResourceInfo {
 	return result
 }
 
-// registerResource adds a resource to the server.
+// registerResource adds a resource to the server. A duplicate URI template is
+// rejected (the first registration wins) and recorded rather than silently
+// overwriting the earlier resource; check Err() to surface the collision. To
+// intentionally replace a resource, call RemoveResource first, then
+// re-register.
 func (s *Server) registerResource(r *Resource) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, exists := s.resources[r.uriTemplate]; exists {
+		s.regErrs = append(s.regErrs,
+			fmt.Errorf("duplicate resource registration: URI template %q is already registered", r.uriTemplate))
+		return
+	}
 	s.resources[r.uriTemplate] = r
 }
 
@@ -352,17 +388,19 @@ func (s *Server) RemoveResource(uriTemplate string) bool {
 	return ok
 }
 
-// FindResourceForURI finds a resource that matches the given URI.
+// FindResourceForURI finds the resource that matches the given URI.
+//
+// When several registered templates match the same concrete URI (e.g. the
+// specific "config://database" and the catch-all "config://{key}"), selection
+// is deterministic and most-specific-wins: an exact literal template beats any
+// template with parameters, and among templates the one with the fewest
+// parameters (then the longest literal prefix, then lexically smallest) is
+// chosen. It never depends on Go's randomized map iteration order.
 func (s *Server) FindResourceForURI(uri string) (*Resource, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for _, r := range s.resources {
-		if _, ok := r.matchURI(uri); ok {
-			return r, true
-		}
-	}
-	return nil, false
+	return selectResource(s.resources, uri)
 }
 
 // Prompt starts building a new prompt with the given name.
@@ -392,10 +430,18 @@ func (s *Server) Prompts() []PromptInfo {
 	return result
 }
 
-// registerPrompt adds a prompt to the server.
+// registerPrompt adds a prompt to the server. A duplicate name is rejected
+// (the first registration wins) and recorded rather than silently overwriting
+// the earlier prompt; check Err() to surface the collision. To intentionally
+// replace a prompt, call RemovePrompt first, then re-register.
 func (s *Server) registerPrompt(p *Prompt) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, exists := s.prompts[p.name]; exists {
+		s.regErrs = append(s.regErrs,
+			fmt.Errorf("duplicate prompt registration: %q is already registered", p.name))
+		return
+	}
 	s.prompts[p.name] = p
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -515,3 +515,161 @@ func TestServer_RemovePrompt(t *testing.T) {
 		t.Error("expected RemovePrompt to return false for already removed prompt")
 	}
 }
+
+// registerTestResource registers a resource under tmpl whose handler echoes the
+// template as marker text, so tests can assert which resource matched.
+func registerTestResource(srv *Server, tmpl string) {
+	srv.Resource(tmpl).Handler(func(_ context.Context, uri string, _ map[string]string) (*ResourceContent, error) {
+		return &ResourceContent{URI: uri, Text: tmpl}, nil
+	})
+}
+
+func TestFindResourceForURI_Deterministic(t *testing.T) {
+	t.Run("exact literal beats catch-all template", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		registerTestResource(srv, "config://database")
+		registerTestResource(srv, "config://{key}")
+
+		// Map iteration order is randomized per range; run many times so a
+		// non-deterministic implementation would eventually pick the wrong one.
+		for i := 0; i < 1000; i++ {
+			r, ok := srv.FindResourceForURI("config://database")
+			if !ok {
+				t.Fatalf("iteration %d: expected a match", i)
+			}
+			if r.URITemplate() != "config://database" {
+				t.Fatalf("iteration %d: expected exact match config://database, got %q", i, r.URITemplate())
+			}
+		}
+	})
+
+	t.Run("catch-all still matches non-literal URIs", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		registerTestResource(srv, "config://database")
+		registerTestResource(srv, "config://{key}")
+
+		r, ok := srv.FindResourceForURI("config://timeout")
+		if !ok {
+			t.Fatal("expected the catch-all template to match")
+		}
+		if r.URITemplate() != "config://{key}" {
+			t.Fatalf("expected config://{key}, got %q", r.URITemplate())
+		}
+	})
+
+	t.Run("fewer-parameter template wins over broader overlap", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		// Both match "files://foo/config"; the single-param template with a
+		// literal "/config" suffix is more specific than the two-param one.
+		registerTestResource(srv, "files://{dir}/config")
+		registerTestResource(srv, "files://{dir}/{name}")
+
+		for i := 0; i < 1000; i++ {
+			r, ok := srv.FindResourceForURI("files://foo/config")
+			if !ok {
+				t.Fatalf("iteration %d: expected a match", i)
+			}
+			if r.URITemplate() != "files://{dir}/config" {
+				t.Fatalf("iteration %d: expected files://{dir}/config, got %q", i, r.URITemplate())
+			}
+		}
+		// The broader template still handles the non-overlapping case.
+		r, ok := srv.FindResourceForURI("files://foo/bar")
+		if !ok || r.URITemplate() != "files://{dir}/{name}" {
+			t.Fatalf("expected files://{dir}/{name} for files://foo/bar, got %q (ok=%v)", tmplOf(r), ok)
+		}
+	})
+
+	t.Run("no match returns false", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		registerTestResource(srv, "config://database")
+		if _, ok := srv.FindResourceForURI("other://thing"); ok {
+			t.Fatal("expected no match")
+		}
+	})
+}
+
+func tmplOf(r *Resource) string {
+	if r == nil {
+		return "<nil>"
+	}
+	return r.URITemplate()
+}
+
+func TestDuplicateRegistration(t *testing.T) {
+	t.Run("duplicate tool name is rejected and recorded", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		srv.Tool("greet").Description("first").
+			Handler(func(_ struct{}) (string, error) { return "first", nil })
+		srv.Tool("greet").Description("second").
+			Handler(func(_ struct{}) (string, error) { return "second", nil })
+
+		if err := srv.Err(); err == nil {
+			t.Fatal("expected a duplicate-registration error from Err()")
+		}
+		got, ok := srv.GetTool("greet")
+		if !ok {
+			t.Fatal("expected greet tool to exist")
+		}
+		if got.description != "first" {
+			t.Fatalf("expected the first registration to win, got description %q", got.description)
+		}
+	})
+
+	t.Run("duplicate resource template is rejected and recorded", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		registerTestResource(srv, "config://{key}")
+		registerTestResource(srv, "config://{key}")
+
+		if err := srv.Err(); err == nil {
+			t.Fatal("expected a duplicate-registration error from Err()")
+		}
+		if len(srv.Resources()) != 1 {
+			t.Fatalf("expected exactly one resource, got %d", len(srv.Resources()))
+		}
+	})
+
+	t.Run("duplicate prompt name is rejected and recorded", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		srv.Prompt("p").Description("first").
+			Handler(func(_ context.Context, _ map[string]string) (*PromptResult, error) { return &PromptResult{}, nil })
+		srv.Prompt("p").Description("second").
+			Handler(func(_ context.Context, _ map[string]string) (*PromptResult, error) { return &PromptResult{}, nil })
+
+		if err := srv.Err(); err == nil {
+			t.Fatal("expected a duplicate-registration error from Err()")
+		}
+		got, _ := srv.GetPrompt("p")
+		if got.description != "first" {
+			t.Fatalf("expected first prompt to win, got %q", got.description)
+		}
+	})
+
+	t.Run("no error when names are unique", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		registerTestResource(srv, "a://{x}")
+		registerTestResource(srv, "b://{y}")
+		if err := srv.Err(); err != nil {
+			t.Fatalf("expected no error for unique templates, got %v", err)
+		}
+	})
+
+	t.Run("remove then re-register is an intentional replace", func(t *testing.T) {
+		srv := New(Info{Name: "test", Version: "1.0.0"})
+		srv.Tool("greet").Description("first").
+			Handler(func(_ struct{}) (string, error) { return "first", nil })
+		if !srv.RemoveTool("greet") {
+			t.Fatal("expected RemoveTool to report the tool existed")
+		}
+		srv.Tool("greet").Description("second").
+			Handler(func(_ struct{}) (string, error) { return "second", nil })
+
+		if err := srv.Err(); err != nil {
+			t.Fatalf("expected no error after remove-then-replace, got %v", err)
+		}
+		got, _ := srv.GetTool("greet")
+		if got.description != "second" {
+			t.Fatalf("expected replacement to win, got %q", got.description)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Hardens resource dispatch in the `server` package: overlapping resource URI templates previously resolved to a **non-deterministic** handler, and duplicate registrations silently overwrote each other. This fixes a deep-review batch of dispatch-determinism and registration-shadowing findings.

## Findings addressed

### [HIGH] Overlapping resource URIs dispatched to a non-deterministic handler
`FindResourceForURI` ranged over the randomized `s.resources` map and returned the first `matchURI` hit. Because `{param}` compiles to `([^/]+)`, a concrete URI matches every template it fits — so registering `config://database` alongside the catch-all `config://{key}` meant a read of `config://database` could resolve to *either*, and authz/list-filtering then ran against the wrong resource.

Matching is now deterministic and **most-specific-wins**: an exact/literal template beats any parameterized one; among templates the fewest parameters wins, then the longest literal prefix, then the lexically smallest (a total order). Selection iterates a sorted key slice, never the map. Behavior is unchanged when there is no overlap.

### [MED] Duplicate tool/resource/prompt registration silently overwrote (shadowing)
`registerTool`/`registerResource`/`registerPrompt` did `s.map[name] = x` with no collision check, so a later registration silently replaced an earlier one and the builder's error was swallowed. Duplicates are now **rejected (first registration wins)** and recorded, surfaced via the new `Server.Err()`. Intentional replacement remains available via the existing `RemoveTool`/`RemoveResource`/`RemovePrompt` before re-registering.

### [LOW] Completion resource matching was also order-nondeterministic
`completionRegistry.Handle` did `for template := range r.resourceHandlers { … break }`, returning an arbitrary handler on overlap. It now applies the same deterministic most-specific selection.

### [LOW/helper] Path-containment guardrail for file-style resources
Added exported `ContainedPath(root, param string) (string, error)`: `{param}` blocks `/` but a value of `..` (or a value a handler percent-decodes) can still escape. The helper rejects absolute params, `..` traversal, and symlink escape via `filepath.Clean` + `filepath.Rel` containment + `filepath.EvalSymlinks`. Documented that resource params are untrusted and URL-undecoded. Not wired into existing handlers — provided for handlers that map params to paths.

## Testing

- New TDD coverage: exact URI beats catch-all deterministically (1000-iter loops against randomized map order), fewer-param template wins over broader overlap, duplicate registration errors for all three kinds + remove-then-replace, deterministic completion selection, and `ContainedPath` rejecting `..`/absolute/symlink escape while accepting contained (incl. within-root symlink) paths. Verified the determinism test fails against the old map-range implementation.
- `go vet`, `golangci-lint` (0 issues), `go build`, `go test`, and `go test -race ./server/...` all green. Full pre-commit suite passes.

Scope: touches only `server/server.go`, `server/completion.go`, `server/resource.go` and their tests.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
