### PR TITLE
fix(transport): secure HTTP/SSE/WebSocket defaults

### DIFF
--- a/transport/clientid.go
+++ b/transport/clientid.go
@@ -1,6 +1,10 @@
 package transport
 
-import "context"
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+)
 
 type clientIDKey struct{}
 
@@ -18,4 +22,19 @@ func ClientIDFromContext(ctx context.Context) string {
 		return id
 	}
 	return ""
+}
+
+// newSessionID mints an unguessable server-side session identifier for an SSE
+// connection. The id is the map key for the client's push channel, so it must
+// not be attacker-controlled: a caller-supplied clientId is advisory only. We
+// use crypto/rand rather than a timestamp so an attacker cannot predict or
+// collide with another client's id and hijack its stream. rand.Read never
+// fails on supported platforms; if it does, we surface the error and refuse
+// the connection rather than fall back to a guessable id.
+func newSessionID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
 }

--- a/transport/cors.go
+++ b/transport/cors.go
@@ -2,9 +2,57 @@ package transport
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
+
+// originAllowed reports whether a request's Origin header is permitted to
+// reach a transport handler. Only browsers set Origin (on cross-origin
+// requests and same-origin non-GET requests), so it is the primary control
+// against DNS-rebinding, cross-site request forgery, and cross-site
+// WebSocket hijacking. Non-browser clients (curl, Go's net/http, native MCP
+// clients) omit the header entirely; an empty Origin is therefore treated as
+// trusted because the browser same-origin policy is what this check backstops.
+//
+// When allowAll is set the caller has explicitly opted out of origin
+// enforcement (WithInsecureAllowAllOrigins / WithWebSocketAllowAllOrigins).
+// Otherwise the origin must match the allowlist exactly, or — by default —
+// be same-origin with the request Host or a loopback address, which keeps
+// localhost development working without opening the server to the public web.
+// loopbackHostname is the DNS name that resolves to the local host; treated as
+// same-origin so localhost development works without an explicit allowlist.
+const loopbackHostname = "localhost"
+
+func originAllowed(r *http.Request, allowlist []string, allowAll bool) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if allowAll {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	for _, a := range allowlist {
+		if a == "*" {
+			return true
+		}
+		if strings.EqualFold(a, origin) {
+			return true
+		}
+	}
+	if strings.EqualFold(u.Host, r.Host) {
+		return true
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case loopbackHostname, "127.0.0.1", "::1":
+		return true
+	}
+	return false
+}
 
 // CORSConfig configures CORS behavior for HTTP transports.
 type CORSConfig struct {
@@ -55,6 +103,15 @@ func CORSHandler(config CORSConfig, next http.Handler) http.Handler {
 	}
 
 	allowAllOrigins := len(config.AllowOrigins) == 1 && config.AllowOrigins[0] == "*"
+	// A wildcard origin combined with credentials is rejected by every browser
+	// (the spec forbids "Access-Control-Allow-Origin: *" alongside
+	// "Access-Control-Allow-Credentials: true") and, if honored, would
+	// authorize every site on the web to make credentialed requests. Normalize
+	// the misconfiguration by dropping credentials rather than emitting an
+	// unsafe, non-functional header pair.
+	if allowAllOrigins && config.AllowCredentials {
+		config.AllowCredentials = false
+	}
 	allowedOrigins := make(map[string]bool)
 	for _, origin := range config.AllowOrigins {
 		allowedOrigins[origin] = true

--- a/transport/cors_test.go
+++ b/transport/cors_test.go
@@ -163,6 +163,33 @@ func TestCORSHandler(t *testing.T) {
 	})
 }
 
