### PR TITLE
fix(transport,client): resilient framing, bounded reads, safe redirects

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -35,6 +35,10 @@ type HTTPTransport struct {
 	// clientID correlates this transport's POSTs with its server-push (SSE)
 	// stream so the server can target resource-updated notifications.
 	clientID string
+	// maxResponseBytes caps how many bytes Send reads from a response body. A
+	// malicious or malfunctioning server could otherwise stream an unbounded
+	// body and OOM the client.
+	maxResponseBytes int64
 
 	// Streamable-HTTP session state (MCP 2025-03-26). A server may assign a
 	// session id on the initialize response (Mcp-Session-Id) which subsequent
@@ -43,16 +47,22 @@ type HTTPTransport struct {
 	sessionID string
 }
 
+// DefaultMaxResponseBytes bounds a single JSON-RPC HTTP response body. It
+// matches the 16MB stdio frame cap so both transports agree on the largest
+// message they will accept. Override via WithMaxResponseBytes.
+const DefaultMaxResponseBytes int64 = 16 * 1024 * 1024
+
 // HTTPTransportOption configures an HTTPTransport.
 type HTTPTransportOption func(*httpTransportOptions)
 
 type httpTransportOptions struct {
-	httpClient *http.Client
-	headers    http.Header
-	caBundle   *x509.CertPool
-	insecure   bool
-	timeout    time.Duration
-	endpoint   string
+	httpClient       *http.Client
+	headers          http.Header
+	caBundle         *x509.CertPool
+	insecure         bool
+	timeout          time.Duration
+	endpoint         string
+	maxResponseBytes int64
 }
 
 // WithHTTPClient overrides the http.Client used for requests. This is the only
@@ -106,6 +116,14 @@ func WithEndpointPath(path string) HTTPTransportOption {
 	return func(o *httpTransportOptions) { o.endpoint = path }
 }
 
+// WithMaxResponseBytes caps how many bytes the transport reads from a server
+// response body. Responses larger than the cap fail with an error rather than
+// being read into memory, bounding a malicious server's ability to OOM the
+// client. A non-positive value restores the default (DefaultMaxResponseBytes).
+func WithMaxResponseBytes(n int64) HTTPTransportOption {
+	return func(o *httpTransportOptions) { o.maxResponseBytes = n }
+}
+
 // NewHTTPTransport constructs a transport that POSTs JSON-RPC
 // requests to the supplied base URL. The base URL must include a
 // scheme (http or https) and host; the transport appends "/mcp" by
@@ -131,11 +149,15 @@ func NewHTTPTransport(baseURL string, opts ...HTTPTransportOption) (*HTTPTranspo
 	}
 
 	options := httpTransportOptions{
-		timeout:  30 * time.Second,
-		endpoint: "/mcp",
+		timeout:          30 * time.Second,
+		endpoint:         "/mcp",
+		maxResponseBytes: DefaultMaxResponseBytes,
 	}
 	for _, o := range opts {
 		o(&options)
+	}
+	if options.maxResponseBytes <= 0 {
+		options.maxResponseBytes = DefaultMaxResponseBytes
 	}
 
 	endpoint := joinURL(u, options.endpoint)
@@ -155,10 +177,11 @@ func NewHTTPTransport(baseURL string, opts ...HTTPTransportOption) (*HTTPTranspo
 	headers.Set("Accept", "application/json, text/event-stream")
 
 	return &HTTPTransport{
-		endpoint:   endpoint,
-		httpClient: client,
-		headers:    headers,
-		clientID:   newClientID(),
+		endpoint:         endpoint,
+		httpClient:       client,
+		headers:          headers,
+		clientID:         newClientID(),
+		maxResponseBytes: options.maxResponseBytes,
 	}, nil
 }
 
@@ -182,9 +205,30 @@ func buildHTTPClient(o httpTransportOptions) *http.Client {
 		}
 	}
 	return &http.Client{
-		Timeout:   o.timeout,
-		Transport: tr,
+		Timeout:       o.timeout,
+		Transport:     tr,
+		CheckRedirect: refuseCrossHostRedirect,
 	}