+func TestCORSHandler_WildcardWithCredentialsNormalized(t *testing.T) {
+	echoHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	config := transport.CORSConfig{
+		AllowOrigins:     []string{"*"},
+		AllowCredentials: true,
+	}
+	handler := transport.CORSHandler(config, echoHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "http://example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// "*" + credentials is invalid; credentials must be dropped.
+	if rec.Header().Get("Access-Control-Allow-Credentials") != "" {
+		t.Errorf("wildcard origin must not be combined with credentials, got %q",
+			rec.Header().Get("Access-Control-Allow-Credentials"))
+	}
+	if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("expected wildcard ACAO, got %q", rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
 func TestDefaultCORSConfig(t *testing.T) {
 	config := transport.DefaultCORSConfig()
 

--- a/transport/http.go
+++ b/transport/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -12,6 +13,14 @@ import (
 
 	"go.klarlabs.de/mcp/protocol"
 )
+
+// defaultMaxRequestBytes bounds a single POST /mcp body. JSON-RPC requests are
+// small; the cap stops a client from exhausting memory with an unbounded body.
+const defaultMaxRequestBytes = 4 << 20 // 4 MiB
+
+// defaultMaxSSEConnections caps concurrently registered SSE push channels so a
+// flood of connections cannot exhaust server memory.
+const defaultMaxSSEConnections = 1024
 
 // healthStatusField is the JSON field name used in /health and /healthz
 // payloads.
@@ -28,6 +37,12 @@ type HTTP struct {
 	discovery        *ServerDiscovery
 	tlsConfig        *tls.Config
 	requestContextFn func(context.Context, *http.Request) context.Context
+	authorizeFn      func(*http.Request) error
+
+	allowedOrigins  []string
+	allowAllOrigins bool
+	maxRequestBytes int64
+	maxSSEClients   int
 
 	mu         sync.RWMutex
 	listenAddr string
@@ -149,12 +164,66 @@ func WithRequestContextFn(fn func(context.Context, *http.Request) context.Contex
 	}
 }
 
+// WithAuthorize registers an authorization gate that runs on both POST /mcp
+// and the SSE push stream (GET /mcp/sse) before any work is done. Returning a
+// non-nil error rejects the request with 403 Forbidden, so the same policy
+// protects the request/response path and the server-push stream — the SSE
+// stream is otherwise unauthenticated by construction. The function sees the
+// raw *http.Request (headers, TLS peer certs, etc.); mcp-go ships no identity
+// type and performs no auth of its own.
+func WithAuthorize(fn func(*http.Request) error) HTTPOption {
+	return func(h *HTTP) {
+		h.authorizeFn = fn
+	}
+}
+
+// WithAllowedOrigins restricts which browser Origins may reach POST /mcp and
+// the SSE stream. Pass exact origins (scheme://host[:port]). Requests without
+// an Origin header (non-browser clients) are always allowed; browser requests
+// from a listed origin, a same-origin Host, or a loopback address are allowed
+// by default. This is the primary defense against DNS-rebinding and cross-site
+// access to a localhost server.
+func WithAllowedOrigins(origins ...string) HTTPOption {
+	return func(h *HTTP) {
+		h.allowedOrigins = origins
+	}
+}
+
+// WithInsecureAllowAllOrigins disables Origin enforcement entirely, restoring
+// the pre-hardening behavior where any website could reach the server. Named
+// "insecure" deliberately: only use it behind a trusted gateway that performs
+// its own origin/CSRF checks.
+func WithInsecureAllowAllOrigins() HTTPOption {
+	return func(h *HTTP) {
+		h.allowAllOrigins = true
+	}
+}
+
+// WithMaxRequestBytes caps the POST /mcp request body. A non-positive value
+// disables the limit. Default: 4 MiB.
+func WithMaxRequestBytes(n int64) HTTPOption {
+	return func(h *HTTP) {
+		h.maxRequestBytes = n
+	}
+}
+
+// WithMaxSSEConnections caps the number of concurrent SSE push connections;
+// once reached, new connections receive 503. A non-positive value disables the
+// cap. Default: 1024.
+func WithMaxSSEConnections(n int) HTTPOption {
+	return func(h *HTTP) {
+		h.maxSSEClients = n
+	}
+}
+
 func NewHTTP(addr string, opts ...HTTPOption) *HTTP {
 	h := &HTTP{
 		addr:            addr,
 		readTimeout:     30 * time.Second,
 		writeTimeout:    30 * time.Second,
 		shutdownTimeout: 30 * time.Second,
+		maxRequestBytes: defaultMaxRequestBytes,
+		maxSSEClients:   defaultMaxSSEConnections,
 		sseClients:      make(map[string]chan []byte),
 		sessionStore:    NewInMemoryStore(),
 	}
@@ -289,6 +358,16 @@ func (h *HTTP) handleMCP(w http.ResponseWriter, r *http.Request, handler Handler
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
+	if !originAllowed(r, h.allowedOrigins, h.allowAllOrigins) {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+	if h.authorizeFn != nil {
+		if err := h.authorizeFn(r); err != nil {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 
@@ -303,14 +382,31 @@ func (h *HTTP) handleMCP(w http.ResponseWriter, r *http.Request, handler Handler
 		ctx = ContextWithClientID(ctx, clientID)
 	}
 
+	if h.maxRequestBytes > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, h.maxRequestBytes)
+	}
+
 	var req protocol.Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		resp := protocol.NewErrorResponse(nil, protocol.NewParseError("Invalid JSON"))
 		_ = json.NewEncoder(w).Encode(resp)
 		return
 	}
 
 	resp, err := handler.HandleRequest(ctx, &req)
+
+	// A JSON-RPC notification carries no id and, per spec, MUST NOT be
+	// answered with a response body. Acknowledge receipt and stop.
+	if req.IsNotification() {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
 	if err != nil {
 		resp = protocol.NewErrorResponse(req.ID, protocol.NewInternalError(err.Error()))
 	}
@@ -326,21 +422,58 @@ func (h *HTTP) handleSSE(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "SSE not supported", http.StatusInternalServerError)
 		return
 	}
+	if !originAllowed(r, h.allowedOrigins, h.allowAllOrigins) {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+	if h.authorizeFn != nil {
+		if err := h.authorizeFn(r); err != nil {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+	}
 
+	// Derive request-scoped identity the same way the request/response path
+	// does, so an mTLS or header-derived caller value is available for the
+	// lifetime of the push stream instead of being silently skipped.
+	ctx := r.Context()
+	if h.requestContextFn != nil {
+		ctx = h.requestContextFn(ctx, r)
+	}
+
+	// A client that uses the server-push protocol picks its own unguessable
+	// (crypto/rand) correlation id and sends it on both this SSE connection and
+	// its POSTs. We honor it for correlation but NEVER let it overwrite a live
+	// entry (see registerSSEClient) — that is what stops an attacker from
+	// picking a victim's id to steal their push channel. When no id is supplied
+	// we mint one server-side with crypto/rand rather than a guessable
+	// timestamp.
 	clientID := r.URL.Query().Get("clientId")
 	if clientID == "" {
-		clientID = fmt.Sprintf("%d", time.Now().UnixNano())
+		minted, err := newSessionID()
+		if err != nil {
+			http.Error(w, "failed to allocate session", http.StatusInternalServerError)
+			return
+		}
+		clientID = minted
 	}
 
 	messageCh := make(chan []byte, 10)
-
-	h.sseClientsMu.Lock()
-	h.sseClients[clientID] = messageCh
-	h.sseClientsMu.Unlock()
+	if !h.registerSSEClient(clientID, messageCh) {
+		// Either the connection cap is reached or the id is already registered.
+		// Refusing rather than clobbering keeps an existing client's channel
+		// intact (no hijack) and avoids orphaning it via a colliding delete.
+		http.Error(w, "connection refused", http.StatusServiceUnavailable)
+		return
+	}
 
 	defer func() {
 		h.sseClientsMu.Lock()
-		delete(h.sseClients, clientID)
+		// Only remove the entry if it still points at THIS connection's
+		// channel, so a later reconnect that reused the id is not orphaned.
+		if h.sseClients[clientID] == messageCh {
+			delete(h.sseClients, clientID)
+		}
 		h.sseClientsMu.Unlock()
 		h.mu.RLock()
 		hook := h.onDisconnect
@@ -353,7 +486,6 @@ func (h *HTTP) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	if h.sessionStore != nil {
 		w.Header().Set("Link", fmt.Sprintf(`<%s/mcp/sse?clientId=%s>; rel="stream"`, h.Addr(), clientID))
@@ -367,7 +499,7 @@ func (h *HTTP) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	for {
 		select {
-		case <-r.Context().Done():
+		case <-ctx.Done():
 			return
 		case msg, ok := <-messageCh:
 			if !ok {
@@ -376,6 +508,23 @@ func (h *HTTP) handleSSE(w http.ResponseWriter, r *http.Request) {
 			_ = sse.WriteData(msg)
 		}
 	}
+}
+
+// registerSSEClient atomically enforces the concurrent-connection cap and
+// refuses to overwrite an id already present, then records the push channel.
+// It returns false when the cap is reached or the id collides, so the caller
+// can reject with 503.
+func (h *HTTP) registerSSEClient(clientID string, ch chan []byte) bool {
+	h.sseClientsMu.Lock()
+	defer h.sseClientsMu.Unlock()
+	if h.maxSSEClients > 0 && len(h.sseClients) >= h.maxSSEClients {
+		return false
+	}
+	if _, exists := h.sseClients[clientID]; exists {
+		return false
+	}
+	h.sseClients[clientID] = ch
+	return true
 }
 
 func (h *HTTP) Broadcast(data []byte) {

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -273,27 +273,95 @@ func TestHTTP_SendTo(t *testing.T) {
 	transport := NewHTTP(":0")
 	httpHandler := transport.createHandler(handler)
 
+	// Use a real server so the SSE stream is read over a synchronized network
+	// connection rather than racing on an httptest.Recorder.
+	srv := httptest.NewServer(httpHandler)
+	defer srv.Close()
+
+	// connectSSE opens an SSE stream and returns the connection plus the
+	// clientId echoed in the "connected" event. Registration happens before
+	// that event is written, so the channel is present once it returns.
+	connectSSE := func(t *testing.T, ctx context.Context, query string) (*http.Response, string) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/mcp/sse"+query, nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("connect SSE: %v", err)
+		}
+		data, err := NewSSEReader(resp.Body).ReadData()
+		if err != nil {
+			t.Fatalf("read connected event: %v", err)
+		}
+		var connected struct {
+			ClientID string `json:"clientId"`
+		}
+		if err := json.Unmarshal(data, &connected); err != nil {
+			t.Fatalf("parse connected event %q: %v", data, err)
+		}
+		return resp, connected.ClientID
+	}
+
 	t.Run("send to specific client", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		httpReq := httptest.NewRequest(http.MethodGet, "/mcp/sse?clientId=test-client", nil).WithContext(ctx)
-		rec := httptest.NewRecorder()
+		resp, id := connectSSE(t, ctx, "?clientId=test-client")
+		defer func() { _ = resp.Body.Close() }()
+		if id != "test-client" {
+			t.Fatalf("client-supplied id should be honored for correlation, got %q", id)
+		}
 
-		go httpHandler.ServeHTTP(rec, httpReq)
-
-		time.Sleep(30 * time.Millisecond)
-
-		ok := transport.SendTo("test-client", []byte("direct message"))
-		if !ok {
+		if !transport.SendTo("test-client", []byte("direct message")) {
 			t.Error("expected SendTo to return true for existing client")
 		}
-
-		ok = transport.SendTo("non-existent", []byte("should fail"))
-		if ok {
+		if transport.SendTo("non-existent", []byte("should fail")) {
 			t.Error("expected SendTo to return false for non-existent client")
 		}
+	})
 
-		cancel()
+	t.Run("empty clientId is minted server-side, not a timestamp", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resp, id := connectSSE(t, ctx, "")
+		defer func() { _ = resp.Body.Close() }()
+		// crypto/rand 16 bytes hex-encoded == 32 chars; a UnixNano timestamp
+		// would be ~19 numeric digits.
+		if len(id) != 32 {
+			t.Fatalf("expected 32-char random id, got %q (len %d)", id, len(id))
+		}
+	})
+
+	t.Run("duplicate clientId cannot steal a live channel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Victim connects with a chosen id.
+		victim, id := connectSSE(t, ctx, "?clientId=victim")
+		defer func() { _ = victim.Body.Close() }()
+		if id != "victim" {
+			t.Fatalf("unexpected id %q", id)
+		}
+
+		// Attacker tries to register the same id: must be refused, not allowed
+		// to overwrite/steal the victim's channel.
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/mcp/sse?clientId=victim", nil)
+		attacker, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("attacker connect: %v", err)
+		}
+		defer func() { _ = attacker.Body.Close() }()
+		if attacker.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("duplicate id status = %d, want %d", attacker.StatusCode, http.StatusServiceUnavailable)
+		}
+
+		// The victim's channel is intact and still addressable.
+		if !transport.SendTo("victim", []byte("still mine")) {
+			t.Error("victim channel must survive a hijack attempt")
+		}
 	})
 }
 
@@ -366,6 +434,170 @@ func TestHTTP_Serve(t *testing.T) {
 
 		cancel()
 	})
+}
+
+func okHandler() Handler {
+	return HandlerFunc(func(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, map[string]string{"status": "ok"}), nil
+	})
+}
+
+func TestHTTP_SSE_CrossOriginRejected(t *testing.T) {
+	h := NewHTTP(":0").createHandler(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got == "*" {
+		t.Errorf("SSE must not emit Access-Control-Allow-Origin: *, got %q", got)
+	}
+}
+
+func TestHTTP_SSE_SameOriginAllowed(t *testing.T) {
+	h := NewHTTP(":0").createHandler(okHandler())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil).WithContext(ctx)
+	req.Host = "localhost:8080"
+	req.Header.Set("Origin", "http://localhost:8080")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SSE handler did not exit")
+	}
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("same-origin request rejected: %d", rec.Code)
+	}
+}
+
+func TestHTTP_SSE_AllowlistedOriginAllowed(t *testing.T) {
+	h := NewHTTP(":0", WithAllowedOrigins("https://app.example")).createHandler(okHandler())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil).WithContext(ctx)
+	req.Header.Set("Origin", "https://app.example")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SSE handler did not exit")
+	}
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("allowlisted origin rejected: %d", rec.Code)
+	}
+}
+
+func TestHTTP_MCP_CrossOriginRejected(t *testing.T) {
+	h := NewHTTP(":0").createHandler(okHandler())
+
+	body, _ := json.Marshal(protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "test"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	req.Header.Set("Origin", "http://evil.example")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestHTTP_MCP_OversizeBodyRejected(t *testing.T) {
+	h := NewHTTP(":0", WithMaxRequestBytes(256)).createHandler(okHandler())
+
+	big := strings.Repeat("a", 4096)
+	body := `{"jsonrpc":"2.0","id":1,"method":"test","params":{"x":"` + big + `"}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestHTTP_MCP_NotificationReturns202(t *testing.T) {
+	h := NewHTTP(":0").createHandler(okHandler())
+
+	// No id => notification.
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","method":"notify"}`))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusAccepted)
+	}
+	if strings.Contains(rec.Body.String(), `"result"`) {
+		t.Errorf("notification must not receive a response body, got %q", rec.Body.String())
+	}
+}
+
+func TestHTTP_Authorize_RejectsBothPaths(t *testing.T) {
+	deny := WithAuthorize(func(_ *http.Request) error { return context.Canceled })
+	h := NewHTTP(":0", deny).createHandler(okHandler())
+
+	post := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"t"}`))
+	postRec := httptest.NewRecorder()
+	h.ServeHTTP(postRec, post)
+	if postRec.Code != http.StatusForbidden {
+		t.Errorf("POST /mcp status = %d, want 403", postRec.Code)
+	}
+
+	sse := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil)
+	sseRec := httptest.NewRecorder()
+	h.ServeHTTP(sseRec, sse)
+	if sseRec.Code != http.StatusForbidden {
+		t.Errorf("GET /mcp/sse status = %d, want 403", sseRec.Code)
+	}
+}
+
+func TestHTTP_SSE_MaxConnections(t *testing.T) {
+	h := NewHTTP(":0", WithMaxSSEConnections(1)).createHandler(okHandler())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil).WithContext(ctx)
+	firstRec := httptest.NewRecorder()
+	go func() { h.ServeHTTP(firstRec, first) }()
+	time.Sleep(20 * time.Millisecond)
+
+	second := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil)
+	secondRec := httptest.NewRecorder()
+	h.ServeHTTP(secondRec, second)
+
+	if secondRec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("second connection status = %d, want %d", secondRec.Code, http.StatusServiceUnavailable)
+	}
 }
 
 func TestHTTP_RequestContextFn(t *testing.T) {

--- a/transport/websocket.go
+++ b/transport/websocket.go
@@ -14,6 +14,13 @@ import (
 	"go.klarlabs.de/mcp/protocol"
 )
 
+// defaultWSMaxMessageBytes bounds a single inbound WebSocket message. A
+// non-positive value disables the limit.
+const defaultWSMaxMessageBytes = 4 << 20 // 4 MiB
+
+// defaultWSMaxConnections caps concurrent WebSocket connections.
+const defaultWSMaxConnections = 1024
+
 // WebSocket implements MCP transport over WebSocket connections.
 type WebSocket struct {
 	addr     string
@@ -23,6 +30,11 @@ type WebSocket struct {
 	readTimeout  time.Duration
 	writeTimeout time.Duration
 	tlsConfig    *tls.Config
+
+	allowedOrigins  []string
+	allowAllOrigins bool
+	maxMessageBytes int64
+	maxConnections  int
 
 	mu      sync.RWMutex
 	clients map[*wsClient]struct{}
@@ -51,10 +63,49 @@ func WithWebSocketWriteTimeout(d time.Duration) WebSocketOption {
 	}
 }
 
-// WithWebSocketCheckOrigin sets the origin check function for WebSocket upgrades.
+// WithWebSocketCheckOrigin sets the origin check function for WebSocket
+// upgrades, fully overriding the secure default. Return true to accept the
+// upgrade. Prefer WithWebSocketAllowedOrigins unless you need custom logic.
 func WithWebSocketCheckOrigin(fn func(r *http.Request) bool) WebSocketOption {
 	return func(ws *WebSocket) {
 		ws.upgrader.CheckOrigin = fn
+	}
+}
+
+// WithWebSocketAllowedOrigins restricts which browser Origins may complete a
+// WebSocket upgrade. Requests without an Origin header (non-browser clients)
+// are allowed; browser requests must match a listed origin, the same-origin
+// Host, or a loopback address. This is the defense against Cross-Site
+// WebSocket Hijacking.
+func WithWebSocketAllowedOrigins(origins ...string) WebSocketOption {
+	return func(ws *WebSocket) {
+		ws.allowedOrigins = origins
+	}
+}
+
+// WithWebSocketAllowAllOrigins disables origin enforcement on the upgrade,
+// restoring the pre-hardening behavior where any website could open a socket.
+// Named "insecure" behavior deliberately: only use it behind a trusted proxy.
+func WithWebSocketAllowAllOrigins() WebSocketOption {
+	return func(ws *WebSocket) {
+		ws.allowAllOrigins = true
+	}
+}
+
+// WithWebSocketMaxMessageBytes caps the size of a single inbound message. A
+// non-positive value disables the limit. Default: 4 MiB.
+func WithWebSocketMaxMessageBytes(n int64) WebSocketOption {
+	return func(ws *WebSocket) {
+		ws.maxMessageBytes = n
+	}
+}
+
+// WithWebSocketMaxConnections caps concurrent connections; once reached, new
+// upgrade attempts receive 503. A non-positive value disables the cap.
+// Default: 1024.
+func WithWebSocketMaxConnections(n int) WebSocketOption {
+	return func(ws *WebSocket) {
+		ws.maxConnections = n
 	}
 }
 
@@ -74,11 +125,20 @@ func NewWebSocket(addr string, opts ...WebSocketOption) *WebSocket {
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
-			CheckOrigin:     func(r *http.Request) bool { return true }, // Allow all origins by default
 		},
-		readTimeout:  60 * time.Second,
-		writeTimeout: 10 * time.Second,
-		clients:      make(map[*wsClient]struct{}),
+		readTimeout:     60 * time.Second,
+		writeTimeout:    10 * time.Second,
+		maxMessageBytes: defaultWSMaxMessageBytes,
+		maxConnections:  defaultWSMaxConnections,
+		clients:         make(map[*wsClient]struct{}),
+	}
+
+	// Secure default: reject cross-origin upgrades (Cross-Site WebSocket
+	// Hijacking). The closure reads ws.allowedOrigins/allowAllOrigins at
+	// upgrade time, so options applied below take effect. A caller can fully
+	// override this via WithWebSocketCheckOrigin.
+	ws.upgrader.CheckOrigin = func(r *http.Request) bool {
+		return originAllowed(r, ws.allowedOrigins, ws.allowAllOrigins)
 	}
 
 	for _, opt := range opts {
@@ -135,9 +195,26 @@ func (ws *WebSocket) Serve(ctx context.Context, handler Handler) error {
 }
 
 func (ws *WebSocket) handleConnection(ctx context.Context, w http.ResponseWriter, r *http.Request, handler Handler) {
+	// Enforce the connection cap before upgrading — once the handshake
+	// completes we can no longer reply with an HTTP status.
+	if ws.maxConnections > 0 {
+		ws.mu.RLock()
+		n := len(ws.clients)
+		ws.mu.RUnlock()
+		if n >= ws.maxConnections {
+			http.Error(w, "too many connections", http.StatusServiceUnavailable)
+			return
+		}
+	}
+
 	conn, err := ws.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
+	}
+
+	// Bound inbound message size so a client cannot exhaust memory.
+	if ws.maxMessageBytes > 0 {
+		conn.SetReadLimit(ws.maxMessageBytes)
 	}
 
 	client := &wsClient{conn: conn}

--- a/transport/websocket_test.go
+++ b/transport/websocket_test.go
@@ -3,6 +3,8 @@ package transport_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +41,124 @@ func TestWebSocket(t *testing.T) {
 
 		// Test is covered by integration tests below
 		cancel()
+	})
+}
+
+func TestWebSocket_Security(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	newServer := func(t *testing.T, addr string, opts ...transport.WebSocketOption) {
+		t.Helper()
+		handler := transport.HandlerFunc(func(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+			return protocol.NewResponse(req.ID, "ok"), nil
+		})
+		ws := transport.NewWebSocket(addr, opts...)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go func() { _ = ws.Serve(ctx, handler) }()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Run("rejects cross-origin upgrade by default", func(t *testing.T) {
+		newServer(t, ":18771")
+
+		hdr := http.Header{}
+		hdr.Set("Origin", "http://evil.example")
+		conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:18771/", hdr)
+		if err == nil {
+			_ = conn.Close()
+			t.Fatal("expected cross-origin upgrade to be rejected")
+		}
+		if resp != nil {
+			if resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+			if resp.StatusCode != http.StatusForbidden {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+			}
+		}
+	})
+
+	t.Run("allows no-origin (non-browser) client", func(t *testing.T) {
+		newServer(t, ":18772")
+
+		conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:18772/", nil)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			t.Fatalf("no-origin client should connect: %v", err)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("allows allowlisted origin", func(t *testing.T) {
+		newServer(t, ":18773", transport.WithWebSocketAllowedOrigins("http://app.example"))
+
+		hdr := http.Header{}
+		hdr.Set("Origin", "http://app.example")
+		conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:18773/", hdr)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			t.Fatalf("allowlisted origin should connect: %v", err)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("enforces max connections", func(t *testing.T) {
+		newServer(t, ":18774", transport.WithWebSocketMaxConnections(1))
+
+		conn1, resp1, err := websocket.DefaultDialer.Dial("ws://localhost:18774/", nil)
+		if resp1 != nil && resp1.Body != nil {
+			_ = resp1.Body.Close()
+		}
+		if err != nil {
+			t.Fatalf("first connection failed: %v", err)
+		}
+		defer conn1.Close()
+		time.Sleep(50 * time.Millisecond)
+
+		conn2, resp2, err := websocket.DefaultDialer.Dial("ws://localhost:18774/", nil)
+		if err == nil {
+			_ = conn2.Close()
+			t.Fatal("expected second connection to be rejected")
+		}
+		if resp2 != nil {
+			if resp2.Body != nil {
+				_ = resp2.Body.Close()
+			}
+			if resp2.StatusCode != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want %d", resp2.StatusCode, http.StatusServiceUnavailable)
+			}
+		}
+	})
+
+	t.Run("enforces read limit", func(t *testing.T) {
+		newServer(t, ":18775", transport.WithWebSocketMaxMessageBytes(128))
+
+		conn, resp, err := websocket.DefaultDialer.Dial("ws://localhost:18775/", nil)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			t.Fatalf("connection failed: %v", err)
+		}
+		defer conn.Close()
+
+		oversize := `{"jsonrpc":"2.0","id":1,"method":"test","params":{"x":"` + strings.Repeat("a", 4096) + `"}}`
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(oversize)); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		// Server should close the connection once the read limit is exceeded.
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		if _, _, err := conn.ReadMessage(); err == nil {
+			t.Fatal("expected connection to be closed after oversize message")
+		}
 	})
 }
 


### PR DESCRIPTION
## Secure-by-default HTTP / SSE / WebSocket transports

A deep review found the HTTP, SSE, and WebSocket transports were insecure by default. This makes them secure-by-default with explicit, named opt-outs (minor version bump). No public API is removed; new options are additive.

### Fixes

| # | Sev | Fix |
|---|-----|-----|
| 1 | HIGH | **SSE session hijack / weak session.** Removed the `time.Now().UnixNano()` fallback. The caller's crypto-random correlation id is honored for POST/SSE correlation but can **never overwrite a live map entry** (attacker can't pick a victim's id to steal their channel); an absent id is minted server-side with `crypto/rand`; the entry is deleted only when it still points at *this* connection's channel (no colliding-delete orphan). |
| 2 | HIGH | **SSE `Access-Control-Allow-Origin: *` + no Origin check.** Dropped the unconditional `ACAO:*`; `/mcp/sse` and `/mcp` now validate `Origin` against an allowlist (same-origin/localhost by default) and return 403 otherwise. New `WithAllowedOrigins(...)` and `WithInsecureAllowAllOrigins()`. |
| 3 | HIGH | **WebSocket `CheckOrigin` returned true (CSWSH).** Default now enforces the same allowlist. New `WithWebSocketAllowedOrigins(...)` / `WithWebSocketAllowAllOrigins()`; `WithWebSocketCheckOrigin` still fully overrides. |
| 4 | HIGH | **SSE bypassed the caller auth hook.** `requestContextFn` now runs on the SSE path, and new `WithAuthorize(func(*http.Request) error)` gates **both** POST `/mcp` and the SSE stream with 403 on rejection. |
| 5 | MED | **No Origin gate on POST `/mcp`.** Origin allowlist now enforced before dispatch (403). |
| 6 | MED | **Unbounded request body.** `http.MaxBytesReader` wraps the body; `WithMaxRequestBytes` (default 4 MiB), returns 413. |
| 7 | MED | **Unbounded WebSocket reads.** `conn.SetReadLimit` after upgrade; `WithWebSocketMaxMessageBytes` (default 4 MiB). |
| 8 | MED | **Unbounded concurrent connections.** SSE and WS connection caps (`WithMaxSSEConnections` / `WithWebSocketMaxConnections`, default 1024), 503 on exceed. |
| 9 | MED | **HTTP replied to notifications.** POST `/mcp` now returns 202 for JSON-RPC notifications with no body. |
| 10 | LOW | **CORS wildcard + credentials.** `AllowOrigins:["*"]` with `AllowCredentials` now drops credentials (invalid/unsafe combo). |

### Scope note
- **Fix #1** is implemented as *honor-client-id-but-refuse-overwrite* rather than fully ignoring the caller value. The client (out of scope for this PR) correlates POST and SSE via a client-minted `crypto/rand` id sent on both and ignores the server `connected` hello, so fully server-minting would break the documented resource-subscription push protocol (`e2e/TestResourceSubscriptionPushE2E`). Refuse-overwrite + crypto-random fallback + delete-if-ours closes the actual hijack, steal, and colliding-delete-orphan vectors.
- **discovery.go** left as public metadata (`.well-known`) by design; the auth requirement in #4 was applied to the SSE stream as specified.

### Verification
`go vet`, `golangci-lint run` (0 issues), `go build`, and `go test -race ./...` all green. New httptest/integration tests cover: cross-origin SSE/POST rejected (403), same-origin & allowlisted accepted, duplicate clientId cannot steal a live channel, empty id minted server-side (32-char random), oversize body → 413, notification → 202, WS bad-origin rejected, WS max-connections → 503, WS read-limit enforced, CORS wildcard+credentials normalized.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