+}
+
+// refuseCrossHostRedirect blocks redirects that change host. WithHTTPHeader is
+// the auth hook (e.g. X-API-Key); Go only strips Authorization/Cookie on a
+// cross-host redirect, not arbitrary custom headers, so following a
+// server-supplied 3xx to another host would leak those credentials to an
+// attacker. Same-host redirects (path/scheme upgrades) remain allowed, capped
+// at Go's default of 10 hops. Only applies to the transport's built-in client;
+// a client supplied via WithHTTPClient keeps its own CheckRedirect.
+func refuseCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if req.URL.Host != via[0].URL.Host {
+		return fmt.Errorf("mcp-go/client: refusing cross-host redirect from %q to %q", via[0].URL.Host, req.URL.Host)
+	}
+	if len(via) >= 10 {
+		return errors.New("mcp-go/client: stopped after 10 redirects")
+	}
+	return nil
 }
 
 func joinURL(base *url.URL, path string) string {
@@ -233,9 +277,15 @@ func (t *HTTPTransport) Send(ctx context.Context, req *protocol.Request) (*proto
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	// Bound the read: an untrusted server must not be able to stream an
+	// unbounded body and OOM the client. Read one byte past the cap so an
+	// exactly-at-cap body still succeeds while an over-cap body is detected.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, t.maxResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(respBody)) > t.maxResponseBytes {
+		return nil, fmt.Errorf("mcp-go/client: response exceeds %d byte limit", t.maxResponseBytes)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -271,12 +321,14 @@ func (t *HTTPTransport) Send(ctx context.Context, req *protocol.Request) (*proto
 }
 
 // responseFromSSE extracts the JSON-RPC response from an SSE body. It scans
-// `data:` frames (concatenating multi-line data per event) and returns the first
-// frame that decodes to a Response matching the request id (or, failing an id
-// match, the first frame that carries a result/error).
+// `data:` frames (concatenating multi-line data per event) and returns the
+// frame whose id matches the request id. A mismatched id is never accepted as
+// the response: correlating an awaited request with an unrelated server frame
+// would let a server answer request A with the result meant for B. When the
+// request carried no id (want == ""), correlation is impossible, so the first
+// result/error frame is accepted.
 func responseFromSSE(body []byte, reqID json.RawMessage) (*protocol.Response, error) {
 	want := strings.TrimSpace(string(reqID))
-	var fallback *protocol.Response
 	var data strings.Builder
 	flush := func() (*protocol.Response, bool) {
 		defer data.Reset()
@@ -291,12 +343,12 @@ func responseFromSSE(body []byte, reqID json.RawMessage) (*protocol.Response, er
 		if r.Result == nil && r.Error == nil {
 			return nil, false
 		}
-		if want != "" && strings.TrimSpace(string(r.ID)) == want {
+		if want == "" {
+			// No id to correlate on: accept the first usable frame.
 			return &r, true
 		}
-		if fallback == nil {
-			rr := r
-			fallback = &rr
+		if strings.TrimSpace(string(r.ID)) == want {
+			return &r, true
 		}
 		return nil, false
 	}
@@ -314,8 +366,8 @@ func responseFromSSE(body []byte, reqID json.RawMessage) (*protocol.Response, er
 	if r, ok := flush(); ok {
 		return r, nil
 	}
-	if fallback != nil {
-		return fallback, nil
+	if want != "" {
+		return nil, fmt.Errorf("no JSON-RPC response matching id %s in SSE stream", want)
 	}
 	return nil, fmt.Errorf("no JSON-RPC response in SSE stream")
 }

--- a/client/http_streamable_test.go
+++ b/client/http_streamable_test.go
@@ -67,6 +67,45 @@ func TestHTTPTransportStreamableSSE(t *testing.T) {
 	}
 }
 
+// A server must not be able to answer an awaited request with an SSE frame
+// carrying a different id: that would let it deliver B's result as A's response.
+func TestResponseFromSSE_MismatchedIDRejected(t *testing.T) {
+	body := "data: {\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"ok\":true}}\n\n"
+	if _, err := responseFromSSE([]byte(body), json.RawMessage("1")); err == nil {
+		t.Fatal("expected error for id mismatch, got nil (mismatched frame accepted)")
+	}
+}
+
+// The correct frame must be selected even when other-id frames precede it.
+func TestResponseFromSSE_MatchingIDSelected(t *testing.T) {
+	body := "data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"n\":2}}\n\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"n\":1}}\n\n"
+	resp, err := responseFromSSE([]byte(body), json.RawMessage("1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(resp.ID)) != "1" {
+		t.Fatalf("selected id %s, want 1", resp.ID)
+	}
+}
+
+// A mismatched-id SSE frame must surface as a Send error, not a wrong response.
+func TestHTTPTransport_SSEMismatchedIDSendError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Client will await id 1; server answers with id 42.
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"id\":42,\"result\":{\"ok\":true}}\n\n")
+	}))
+	defer srv.Close()
+
+	tr, _ := NewHTTPTransport(srv.URL, WithEndpointPath(""))
+	_, err := tr.Send(context.Background(), &protocol.Request{JSONRPC: jsonrpcVersion, ID: json.RawMessage("1"), Method: "x"})
+	if err == nil {
+		t.Fatal("expected error for mismatched SSE id, got nil")
+	}
+}
+
 // A plain-JSON server still works (back-compat).
 func TestHTTPTransportPlainJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -356,5 +357,126 @@ func TestHTTPTransport_EndpointPathOverride(t *testing.T) {
 	defer func() { _ = tr.Close() }()
 	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "ping")); err != nil {
 		t.Fatalf("Send: %v", err)
+	}
+}
+
+// A malicious server must not be able to OOM the client by streaming an
+// unbounded body: the transport caps how many bytes it reads and errors past it.
+func TestHTTPTransport_OversizedResponseCapped(t *testing.T) {
+	big := strings.Repeat("a", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"data":%q}}`, big)
+	}))
+	defer srv.Close()
+
+	tr, err := client.NewHTTPTransport(srv.URL, client.WithMaxResponseBytes(256))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+
+	_, err = tr.Send(context.Background(), mkRequest(t, 1, "x"))
+	if err == nil {
+		t.Fatal("expected oversized response to be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %v, want a size-limit error", err)
+	}
+}
+
+// A response at or below the cap still succeeds (boundary not over-rejected).
+func TestHTTPTransport_ResponseWithinCapSucceeds(t *testing.T) {
+	srv := &echoServer{
+		response: map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"ok": true}},
+	}
+	ts := httptest.NewServer(srv.handler(t))
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL, client.WithMaxResponseBytes(64*1024))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "x")); err != nil {
+		t.Fatalf("Send within cap: %v", err)
+	}
+}
+
+// A server-supplied redirect to another host must not forward the caller's
+// custom auth header (WithHTTPHeader is the auth hook; Go only strips
+// Authorization/Cookie cross-host). The transport refuses the cross-host hop.
+func TestHTTPTransport_RefusesCrossHostRedirect(t *testing.T) {
+	var mu sync.Mutex
+	attackerCalled := false
+	leakedKey := ""
+
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attackerCalled = true
+		leakedKey = r.Header.Get("X-API-Key")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/mcp", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	tr, err := client.NewHTTPTransport(origin.URL, client.WithHTTPHeader("X-API-Key", "s3cret"))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+
+	_, err = tr.Send(context.Background(), mkRequest(t, 1, "x"))
+	if err == nil {
+		t.Fatal("expected cross-host redirect to be refused, got nil")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attackerCalled {
+		t.Fatalf("attacker host received the request; custom auth header leaked: %q", leakedKey)
+	}
+}
+
+// A same-host redirect (e.g. path change) is still followed, and the custom
+// header is forwarded to the same host as expected.
+func TestHTTPTransport_AllowsSameHostRedirect(t *testing.T) {
+	var mu sync.Mutex
+	gotKeyAtFinal := ""
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/final", http.StatusTemporaryRedirect)
+	})
+	mux.HandleFunc("/final", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotKeyAtFinal = r.Header.Get("X-API-Key")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	tr, err := client.NewHTTPTransport(ts.URL, client.WithHTTPHeader("X-API-Key", "s3cret"))
+	if err != nil {
+		t.Fatalf("NewHTTPTransport: %v", err)
+	}
+	defer func() { _ = tr.Close() }()
+
+	if _, err := tr.Send(context.Background(), mkRequest(t, 1, "x")); err != nil {
+		t.Fatalf("same-host redirect Send: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotKeyAtFinal != "s3cret" {
+		t.Fatalf("same-host redirect target key = %q, want s3cret", gotKeyAtFinal)
 	}
 }

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -4,6 +4,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -172,7 +173,13 @@ func (t *StdioTransport) readResponses() {
 	for {
 		line, err := t.framer.ReadMessage()
 		if err != nil {
-			return // EOF or read error: stop dispatching.
+			if errors.Is(err, transport.ErrFrameTooLarge) {
+				// A single over-cap frame is recoverable: the framer already
+				// drained it. Skip it and keep the read goroutine alive so
+				// pending and future Sends are not orphaned forever.
+				continue
+			}
+			return // EOF or genuine read error: stop dispatching.
 		}
 
 		var resp protocol.Response

--- a/middleware/ratelimit.go
+++ b/middleware/ratelimit.go
@@ -9,19 +9,42 @@ import (
 	"go.klarlabs.de/mcp/protocol"
 )
 
+// clientIDKey carries a per-client identifier used as the default rate-limit
+// bucket key. Transports/servers can populate it via ContextWithClientID so
+// RateLimit isolates clients without any extra configuration.
+const clientIDKey contextKey = "clientID"
+
+// ContextWithClientID attaches a per-client identifier to the context. RateLimit
+// uses it as the default bucket key so one client cannot exhaust another's
+// budget. Wire this from your transport (e.g. from an authenticated principal or
+// connection id) to get per-client limiting out of the box.
+func ContextWithClientID(ctx context.Context, clientID string) context.Context {
+	return context.WithValue(ctx, clientIDKey, clientID)
+}
+
+// ClientIDFromContext returns the per-client identifier set by
+// ContextWithClientID, or "" when none is present.
+func ClientIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(clientIDKey).(string)
+	return id
+}
+
 // RateLimitOption configures the rate limiter.
 type RateLimitOption func(*rateLimitConfig)
 
 type rateLimitConfig struct {
-	keyFunc func(*protocol.Request) string
-	logger  Logger
+	// keyFn derives the bucket key from the request context and payload. It is
+	// the single internal hook; WithRateLimitKeyFunc adapts the public
+	// request-only signature onto it.
+	keyFn  func(context.Context, *protocol.Request) string
+	logger Logger
 }
 
 // WithRateLimitKeyFunc sets a function to extract a rate limit key from requests.
 // This allows per-client or per-method rate limiting.
 func WithRateLimitKeyFunc(fn func(*protocol.Request) string) RateLimitOption {
 	return func(o *rateLimitConfig) {
-		o.keyFunc = fn
+		o.keyFn = func(_ context.Context, req *protocol.Request) string { return fn(req) }
 	}
 }
 
@@ -32,12 +55,26 @@ func WithRateLimitLogger(l Logger) RateLimitOption {
 	}
 }
 
-// RateLimit returns middleware that limits request rate using a token bucket algorithm.
-// The rate is specified as requests per second.
-// Burst allows short bursts above the rate limit.
+// RateLimit returns middleware that limits request rate using a token bucket
+// algorithm. The rate is specified as requests per second; burst allows short
+// bursts above the rate limit.
+//
+// Bucket key: by default RateLimit keys per client, using the identifier from
+// ContextWithClientID when present. If no client id is on the context it falls
+// back to a single shared "global" bucket — meaning one client can then consume
+// the whole budget for everyone. Wire ContextWithClientID from your transport
+// for safe per-client limiting, use RateLimitByClient to key off the request
+// payload, or override entirely with WithRateLimitKeyFunc.
 func RateLimit(rate int, burst int, opts ...RateLimitOption) Middleware {
 	cfg := &rateLimitConfig{
-		keyFunc: func(_ *protocol.Request) string { return "global" }, // Global by default
+		// Safe default: isolate per client when a client id is on the context,
+		// otherwise fall back to a shared bucket (documented above).
+		keyFn: func(ctx context.Context, _ *protocol.Request) string {
+			if id := ClientIDFromContext(ctx); id != "" {
+				return "client:" + id
+			}
+			return "global"
+		},
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -52,7 +89,7 @@ func RateLimit(rate int, burst int, opts ...RateLimitOption) Middleware {
 
 	return func(next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
-			key := cfg.keyFunc(req)
+			key := cfg.keyFn(ctx, req)
 
 			if !limiter.Allow(ctx, key) {
 				if cfg.logger != nil {

--- a/middleware/ratelimit_test.go
+++ b/middleware/ratelimit_test.go
@@ -282,3 +282,44 @@ func TestRateLimit_Recovery(t *testing.T) {
 		}
 	})
 }
+
+func TestRateLimit_DefaultPerClientFromContext(t *testing.T) {
+	// With a client id on the context, the default bucket key isolates clients:
+	// one client exhausting its budget must not rate-limit another.
+	m := middleware.RateLimit(1, 1)
+	handler := m(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, "ok"), nil
+	})
+	req := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "test"}
+
+	ctxA := middleware.ContextWithClientID(context.Background(), "clientA")
+	ctxB := middleware.ContextWithClientID(context.Background(), "clientB")
+
+	if _, err := handler(ctxA, req); err != nil {
+		t.Fatalf("clientA first request: %v", err)
+	}
+	// clientB is a distinct bucket and must still be allowed.
+	if _, err := handler(ctxB, req); err != nil {
+		t.Fatalf("clientB first request should be independent: %v", err)
+	}
+	// clientA's second request is over its own budget.
+	if _, err := handler(ctxA, req); err == nil {
+		t.Fatal("expected clientA to be rate limited on its own bucket")
+	}
+}
+
+func TestRateLimit_DefaultGlobalWithoutClientID(t *testing.T) {
+	// Without a client id, the documented fallback is a single global bucket.
+	m := middleware.RateLimit(1, 1)
+	handler := m(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, "ok"), nil
+	})
+	req := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "test"}
+
+	if _, err := handler(context.Background(), req); err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	if _, err := handler(context.Background(), req); err == nil {
+		t.Fatal("expected global bucket to rate limit the second request")
+	}
+}

--- a/middleware/tracing.go
+++ b/middleware/tracing.go
@@ -44,10 +44,14 @@ func TracingWithHeaders(correlationHeader, traceHeader string) Middleware {
 func TracingFromHeaders(headerNames ...string) Middleware {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			// Inbound ids are attacker-controlled: they flow into logs and
+			// downstream correlation. Adopt only well-formed values so a crafted
+			// header cannot inject newlines/control characters (log forging) or
+			// bloat the id. Malformed headers are ignored, not adopted.
 			if existing := CorrelationIDFromContext(ctx); existing == "" {
 				for _, header := range headerNames {
-					if val := getHeaderFromContext(ctx, header); val != "" {
-						ctx = ContextWithCorrelationID(ctx, val)
+					if id, ok := sanitizeTracingID(getHeaderFromContext(ctx, header)); ok {
+						ctx = ContextWithCorrelationID(ctx, id)
 						break
 					}
 				}
@@ -55,8 +59,8 @@ func TracingFromHeaders(headerNames ...string) Middleware {
 
 			if existing := TraceIDFromContext(ctx); existing == "" {
 				for _, header := range headerNames {
-					if val := getHeaderFromContext(ctx, header); val != "" {
-						ctx = ContextWithTracing(ctx, val)
+					if id, ok := sanitizeTracingID(getHeaderFromContext(ctx, header)); ok {
+						ctx = ContextWithTracing(ctx, id)
 						break
 					}
 				}
@@ -65,6 +69,32 @@ func TracingFromHeaders(headerNames ...string) Middleware {
 			return next(ctx, req)
 		}
 	}
+}
+
+// maxTracingIDLen caps the length of an adopted inbound trace/correlation id.
+const maxTracingIDLen = 128
+
+// sanitizeTracingID validates an inbound (client-supplied) trace/correlation
+// id. It accepts a non-empty value of at most maxTracingIDLen characters drawn
+// from an unreserved set (alphanumerics and '-', '_', '.', ':') so the id is
+// safe to embed in structured logs and propagate. It reports ok=false for
+// empty, over-long, or otherwise malformed values, which callers treat as
+// "no id supplied".
+func sanitizeTracingID(s string) (string, bool) {
+	if s == "" || len(s) > maxTracingIDLen {
+		return "", false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.', r == ':':
+		default:
+			return "", false
+		}
+	}
+	return s, true
 }
 
 func ContextWithTracing(ctx context.Context, traceID string) context.Context {
@@ -127,11 +157,17 @@ func FormatTracingHeaders(ctx context.Context) map[string]string {
 func ParseTracingHeaders(headers map[string]string) (correlationID, traceID string) {
 	for key, val := range headers {
 		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		// These ids are inbound and untrusted; drop malformed values rather than
+		// return them for logging/propagation.
 		if strings.EqualFold(normalizedKey, CorrelationIDHeader) {
-			correlationID = val
+			if id, ok := sanitizeTracingID(val); ok {
+				correlationID = id
+			}
 		}
 		if strings.EqualFold(normalizedKey, TraceIDHeader) {
-			traceID = val
+			if id, ok := sanitizeTracingID(val); ok {
+				traceID = id
+			}
 		}
 	}
 	return

--- a/middleware/tracing_test.go
+++ b/middleware/tracing_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"go.klarlabs.de/mcp/protocol"
@@ -79,4 +80,65 @@ func TestParseTracingHeaders(t *testing.T) {
 			t.Errorf("traceID = %q, want trace-456", traceID)
 		}
 	})
+}
+
+func TestTracingFromHeaders_SanitizesInboundIDs(t *testing.T) {
+	const header = "X-Correlation-ID"
+
+	t.Run("adopts a well-formed inbound id", func(t *testing.T) {
+		mw := TracingFromHeaders(header)
+		var got string
+		handler := mw(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			got = CorrelationIDFromContext(ctx)
+			return protocol.NewResponse(req.ID, nil), nil
+		})
+		ctx := ContextWithHeader(context.Background(), header, "abc-123_def.45")
+		handler(ctx, &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "ping"})
+		if got != "abc-123_def.45" {
+			t.Fatalf("correlation id = %q, want the sanitized inbound value", got)
+		}
+	})
+
+	t.Run("rejects a malformed inbound id (log injection)", func(t *testing.T) {
+		mw := TracingFromHeaders(header)
+		var got string
+		handler := mw(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			got = CorrelationIDFromContext(ctx)
+			return protocol.NewResponse(req.ID, nil), nil
+		})
+		// Newline + spaces would forge log lines / spoof correlation.
+		ctx := ContextWithHeader(context.Background(), header, "evil\nINJECTED admin=true")
+		handler(ctx, &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "ping"})
+		if got != "" {
+			t.Fatalf("malformed inbound id was adopted: %q", got)
+		}
+	})
+
+	t.Run("rejects an over-long inbound id", func(t *testing.T) {
+		mw := TracingFromHeaders(header)
+		var got string
+		handler := mw(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			got = CorrelationIDFromContext(ctx)
+			return protocol.NewResponse(req.ID, nil), nil
+		})
+		long := strings.Repeat("a", maxTracingIDLen+1)
+		ctx := ContextWithHeader(context.Background(), header, long)
+		handler(ctx, &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "ping"})
+		if got != "" {
+			t.Fatalf("over-long inbound id was adopted (len %d)", len(got))
+		}
+	})
+}
+
+func TestParseTracingHeaders_DropsMalformed(t *testing.T) {
+	corrID, traceID := ParseTracingHeaders(map[string]string{
+		"x-correlation-id": "bad\nvalue",
+		"X-Trace-ID":       "good-1",
+	})
+	if corrID != "" {
+		t.Fatalf("malformed correlation id passed through: %q", corrID)
+	}
+	if traceID != "good-1" {
+		t.Fatalf("well-formed trace id = %q, want good-1", traceID)
+	}
 }

--- a/transport/framer.go
+++ b/transport/framer.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"io"
 	"sync"
 )
@@ -14,6 +15,19 @@ import (
 // maximum message size.
 const maxFrameSize = 16 * 1024 * 1024
 
+// readChunk sizes the buffered reader used by ReadMessage. It is the largest
+// slice ReadMessage accumulates per underlying read; a modest value keeps the
+// common (small message) path cheap while still round-tripping messages up to
+// maxFrameSize by looping.
+const readChunk = 64 * 1024
+
+// ErrFrameTooLarge is returned by ReadMessage when a single frame exceeds
+// maxFrameSize. It is recoverable: the framer drains the remainder of the
+// oversized line so the NEXT ReadMessage resynchronizes on the following frame.
+// Read loops should treat it as "skip this message" rather than a fatal error,
+// keeping the transport alive instead of wedging on one malformed frame.
+var ErrFrameTooLarge = errors.New("mcp-go/transport: frame exceeds maximum size")
+
 // NewlineFramer reads and writes JSON-RPC messages as newline-delimited JSON
 // (one compact JSON value per line). It is the single framing primitive shared
 // by the stdio client and the stdio server so the wire format and buffering
@@ -24,7 +38,8 @@ const maxFrameSize = 16 * 1024 * 1024
 // reads are not safe for concurrent ReadMessage calls and are expected to run
 // from a single goroutine.
 type NewlineFramer struct {
-	scanner *bufio.Scanner
+	reader *bufio.Reader
+	buf    []byte // reused accumulation buffer for the current line
 
 	mu sync.Mutex
 	w  io.Writer
@@ -35,28 +50,85 @@ type NewlineFramer struct {
 func NewNewlineFramer(r io.Reader, w io.Writer) *NewlineFramer {
 	f := &NewlineFramer{w: w}
 	if r != nil {
-		sc := bufio.NewScanner(r)
-		sc.Buffer(make([]byte, 0, 64*1024), maxFrameSize)
-		f.scanner = sc
+		f.reader = bufio.NewReaderSize(r, readChunk)
 	}
 	return f
 }
 
 // ReadMessage reads one newline-delimited JSON message and returns its raw
-// bytes. It returns io.EOF when the underlying reader is exhausted. The
-// returned slice is only valid until the next ReadMessage call; callers that
-// retain it must copy.
+// bytes (without the trailing newline). It returns io.EOF when the underlying
+// reader is exhausted, and ErrFrameTooLarge when a single frame exceeds
+// maxFrameSize — in the latter case it has already drained the oversized line,
+// so a subsequent ReadMessage resynchronizes on the next frame. The returned
+// slice is only valid until the next ReadMessage call; callers that retain it
+// must copy.
 func (f *NewlineFramer) ReadMessage() ([]byte, error) {
-	if f.scanner == nil {
+	if f.reader == nil {
 		return nil, io.EOF
 	}
-	if !f.scanner.Scan() {
-		if err := f.scanner.Err(); err != nil {
+
+	f.buf = f.buf[:0]
+	overflow := false // current line already exceeded maxFrameSize; drain and skip
+
+	for {
+		chunk, err := f.reader.ReadSlice('\n')
+
+		switch {
+		case err == nil:
+			// A complete line terminated by '\n' (chunk includes it). The
+			// delimiter itself does not count toward the frame size, so measure
+			// content only (chunk always holds at least the trailing '\n').
+			if overflow || len(f.buf)+len(chunk)-1 > maxFrameSize {
+				f.buf = f.buf[:0]
+				return nil, ErrFrameTooLarge
+			}
+			f.buf = append(f.buf, chunk...)
+			return trimLineEnding(f.buf), nil
+
+		case errors.Is(err, bufio.ErrBufferFull):
+			// Partial line: the delimiter was not found within the buffer.
+			// Accumulate unless we have already overflowed, in which case we
+			// keep reading to drain the rest of the oversized line.
+			if !overflow {
+				if len(f.buf)+len(chunk) > maxFrameSize {
+					overflow = true
+					f.buf = f.buf[:0]
+				} else {
+					f.buf = append(f.buf, chunk...)
+				}
+			}
+			continue
+
+		default:
+			// io.EOF or a genuine read error. A trailing partial line without a
+			// final newline is still a valid frame (bufio.Scanner returned it),
+			// so preserve it — unless it, too, exceeds the cap.
+			if errors.Is(err, io.EOF) {
+				if overflow || len(f.buf)+len(chunk) > maxFrameSize {
+					return nil, ErrFrameTooLarge
+				}
+				if len(chunk) > 0 {
+					f.buf = append(f.buf, chunk...)
+				}
+				if len(f.buf) > 0 {
+					return trimLineEnding(f.buf), nil
+				}
+				return nil, io.EOF
+			}
 			return nil, err
 		}
-		return nil, io.EOF
 	}
-	return f.scanner.Bytes(), nil
+}
+
+// trimLineEnding drops a single trailing "\n" or "\r\n" from a framed line.
+func trimLineEnding(line []byte) []byte {
+	if n := len(line); n > 0 && line[n-1] == '\n' {
+		line = line[:n-1]
+		if n := len(line); n > 0 && line[n-1] == '\r' {
+			line = line[:n-1]
+		}
+	}
+	return line
 }
 
 // WriteMessage marshals v to compact JSON and writes it followed by a newline.

--- a/transport/framer_test.go
+++ b/transport/framer_test.go
@@ -3,11 +3,60 @@ package transport
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"sync"
 	"testing"
 )
+
+func TestNewlineFramer_OverCapFrameSkippedAndResync(t *testing.T) {
+	// A frame larger than maxFrameSize must not wedge the reader. It should
+	// surface ErrFrameTooLarge (recoverable) and then resynchronize on the next
+	// newline-delimited frame instead of dying or corrupting the stream.
+	oversized := strings.Repeat("A", maxFrameSize+1024)
+	good := `{"method":"after"}`
+	stream := oversized + "\n" + good + "\n"
+
+	r := NewNewlineFramer(strings.NewReader(stream), nil)
+
+	// First read: the oversized frame is reported as a recoverable skip.
+	if _, err := r.ReadMessage(); !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("first ReadMessage err = %v, want ErrFrameTooLarge", err)
+	}
+
+	// Second read: the reader has drained the oversized line and resynced.
+	line, err := r.ReadMessage()
+	if err != nil {
+		t.Fatalf("second ReadMessage: %v", err)
+	}
+	if string(line) != good {
+		t.Fatalf("after skip got %q, want %q", line, good)
+	}
+
+	if _, err := r.ReadMessage(); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF at end, got %v", err)
+	}
+}
+
+func TestNewlineFramer_AtCapFrameStillReads(t *testing.T) {
+	// A frame exactly at the cap must round-trip (boundary must not over-reject).
+	// Build a JSON object whose serialized length is exactly maxFrameSize.
+	prefix := `{"data":"`
+	suffix := `"}`
+	payload := prefix + strings.Repeat("x", maxFrameSize-len(prefix)-len(suffix)) + suffix
+	if len(payload) != maxFrameSize {
+		t.Fatalf("payload len = %d, want %d", len(payload), maxFrameSize)
+	}
+	r := NewNewlineFramer(strings.NewReader(payload+"\n"), nil)
+	line, err := r.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage at cap: %v", err)
+	}
+	if len(line) != maxFrameSize {
+		t.Fatalf("line len = %d, want %d", len(line), maxFrameSize)
+	}
+}
 
 func TestNewlineFramer_RoundTrip(t *testing.T) {
 	var buf bytes.Buffer

--- a/transport/stdio.go
+++ b/transport/stdio.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"sync"
 
 	"go.klarlabs.de/mcp/protocol"
 )
@@ -17,13 +16,12 @@ type Stdio struct {
 	out    io.Writer
 	errOut io.Writer
 
-	framerMu sync.Mutex
-	framer   *NewlineFramer
-	// fallback is a single write-only framer over s.out, constructed lazily and
-	// reused for every out-of-Serve write (SendNotification/writeResponse before
-	// or after Serve). Reusing one framer means all such writes share the same
-	// mutex and therefore never interleave on s.out. Guarded by framerMu.
-	fallback *NewlineFramer
+	// writer is the single write-only framer over s.out. EVERY write to s.out —
+	// Serve responses, out-of-band SendNotification, and pre/post-Serve
+	// writeResponse — goes through this one framer, so all of them share one
+	// mutex and can never interleave bytes on s.out. Reads use a separate
+	// read-only framer created per Serve call.
+	writer *NewlineFramer
 }
 
 // StdioOption configures a Stdio transport.
@@ -62,6 +60,10 @@ func NewStdio(opts ...StdioOption) *Stdio {
 		opt(s)
 	}
 
+	// Construct the single shared write framer after options settle s.out. All
+	// writes to s.out flow through it so there is exactly one write mutex.
+	s.writer = NewNewlineFramer(nil, s.out)
+
 	return s
 }
 
@@ -73,11 +75,11 @@ func (s *Stdio) Addr() string {
 // Serve starts processing requests from stdin. It frames messages as
 // newline-delimited JSON via the shared transport.NewlineFramer, the same
 // primitive the stdio client uses, so the wire format never drifts between the
-// two sides.
+// two sides. Reads use a dedicated read-only framer; all writes go through the
+// shared write framer (s.writer) so out-of-band notifications cannot interleave
+// with Serve responses.
 func (s *Stdio) Serve(ctx context.Context, handler Handler) error {
-	framer := NewNewlineFramer(s.in, s.out)
-	s.setFramer(framer)
-	defer s.setFramer(nil)
+	reader := NewNewlineFramer(s.in, nil)
 
 	// Channel for scanner results
 	lines := make(chan []byte)
@@ -85,8 +87,14 @@ func (s *Stdio) Serve(ctx context.Context, handler Handler) error {
 
 	go func() {
 		for {
-			line, err := framer.ReadMessage()
+			line, err := reader.ReadMessage()
 			if err != nil {
+				if errors.Is(err, ErrFrameTooLarge) {
+					// A single over-cap frame must not wedge the transport: the
+					// framer already drained it, so skip and keep reading.
+					s.noteSkippedFrame()
+					continue
+				}
 				if !errors.Is(err, io.EOF) {
 					scanErr <- err
 				}
@@ -119,27 +127,13 @@ func (s *Stdio) Serve(ctx context.Context, handler Handler) error {
 	}
 }
 
-func (s *Stdio) setFramer(f *NewlineFramer) {
-	s.framerMu.Lock()
-	s.framer = f
-	s.framerMu.Unlock()
-}
-
-func (s *Stdio) currentFramer() *NewlineFramer {
-	s.framerMu.Lock()
-	defer s.framerMu.Unlock()
-	if s.framer != nil {
-		return s.framer
+// noteSkippedFrame emits a best-effort diagnostic when an over-cap frame is
+// dropped. Errors are ignored: a broken stderr must not affect request serving.
+func (s *Stdio) noteSkippedFrame() {
+	if s.errOut == nil {
+		return
 	}
-	// Serve has not been called (or has returned): fall back to a single
-	// write-only framer over the configured output so SendNotification/
-	// writeResponse stay usable in tests and out-of-band sends. The fallback is
-	// cached and reused so all out-of-Serve writes share one mutex and never
-	// interleave on s.out.
-	if s.fallback == nil {
-		s.fallback = NewNewlineFramer(nil, s.out)
-	}
-	return s.fallback
+	_, _ = io.WriteString(s.errOut, "mcp-go/transport: dropped oversized stdio frame\n")
 }
 
 // SendNotification sends a JSON-RPC notification to the client.
@@ -149,7 +143,7 @@ func (s *Stdio) SendNotification(method string, params any) error {
 		return err
 	}
 
-	return s.currentFramer().WriteMessage(Notification{
+	return s.writer.WriteMessage(Notification{
 		JSONRPC: JSONRPCVersion,
 		Method:  method,
 		Params:  paramsData,
@@ -193,5 +187,5 @@ func (s *Stdio) handleLine(ctx context.Context, handler Handler, line []byte) {
 }
 
 func (s *Stdio) writeResponse(resp *protocol.Response) {
-	_ = s.currentFramer().WriteMessage(resp)
+	_ = s.writer.WriteMessage(resp)
 }

--- a/transport/stdio_test.go
+++ b/transport/stdio_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -296,6 +298,112 @@ func TestStdio_ConcurrentSendNotificationBeforeServe(t *testing.T) {
 		}
 		if n.Method != "notifications/progress" {
 			t.Fatalf("line %d method = %q, want notifications/progress", i, n.Method)
+		}
+	}
+}
+
+// TestStdio_Serve_SurvivesOversizedFrame verifies a single over-cap frame does
+// not wedge Serve: the frame is skipped and a following valid request is still
+// handled.
+func TestStdio_Serve_SurvivesOversizedFrame(t *testing.T) {
+	oversized := strings.Repeat("A", maxFrameSize+1024)
+	good, _ := json.Marshal(protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`7`),
+		Method:  "after",
+	})
+	in := bytes.NewBufferString(oversized + "\n" + string(good) + "\n")
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+
+	tr := NewStdio(WithStdin(in), WithStdout(out), WithStderr(errOut))
+	handler := HandlerFunc(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, "handled"), nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := tr.Serve(ctx, handler); err != nil {
+		t.Fatalf("Serve returned error (read loop died): %v", err)
+	}
+
+	if !strings.Contains(out.String(), `"result":"handled"`) {
+		t.Fatalf("valid request after oversized frame was not handled; out=%q", out.String())
+	}
+	if !strings.Contains(errOut.String(), "oversized") {
+		t.Fatalf("expected a dropped-frame diagnostic on stderr, got %q", errOut.String())
+	}
+}
+
+// TestStdio_ConcurrentFallbackAndServeWritesNoInterleave exercises the
+// fallback->Serve transition: out-of-band SendNotification writes must not
+// interleave with Serve's response writes on the same s.out. Every write flows
+// through one shared write framer (one mutex), so the interleave-prone sink
+// still yields only well-formed frames and -race stays clean.
+func TestStdio_ConcurrentFallbackAndServeWritesNoInterleave(t *testing.T) {
+	out := &interleaveProneWriter{}
+	pr, pw := io.Pipe()
+	tr := NewStdio(WithStdin(pr), WithStdout(out), WithStderr(io.Discard))
+
+	handler := HandlerFunc(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+		return protocol.NewResponse(req.ID, "ok"), nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- tr.Serve(ctx, handler) }()
+
+	const requests = 100
+	const notifiers = 8
+	const perNotifier = 25
+
+	// Drive Serve with requests so its response writes overlap the concurrent
+	// notification writes below.
+	go func() {
+		var in bytes.Buffer
+		for i := 0; i < requests; i++ {
+			b, _ := json.Marshal(protocol.Request{
+				JSONRPC: "2.0",
+				ID:      json.RawMessage(strconv.Itoa(i + 1)),
+				Method:  "ping",
+			})
+			in.Write(b)
+			in.WriteByte('\n')
+		}
+		_, _ = pw.Write(in.Bytes())
+		_ = pw.Close() // EOF -> Serve returns
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(notifiers)
+	for n := 0; n < notifiers; n++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perNotifier; i++ {
+				if err := tr.SendNotification("notifications/progress", map[string]int{"n": id, "seq": i}); err != nil {
+					t.Errorf("SendNotification: %v", err)
+					return
+				}
+			}
+		}(n)
+	}
+	wg.Wait()
+
+	if err := <-serveErr; err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	output := out.String()
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if got, want := len(lines), requests+notifiers*perNotifier; got != want {
+		t.Fatalf("got %d lines, want %d (interleaving splits or merges frames)", got, want)
+	}
+	for i, line := range lines {
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &probe); err != nil {
+			t.Fatalf("line %d is not a well-formed frame: %v\nline=%q", i, err, line)
 		}
 	}
 }

--- a/transport/store.go
+++ b/transport/store.go
@@ -18,22 +18,76 @@ type Store interface {
 	ListSessions(ctx context.Context) ([]string, error)
 }
 
+// DefaultMaxSessions bounds the number of entries an InMemoryStore retains by
+// default so an unbounded stream of distinct client ids cannot grow the map
+// without limit (a memory-exhaustion vector). When the store is full, storing a
+// NEW client id evicts the oldest entry (FIFO). Override via WithMaxSessions.
+const DefaultMaxSessions = 10000
+
 type InMemoryStore struct {
-	sessions map[string][]byte
-	mu       sync.RWMutex
+	mu         sync.RWMutex
+	sessions   map[string][]byte
+	order      []string // insertion order of live keys, for FIFO eviction
+	maxEntries int
 }
 
-func NewInMemoryStore() *InMemoryStore {
-	return &InMemoryStore{
-		sessions: make(map[string][]byte),
+// InMemoryStoreOption configures an InMemoryStore.
+type InMemoryStoreOption func(*InMemoryStore)
+
+// WithMaxSessions bounds the number of retained sessions. A non-positive value
+// restores the default (DefaultMaxSessions).
+func WithMaxSessions(n int) InMemoryStoreOption {
+	return func(s *InMemoryStore) {
+		if n <= 0 {
+			n = DefaultMaxSessions
+		}
+		s.maxEntries = n
 	}
+}
+
+func NewInMemoryStore(opts ...InMemoryStoreOption) *InMemoryStore {
+	s := &InMemoryStore{
+		sessions:   make(map[string][]byte),
+		maxEntries: DefaultMaxSessions,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 func (s *InMemoryStore) StoreSession(ctx context.Context, clientID string, data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.sessions[clientID] = data
+
+	// Store a copy so a later mutation of the caller's slice cannot corrupt the
+	// retained session data.
+	cp := append([]byte(nil), data...)
+
+	if _, exists := s.sessions[clientID]; exists {
+		s.sessions[clientID] = cp
+		return nil
+	}
+
+	// New key: enforce the bound before inserting, evicting the oldest entry.
+	if s.maxEntries > 0 && len(s.sessions) >= s.maxEntries {
+		s.evictOldestLocked()
+	}
+	s.sessions[clientID] = cp
+	s.order = append(s.order, clientID)
 	return nil
+}
+
+// evictOldestLocked removes the oldest live entry. Callers must hold s.mu.
+func (s *InMemoryStore) evictOldestLocked() {
+	for len(s.order) > 0 {
+		oldest := s.order[0]
+		s.order = s.order[1:]
+		if _, ok := s.sessions[oldest]; ok {
+			delete(s.sessions, oldest)
+			return
+		}
+	}
 }
 
 func (s *InMemoryStore) GetSession(ctx context.Context, clientID string) ([]byte, error) {
@@ -43,14 +97,30 @@ func (s *InMemoryStore) GetSession(ctx context.Context, clientID string) ([]byte
 	if !ok {
 		return nil, nil
 	}
-	return data, nil
+	// Return a copy: handing out the map's backing slice lets a caller mutate
+	// stored state (or race a concurrent StoreSession) through the alias.
+	return append([]byte(nil), data...), nil
 }
 
 func (s *InMemoryStore) DeleteSession(ctx context.Context, clientID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.sessions, clientID)
+	if _, ok := s.sessions[clientID]; ok {
+		delete(s.sessions, clientID)
+		s.removeFromOrderLocked(clientID)
+	}
 	return nil
+}
+
+// removeFromOrderLocked drops clientID from the insertion-order list. Callers
+// must hold s.mu.
+func (s *InMemoryStore) removeFromOrderLocked(clientID string) {
+	for i, id := range s.order {
+		if id == clientID {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			return
+		}
+	}
 }
 
 func (s *InMemoryStore) ListSessions(ctx context.Context) ([]string, error) {

--- a/transport/store_test.go
+++ b/transport/store_test.go
@@ -132,3 +132,71 @@ func TestInMemoryStore(t *testing.T) {
 		}
 	})
 }
+
+func TestInMemoryStore_GetSessionReturnsCopy(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	orig := []byte(`{"secret":"a"}`)
+	if err := store.StoreSession(ctx, "c1", orig); err != nil {
+		t.Fatalf("StoreSession: %v", err)
+	}
+
+	// Mutating the caller's slice after storing must not change stored state.
+	orig[2] = 'X'
+
+	got, err := store.GetSession(ctx, "c1")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if string(got) != `{"secret":"a"}` {
+		t.Fatalf("stored data mutated via caller alias: got %q", got)
+	}
+
+	// Mutating the returned slice must not corrupt stored state either.
+	got[2] = 'Z'
+	again, _ := store.GetSession(ctx, "c1")
+	if string(again) != `{"secret":"a"}` {
+		t.Fatalf("stored data mutated via returned alias: got %q", again)
+	}
+}
+
+func TestInMemoryStore_BoundedEviction(t *testing.T) {
+	store := NewInMemoryStore(WithMaxSessions(3))
+	ctx := context.Background()
+
+	for _, id := range []string{"a", "b", "c"} {
+		if err := store.StoreSession(ctx, id, []byte(id)); err != nil {
+			t.Fatalf("StoreSession %s: %v", id, err)
+		}
+	}
+	// Inserting a 4th new key evicts the oldest ("a").
+	if err := store.StoreSession(ctx, "d", []byte("d")); err != nil {
+		t.Fatalf("StoreSession d: %v", err)
+	}
+
+	ids, _ := store.ListSessions(ctx)
+	if len(ids) != 3 {
+		t.Fatalf("len(sessions) = %d, want 3 (bound not enforced)", len(ids))
+	}
+	if got, _ := store.GetSession(ctx, "a"); got != nil {
+		t.Fatalf("oldest entry 'a' not evicted: %q", got)
+	}
+	for _, id := range []string{"b", "c", "d"} {
+		if got, _ := store.GetSession(ctx, id); string(got) != id {
+			t.Fatalf("entry %q = %q, want retained", id, got)
+		}
+	}
+
+	// Updating an existing key must not grow the store or evict.
+	if err := store.StoreSession(ctx, "b", []byte("b2")); err != nil {
+		t.Fatalf("update b: %v", err)
+	}
+	ids, _ = store.ListSessions(ctx)
+	if len(ids) != 3 {
+		t.Fatalf("after update len = %d, want 3", len(ids))
+	}
+	if got, _ := store.GetSession(ctx, "b"); string(got) != "b2" {
+		t.Fatalf("b = %q, want b2", got)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens the stdio framing, in-memory session store, HTTP client, and observability middleware against correctness and abuse issues from deep review. TDD throughout; all pre-commit gates (go vet, golangci-lint 0 issues, build, test) and `go test -race ./transport/... ./client/... ./middleware/...` are green.

## Fixes

| # | Sev | Fix |
|---|-----|-----|
| 1 | MED | **Over-cap frame no longer wedges the transport.** `framer.ReadMessage` drains an oversized (>16MB) line and returns a recoverable `ErrFrameTooLarge` sentinel, resynchronizing on the next frame. Replaced `bufio.Scanner` (cannot resync) with a `bufio.Reader` accumulator. Server `Serve` and client `readResponses` skip the frame and keep their read loops alive. |
| 2 | MED | **Single write mutex for stdio.** All writes to `s.out` — Serve responses and out-of-band `SendNotification`/`writeResponse` — now flow through one shared write framer, so a fallback write can never interleave bytes with a Serve response. |
| 3 | LOW | **`InMemoryStore` copy + bound.** `GetSession` returns a copy (no backing-slice alias), `StoreSession` copies input, and the store is bounded (`DefaultMaxSessions`, FIFO eviction, `WithMaxSessions`). |
| 4 | HIGH | **Bounded HTTP response read.** Client reads via `io.LimitReader` (`WithMaxResponseBytes`, default 16MB); an over-cap body errors instead of OOMing the client. |
| 5 | LOW | **Refuse cross-host redirects.** The built-in client's `CheckRedirect` blocks host-changing redirects so a custom auth header (e.g. `X-API-Key`) can't be harvested by an attacker host. Same-host redirects still work. |
| 6 | LOW | **Exact SSE id correlation.** `responseFromSSE` requires an exact id match; a mismatched-id frame is an error, never accepted as the response (only the no-id case accepts the first frame). |
| 7 | LOW | **Sanitize inbound trace ids.** `TracingFromHeaders`/`ParseTracingHeaders` validate charset + max length before adopting client-supplied ids, preventing log injection / correlation spoofing. `Tracing()` (generated ids) is unchanged. |
| 8 | MED | **Per-client rate-limit default.** `RateLimit`'s default bucket key is per-client when a client id is on the context (`ContextWithClientID`), falling back to a documented global bucket otherwise. |

## Tests

Over-cap frame skipped + read loop survives + resyncs; at-cap frame still reads; concurrent fallback+Serve writes don't interleave (under `-race`); `GetSession` returns a copy + bounded eviction; oversized HTTP response capped; cross-host redirect refused (header not leaked) + same-host allowed; mismatched-id SSE rejected; malformed/over-long trace header dropped; per-client vs global rate-limit default.

## Scope

Touches only `transport/framer.go`, `transport/stdio.go`, `transport/store.go`, `client/*.go`, `middleware/tracing.go`, `middleware/ratelimit.go` and their tests.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
