### PR TITLE
fix(server): bound task registry, wire cancellation, stop error-detail leak

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -33,6 +33,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"go.klarlabs.de/mcp/middleware"
@@ -617,6 +618,9 @@ type requestHandler struct {
 	toolFilter     ToolFilterFunc
 	resourceFilter ResourceFilterFunc
 	promptFilter   PromptFilterFunc
+	// cancellations tracks in-flight requests so an incoming
+	// notifications/cancelled can actually cancel a running handler's context.
+	cancellations *server.CancellationManager
 }
 
 func newRequestHandler(srv *Server, opts ...ServeOption) *requestHandler {
@@ -630,6 +634,7 @@ func newRequestHandler(srv *Server, opts ...ServeOption) *requestHandler {
 		toolFilter:     options.toolFilter,
 		resourceFilter: options.resourceFilter,
 		promptFilter:   options.promptFilter,
+		cancellations:  server.NewCancellationManager(),
 	}
 
 	// Build the handler function
@@ -676,14 +681,66 @@ func (h *requestHandler) methodHandlers() map[string]func(context.Context, *prot
 		protocol.MethodPromptsList:          h.handlePromptsList,
 		protocol.MethodPromptsGet:           h.handlePromptsGet,
 		protocol.MethodPing:                 h.handlePing,
+		protocol.MethodCancelled:            h.handleCancelled,
 	}
 }
 
 func (h *requestHandler) handle(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	// Track in-flight requests (those with an ID) so a notifications/cancelled
+	// for this ID cancels the derived context mid-flight. The deferred cancel
+	// also untracks on normal completion. Notifications have no ID and are not
+	// tracked (a cancelled notification must not try to cancel itself).
+	if !req.IsNotification() {
+		var cancel context.CancelFunc
+		ctx, cancel = h.cancellations.Track(ctx, string(req.ID))
+		defer cancel()
+	}
+
+	resp, err := h.dispatch(ctx, req)
+	if err != nil {
+		return nil, h.publicError(req, err)
+	}
+	return resp, nil
+}
+
+func (h *requestHandler) dispatch(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 	if handler, ok := h.methodHandlers()[req.Method]; ok {
 		return handler(ctx, req)
 	}
 	return nil, protocol.NewMethodNotFound(req.Method)
+}
+
+// publicError is the single chokepoint that decides what error detail reaches
+// the peer. Deliberate protocol errors (InvalidParams, MethodNotFound,
+// NotFound, …) carry an intended-public message and pass through verbatim. Any
+// other error is an internal failure whose message may embed paths, state, or
+// secret-adjacent detail: it is logged server-side (stderr — never stdout,
+// which would corrupt stdio framing) and replaced with a generic -32603 so
+// nothing leaks. Because this sits at the shared handler boundary it covers
+// every transport uniformly.
+func (h *requestHandler) publicError(req *protocol.Request, err error) error {
+	var mcpErr *protocol.Error
+	if errors.As(err, &mcpErr) {
+		return mcpErr
+	}
+	method := ""
+	if req != nil {
+		method = req.Method
+	}
+	log.Printf("mcp: internal error handling %q: %v", method, err)
+	return protocol.NewInternalError("internal error")
+}
+
+// handleCancelled processes a notifications/cancelled by cancelling the tracked
+// in-flight request with the given id. It is a notification, so it returns no
+// response body.
+func (h *requestHandler) handleCancelled(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	var notif server.CancelledNotification
+	if err := json.Unmarshal(req.Params, &notif); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	h.cancellations.Cancel(string(notif.RequestID))
+	return nil, nil
 }
 
 func (h *requestHandler) handleInitialize(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
@@ -818,15 +875,16 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 		}
 	}
 
-	// Execute tool
+	// Execute tool. A deliberate protocol error passes through verbatim; any
+	// other error is returned raw so publicError can sanitize it (no leaking
+	// internal detail to the peer).
 	result, err := tool.Execute(ctx, params.Arguments)
 	if err != nil {
-		// Check if it's already an MCP error
 		var mcpErr *protocol.Error
 		if errors.As(err, &mcpErr) {
 			return nil, mcpErr
 		}
-		return nil, protocol.NewInternalError(err.Error())
+		return nil, err
 	}
 
 	// Format result based on type
@@ -965,14 +1023,15 @@ func (h *requestHandler) handleResourcesRead(ctx context.Context, req *protocol.
 		return nil, protocol.NewNotFound("resource not found: " + params.URI)
 	}
 
-	// Read resource
+	// Read resource. Protocol errors pass through; other errors are returned
+	// raw for publicError to sanitize.
 	content, err := resource.Read(ctx, params.URI)
 	if err != nil {
 		var mcpErr *protocol.Error
 		if errors.As(err, &mcpErr) {
 			return nil, mcpErr
 		}
-		return nil, protocol.NewInternalError(err.Error())
+		return nil, err
 	}
 
 	result := map[string]any{
@@ -1093,14 +1152,16 @@ func (h *requestHandler) handlePromptsGet(ctx context.Context, req *protocol.Req
 		return nil, protocol.NewNotFound("prompt not found: " + params.Name)
 	}
 
-	// Execute prompt
+	// Execute prompt. Protocol errors pass through; other errors are returned
+	// raw for publicError to sanitize (a handler failure is internal, not a
+	// client params error).
 	result, err := prompt.Get(ctx, params.Arguments)
 	if err != nil {
 		var mcpErr *protocol.Error
 		if errors.As(err, &mcpErr) {
 			return nil, mcpErr
 		}
-		return nil, protocol.NewInvalidParams(err.Error())
+		return nil, err
 	}
 
 	response := map[string]any{

--- a/mcp_defaults_test.go
+++ b/mcp_defaults_test.go
@@ -1,10 +1,13 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"strings"
 	"testing"
+	"time"
 
 	"go.klarlabs.de/mcp/protocol"
 )
@@ -73,3 +76,102 @@ func TestRecoverIsOnByDefault(t *testing.T) {
 		t.Fatalf("expected a generic internal error, got: %v", err)
 	}
 }
+
+// TestRawHandlerErrorIsSanitized proves that a handler returning a raw error
+// with secret detail yields a GENERIC internal error to the peer, while the
+// detail is logged server-side. This is the non-panic counterpart to
+// TestRecoverIsOnByDefault.
+func TestRawHandlerErrorIsSanitized(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	const secret = "failed reading /etc/shadow: permission denied"
+	type Input struct{}
+	srv.Tool("leaky").Handler(func(_ Input) (string, error) {
+		return "", errorsNew(secret)
+	})
+
+	// Capture server-side log output.
+	var logBuf bytes.Buffer
+	restore := log.Writer()
+	flags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(restore)
+		log.SetFlags(flags)
+	}()
+
+	handler := newRequestHandler(srv)
+	req := &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"leaky","arguments":{}}`),
+	}
+
+	_, err := handler.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected an error from a failing handler, got nil")
+	}
+	if strings.Contains(err.Error(), "shadow") || strings.Contains(err.Error(), "permission") {
+		t.Fatalf("internal detail leaked to client: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "internal error") {
+		t.Fatalf("expected a generic internal error, got: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "shadow") {
+		t.Fatalf("expected the internal detail to be logged server-side, log = %q", logBuf.String())
+	}
+}
+
+// TestCancelledNotificationCancelsInFlight proves that an incoming
+// notifications/cancelled cancels the context of a matching in-flight request.
+func TestCancelledNotificationCancelsInFlight(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	started := make(chan struct{})
+	type Input struct{}
+	srv.Tool("block").Handler(func(ctx context.Context, _ Input) (string, error) {
+		close(started)
+		<-ctx.Done() // unblocks only when the request context is canceled
+		return "", ctx.Err()
+	})
+
+	handler := newRequestHandler(srv)
+
+	returned := make(chan struct{})
+	go func() {
+		_, _ = handler.HandleRequest(context.Background(), &protocol.Request{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage(`1`),
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"block","arguments":{}}`),
+		})
+		close(returned)
+	}()
+
+	<-started
+
+	// Deliver notifications/cancelled for request id 1 (a notification: no ID).
+	if _, err := handler.HandleRequest(context.Background(), &protocol.Request{
+		JSONRPC: "2.0",
+		Method:  "notifications/cancelled",
+		Params:  json.RawMessage(`{"requestId":1,"reason":"user requested"}`),
+	}); err != nil {
+		t.Fatalf("cancelled notification returned error: %v", err)
+	}
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notifications/cancelled did not cancel the in-flight request")
+	}
+}
+
+// errorsNew returns a plain (non-protocol) error carrying the given message,
+// exercising the sanitization path for library-user handler failures.
+func errorsNew(msg string) error { return &plainError{msg} }
+
+type plainError struct{ msg string }
+
+func (e *plainError) Error() string { return e.msg }

--- a/server/resource_subscriptions.go
+++ b/server/resource_subscriptions.go
@@ -21,13 +21,19 @@ type ResourceNotifier interface {
 // resources/subscribe request handlers and an out-of-band watcher that calls
 // NotifyResourceUpdated.
 type resourceSubscriptions struct {
-	mu       sync.RWMutex
-	byURI    map[string]map[string]struct{} // uri -> set of client ids
-	notifier ResourceNotifier
+	mu           sync.RWMutex
+	byURI        map[string]map[string]struct{} // uri -> set of client ids
+	perClient    map[string]int                 // client id -> subscription count
+	maxPerClient int
+	notifier     ResourceNotifier
 }
 
 func newResourceSubscriptions() *resourceSubscriptions {
-	return &resourceSubscriptions{byURI: make(map[string]map[string]struct{})}
+	return &resourceSubscriptions{
+		byURI:        make(map[string]map[string]struct{}),
+		perClient:    make(map[string]int),
+		maxPerClient: defaultMaxSubscriptionsPerClient,
+	}
 }
 
 func (r *resourceSubscriptions) setNotifier(n ResourceNotifier) {
@@ -36,26 +42,53 @@ func (r *resourceSubscriptions) setNotifier(n ResourceNotifier) {
 	r.notifier = n
 }
 
-func (r *resourceSubscriptions) subscribe(clientID, uri string) {
+// subscribe records a client's interest in a URI. It returns false (rejecting
+// the subscription) when the client is already at its per-client cap — the
+// registry is client-controlled and must stay bounded (Secure By Default).
+// Re-subscribing to an existing URI is idempotent and always accepted.
+func (r *resourceSubscriptions) subscribe(clientID, uri string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if set := r.byURI[uri]; set != nil {
+		if _, ok := set[clientID]; ok {
+			return true // already subscribed — idempotent
+		}
+	}
+	if r.perClient[clientID] >= r.maxPerClient {
+		return false
+	}
 	set := r.byURI[uri]
 	if set == nil {
 		set = make(map[string]struct{})
 		r.byURI[uri] = set
 	}
 	set[clientID] = struct{}{}
+	r.perClient[clientID]++
+	return true
 }
 
 func (r *resourceSubscriptions) unsubscribe(clientID, uri string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if set := r.byURI[uri]; set != nil {
-		delete(set, clientID)
+		if _, ok := set[clientID]; ok {
+			delete(set, clientID)
+			r.decClientLocked(clientID)
+		}
 		if len(set) == 0 {
 			delete(r.byURI, uri)
 		}
 	}
+}
+
+// decClientLocked decrements a client's subscription count, dropping the entry
+// at zero. Caller must hold r.mu.
+func (r *resourceSubscriptions) decClientLocked(clientID string) {
+	if r.perClient[clientID] <= 1 {
+		delete(r.perClient, clientID)
+		return
+	}
+	r.perClient[clientID]--
 }
 
 // removeClient drops every subscription a client held — called when its
@@ -69,6 +102,7 @@ func (r *resourceSubscriptions) removeClient(clientID string) {
 			delete(r.byURI, uri)
 		}
 	}
+	delete(r.perClient, clientID)
 }
 
 func (r *resourceSubscriptions) subscribers(uri string) []string {

--- a/server/resource_subscriptions_test.go
+++ b/server/resource_subscriptions_test.go
@@ -120,3 +120,38 @@ func TestResourceSubscriptionsJoinsDeliveryErrors(t *testing.T) {
 		t.Errorf("got %d notifications, want 2 (both attempted)", len(notifier.calls))
 	}
 }
+
+// TestResourceSubscriptionsPerClientCap proves the wired resource-subscription
+// registry enforces a per-client cap so a single client cannot grow it without
+// bound, and that unsubscribe / removeClient free the client's budget.
+func TestResourceSubscriptionsPerClientCap(t *testing.T) {
+	r := newResourceSubscriptions()
+	r.maxPerClient = 2
+
+	if !r.subscribe("c1", "u1") {
+		t.Fatal("u1 should be accepted")
+	}
+	if !r.subscribe("c1", "u2") {
+		t.Fatal("u2 should be accepted")
+	}
+	if r.subscribe("c1", "u3") {
+		t.Fatal("u3 should be rejected once the client is at its cap")
+	}
+
+	// Idempotent re-subscribe is always accepted.
+	if !r.subscribe("c1", "u1") {
+		t.Fatal("re-subscribing to u1 should be accepted")
+	}
+
+	// Unsubscribing frees a slot.
+	r.unsubscribe("c1", "u1")
+	if !r.subscribe("c1", "u3") {
+		t.Fatal("after unsubscribe, u3 should be accepted")
+	}
+
+	// removeClient resets the client's budget entirely.
+	r.removeClient("c1")
+	if !r.subscribe("c1", "u4") {
+		t.Fatal("after removeClient, a fresh subscription should be accepted")
+	}
+}

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -4,6 +4,11 @@ import (
 	"sync"
 )
 
+// defaultMaxSubscriptionsPerClient bounds how many distinct resource URIs a
+// single client may subscribe to. Without a cap the subscription map is an
+// unbounded, client-controlled allocation — a denial-of-service vector.
+const defaultMaxSubscriptionsPerClient = 1000
+
 // SubscribeRequest is sent by the client to subscribe to resource updates.
 type SubscribeRequest struct {
 	URI string `json:"uri"`
@@ -23,24 +28,59 @@ type ResourceUpdatedNotification struct {
 type SubscriptionManager struct {
 	mu            sync.RWMutex
 	subscriptions map[string]map[string]struct{} // URI -> set of client IDs
+	perClient     map[string]int                 // client ID -> subscription count
+	maxPerClient  int
 }
 
-// NewSubscriptionManager creates a new subscription manager.
-func NewSubscriptionManager() *SubscriptionManager {
-	return &SubscriptionManager{
-		subscriptions: make(map[string]map[string]struct{}),
+// SubscriptionManagerOption configures a SubscriptionManager.
+type SubscriptionManagerOption func(*SubscriptionManager)
+
+// WithMaxSubscriptionsPerClient sets the per-client subscription cap. Values
+// <= 0 keep the default.
+func WithMaxSubscriptionsPerClient(n int) SubscriptionManagerOption {
+	return func(m *SubscriptionManager) {
+		if n > 0 {
+			m.maxPerClient = n
+		}
 	}
 }
 
-// Subscribe adds a client subscription for a resource URI.
-func (m *SubscriptionManager) Subscribe(clientID, uri string) {
+// NewSubscriptionManager creates a new subscription manager.
+func NewSubscriptionManager(opts ...SubscriptionManagerOption) *SubscriptionManager {
+	m := &SubscriptionManager{
+		subscriptions: make(map[string]map[string]struct{}),
+		perClient:     make(map[string]int),
+		maxPerClient:  defaultMaxSubscriptionsPerClient,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// Subscribe adds a client subscription for a resource URI. It returns false
+// (rejecting the subscription) when the client is already at its per-client
+// cap. Re-subscribing to an existing URI is idempotent and always accepted.
+func (m *SubscriptionManager) Subscribe(clientID, uri string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if clients := m.subscriptions[uri]; clients != nil {
+		if _, ok := clients[clientID]; ok {
+			return true // already subscribed — idempotent
+		}
+	}
+
+	if m.perClient[clientID] >= m.maxPerClient {
+		return false
+	}
 
 	if m.subscriptions[uri] == nil {
 		m.subscriptions[uri] = make(map[string]struct{})
 	}
 	m.subscriptions[uri][clientID] = struct{}{}
+	m.perClient[clientID]++
+	return true
 }
 
 // Unsubscribe removes a client subscription for a resource URI.
@@ -49,7 +89,10 @@ func (m *SubscriptionManager) Unsubscribe(clientID, uri string) {
 	defer m.mu.Unlock()
 
 	if clients, ok := m.subscriptions[uri]; ok {
-		delete(clients, clientID)
+		if _, subscribed := clients[clientID]; subscribed {
+			delete(clients, clientID)
+			m.decClientLocked(clientID)
+		}
 		if len(clients) == 0 {
 			delete(m.subscriptions, uri)
 		}
@@ -67,6 +110,17 @@ func (m *SubscriptionManager) UnsubscribeAll(clientID string) {
 			delete(m.subscriptions, uri)
 		}
 	}
+	delete(m.perClient, clientID)
+}
+
+// decClientLocked decrements a client's subscription count, dropping the entry
+// at zero. Caller must hold m.mu.
+func (m *SubscriptionManager) decClientLocked(clientID string) {
+	if m.perClient[clientID] <= 1 {
+		delete(m.perClient, clientID)
+		return
+	}
+	m.perClient[clientID]--
 }
 
 // Subscribers returns the client IDs subscribed to a resource URI.

--- a/server/subscriptions_test.go
+++ b/server/subscriptions_test.go
@@ -182,3 +182,36 @@ func TestResourceUpdatedNotification(t *testing.T) {
 		t.Errorf("expected URI 'file:///config.json', got %q", notification.URI)
 	}
 }
+
+// TestSubscriptionManagerPerClientCap proves the per-client subscription cap is
+// enforced: subscriptions beyond the cap are rejected, re-subscribing is
+// idempotent, other clients are unaffected, and unsubscribing frees a slot.
+func TestSubscriptionManagerPerClientCap(t *testing.T) {
+	m := NewSubscriptionManager(WithMaxSubscriptionsPerClient(2))
+
+	if !m.Subscribe("c1", "u1") {
+		t.Fatal("u1 should be accepted")
+	}
+	if !m.Subscribe("c1", "u2") {
+		t.Fatal("u2 should be accepted")
+	}
+	if m.Subscribe("c1", "u3") {
+		t.Fatal("u3 should be rejected once the client is at its cap")
+	}
+
+	// Re-subscribing to an existing URI is idempotent and must not be rejected.
+	if !m.Subscribe("c1", "u1") {
+		t.Fatal("re-subscribing to u1 should be accepted")
+	}
+
+	// A different client has its own independent budget.
+	if !m.Subscribe("c2", "u3") {
+		t.Fatal("c2 should be accepted (separate per-client budget)")
+	}
+
+	// Unsubscribing frees a slot.
+	m.Unsubscribe("c1", "u1")
+	if !m.Subscribe("c1", "u3") {
+		t.Fatal("after unsubscribe, u3 should be accepted")
+	}
+}

--- a/server/tasks.go
+++ b/server/tasks.go
@@ -4,11 +4,29 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
 	"go.klarlabs.de/mcp/protocol"
 )
+
+// Task registry bounds. The registry is an in-memory map that, left
+// unbounded, is a denial-of-service vector: every CreateTask inserts forever.
+// These defaults cap retention so finished tasks are evicted and the map size
+// stays bounded regardless of client behavior.
+const (
+	defaultMaxTasks      = 1000
+	defaultTaskRetention = 10 * time.Minute
+	defaultListLimit     = 100
+	maxListLimit         = 100
+)
+
+// isTerminal reports whether a task has reached a final state and will not
+// transition again.
+func isTerminal(s TaskStatus) bool {
+	return s == TaskStatusCompleted || s == TaskStatusFailed || s == TaskStatusCanceled
+}
 
 type TaskStatus string
 
@@ -55,12 +73,21 @@ type taskRegistry struct {
 	mu       sync.RWMutex
 	tasks    map[string]*Task
 	handlers map[string]TaskSpec
+	// cancels holds the context-cancel func for each in-flight task so
+	// CancelTask can actually stop the running goroutine (not just flip a
+	// status flag). Guarded by mu alongside tasks.
+	cancels   map[string]context.CancelFunc
+	maxTasks  int
+	retention time.Duration
 }
 
 func newTaskRegistry() *taskRegistry {
 	return &taskRegistry{
-		tasks:    make(map[string]*Task),
-		handlers: make(map[string]TaskSpec),
+		tasks:     make(map[string]*Task),
+		handlers:  make(map[string]TaskSpec),
+		cancels:   make(map[string]context.CancelFunc),
+		maxTasks:  defaultMaxTasks,
+		retention: defaultTaskRetention,
 	}
 }
 
@@ -87,10 +114,67 @@ func (r *taskRegistry) ListHandlers() []string {
 	return names
 }
 
-func (r *taskRegistry) CreateTask(task *Task) {
+// CreateTask stores a task and the cancel func for its running goroutine.
+// Before inserting it evicts expired terminal tasks and, if still at capacity,
+// evicts the oldest terminal task; if the registry is full of non-terminal
+// tasks it rejects the insert so the map can never grow without bound.
+func (r *taskRegistry) CreateTask(task *Task, cancel context.CancelFunc) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	r.evictExpiredLocked(time.Now())
+
+	if len(r.tasks) >= r.maxTasks && !r.evictOneTerminalLocked() {
+		return fmt.Errorf("task registry full: %d active tasks", len(r.tasks))
+	}
+
 	r.tasks[task.ID] = task
+	r.cancels[task.ID] = cancel
+	return nil
+}
+
+// getCancel returns the cancel func registered for a task, if any.
+func (r *taskRegistry) getCancel(id string) (context.CancelFunc, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	cancel, ok := r.cancels[id]
+	return cancel, ok
+}
+
+// evictExpiredLocked removes terminal tasks whose completion is older than the
+// retention window. Caller must hold r.mu.
+func (r *taskRegistry) evictExpiredLocked(now time.Time) {
+	if r.retention <= 0 {
+		return
+	}
+	for id, t := range r.tasks {
+		if t.CompletedAt != nil && now.Sub(*t.CompletedAt) >= r.retention {
+			delete(r.tasks, id)
+			delete(r.cancels, id)
+		}
+	}
+}
+
+// evictOneTerminalLocked removes the oldest terminal task and reports whether
+// one was evicted. Caller must hold r.mu.
+func (r *taskRegistry) evictOneTerminalLocked() bool {
+	var oldestID string
+	var oldest time.Time
+	for id, t := range r.tasks {
+		if !isTerminal(t.Status) {
+			continue
+		}
+		if oldestID == "" || t.CreatedAt.Before(oldest) {
+			oldestID = id
+			oldest = t.CreatedAt
+		}
+	}
+	if oldestID == "" {
+		return false
+	}
+	delete(r.tasks, oldestID)
+	delete(r.cancels, oldestID)
+	return true
 }
 
 func (r *taskRegistry) GetTask(id string) (*Task, bool) {
@@ -133,6 +217,7 @@ func (r *taskRegistry) DeleteTask(id string) bool {
 		return false
 	}
 	delete(r.tasks, id)
+	delete(r.cancels, id)
 	return true
 }
 
@@ -173,14 +258,53 @@ type TaskResultRequest struct {
 	TaskID string `json:"taskId"`
 }
 
-type TaskManager struct {
-	registry *taskRegistry
+// TaskManagerOption configures a TaskManager's registry bounds.
+type TaskManagerOption func(*taskRegistry)
+
+// WithMaxTasks caps how many tasks the registry retains. When the cap is
+// reached, terminal tasks are evicted oldest-first; if none are terminal,
+// CreateTask is rejected. Values <= 0 keep the default.
+func WithMaxTasks(n int) TaskManagerOption {
+	return func(r *taskRegistry) {
+		if n > 0 {
+			r.maxTasks = n
+		}
+	}
 }
 
-func NewTaskManager() *TaskManager {
-	return &TaskManager{
-		registry: newTaskRegistry(),
+// WithTaskRetention sets how long a terminal task is kept before eviction.
+// A value <= 0 disables time-based eviction (the cap still bounds the map).
+func WithTaskRetention(d time.Duration) TaskManagerOption {
+	return func(r *taskRegistry) {
+		r.retention = d
 	}
+}
+
+type TaskManager struct {
+	registry *taskRegistry
+	// ctx is the manager-owned parent for every task goroutine; canceling it
+	// (via Shutdown) tears down all in-flight tasks instead of leaking them
+	// past server shutdown.
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewTaskManager(opts ...TaskManagerOption) *TaskManager {
+	registry := newTaskRegistry()
+	for _, opt := range opts {
+		opt(registry)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &TaskManager{
+		registry: registry,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// Shutdown cancels every in-flight task goroutine. Safe to call more than once.
+func (m *TaskManager) Shutdown() {
+	m.cancel()
 }
 
 func (m *TaskManager) RegisterTask(name string, spec TaskSpec) {
@@ -208,21 +332,36 @@ func (m *TaskManager) CreateTask(ctx context.Context, req CreateTaskRequest) (*T
 		},
 	}
 
-	m.registry.CreateTask(task)
+	// Derive the task context from the manager-owned context so Shutdown
+	// cancels it, and store the cancel func so CancelTask can stop it too.
+	taskCtx, cancel := context.WithCancel(m.ctx)
+
+	if err := m.registry.CreateTask(task, cancel); err != nil {
+		cancel()
+		return nil, err
+	}
 
 	taskCopy := *task
-
-	taskCtx, cancel := context.WithCancel(context.Background())
 
 	go func() {
 		defer cancel()
 		m.registry.UpdateTask(task.ID, func(t *Task) {
+			// A cancel that lands before the goroutine starts running must
+			// not be clobbered back to "running".
+			if isTerminal(t.Status) {
+				return
+			}
 			t.Status = TaskStatusRunning
 			t.Message = "Task running"
 		})
 
 		result, err := spec.Handler(taskCtx, req.Params)
 		m.registry.UpdateTask(task.ID, func(t *Task) {
+			// CancelTask may have already marked the task terminal; its
+			// decision wins over whatever the (now-unblocked) handler returned.
+			if isTerminal(t.Status) {
+				return
+			}
 			if err != nil {
 				t.Status = TaskStatusFailed
 				t.Message = err.Error()
@@ -248,22 +387,49 @@ func (m *TaskManager) GetTask(taskID string) (*Task, error) {
 	return task, nil
 }
 
+// ListTasks returns a deterministically ordered, cursor-paged view of the
+// registry. Tasks are ordered by CreatedAt (then ID as a stable tie-break) so
+// paging is repeatable over the otherwise randomly-ordered map. The cursor is
+// the ID of the last task on the previous page; Next is set when more tasks
+// remain.
 func (m *TaskManager) ListTasks(limit int, cursor string) (*ListTasksResponse, error) {
 	tasks := m.registry.ListTasks()
 
-	if limit <= 0 {
-		limit = 100
-	}
-	if limit > 100 {
-		limit = 100
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].CreatedAt.Equal(tasks[j].CreatedAt) {
+			return tasks[i].ID < tasks[j].ID
+		}
+		return tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+	})
+
+	if limit <= 0 || limit > maxListLimit {
+		limit = defaultListLimit
 	}
 
-	if len(tasks) > limit {
-		tasks = tasks[:limit]
+	start := 0
+	if cursor != "" {
+		for i, t := range tasks {
+			if t.ID == cursor {
+				start = i + 1
+				break
+			}
+		}
+	}
+	if start > len(tasks) {
+		start = len(tasks)
+	}
+
+	end := start + limit
+	var next string
+	if end < len(tasks) {
+		next = tasks[end-1].ID
+	} else {
+		end = len(tasks)
 	}
 
 	return &ListTasksResponse{
-		Tasks: tasks,
+		Tasks: tasks[start:end],
+		Next:  next,
 	}, nil
 }
 
@@ -273,16 +439,26 @@ func (m *TaskManager) CancelTask(taskID string) error {
 		return fmt.Errorf("task not found: %s", taskID)
 	}
 
-	if task.Status == TaskStatusCompleted || task.Status == TaskStatusFailed || task.Status == TaskStatusCanceled {
+	if isTerminal(task.Status) {
 		return fmt.Errorf("task already terminal: %s", task.Status)
 	}
 
+	// Mark canceled first so the handler goroutine's completion path (which
+	// re-checks isTerminal) won't overwrite the outcome, then cancel the
+	// context to actually stop the running goroutine.
 	now := time.Now()
 	m.registry.UpdateTask(taskID, func(t *Task) {
+		if isTerminal(t.Status) {
+			return
+		}
 		t.Status = TaskStatusCanceled
 		t.Message = "Task canceled"
 		t.CompletedAt = &now
 	})
+
+	if cancel, ok := m.registry.getCancel(taskID); ok {
+		cancel()
+	}
 
 	return nil
 }
@@ -334,10 +510,17 @@ func (m *TaskManager) HandleRequest(ctx context.Context, req *protocol.Request) 
 }
 
 func (s *Server) RegisterTask(name string, description string, handler TaskHandler) {
+	// Guard the lazy init with the Server mutex: RegisterTask (setup) and
+	// Tasks() (request path) previously read/assigned s.tasks with no
+	// synchronization, a data race under -race.
+	s.mu.Lock()
 	if s.tasks == nil {
 		s.tasks = NewTaskManager()
 	}
-	s.tasks.RegisterTask(name, TaskSpec{
+	tm := s.tasks
+	s.mu.Unlock()
+
+	tm.RegisterTask(name, TaskSpec{
 		Name:        name,
 		Description: description,
 		Handler:     handler,
@@ -345,5 +528,7 @@ func (s *Server) RegisterTask(name string, description string, handler TaskHandl
 }
 
 func (s *Server) Tasks() *TaskManager {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.tasks
 }

--- a/server/tasks_test.go
+++ b/server/tasks_test.go
@@ -252,6 +252,194 @@ func TestTaskRegistry(t *testing.T) {
 	})
 }
 
+// TestCancelTaskCancelsRunningContext proves CancelTask actually cancels the
+// running goroutine's context (not just flips the status flag).
+func TestCancelTaskCancelsRunningContext(t *testing.T) {
+	mgr := NewTaskManager()
+
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	mgr.RegisterTask("blocker", TaskSpec{
+		Name: "blocker",
+		Handler: func(ctx context.Context, _ map[string]any) (*TaskResult, error) {
+			close(started)
+			<-ctx.Done() // must unblock only when the context is canceled
+			close(canceled)
+			return nil, ctx.Err()
+		},
+	})
+
+	task, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "blocker"})
+	if err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	<-started
+	if err := mgr.CancelTask(task.ID); err != nil {
+		t.Fatalf("CancelTask() error = %v", err)
+	}
+
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CancelTask did not cancel the running task's context")
+	}
+
+	updated, _ := mgr.GetTask(task.ID)
+	if updated.Status != TaskStatusCanceled {
+		t.Errorf("status = %v, want canceled", updated.Status)
+	}
+}
+
+// TestTaskManagerShutdownCancelsTasks proves Shutdown tears down in-flight task
+// goroutines instead of leaking them.
+func TestTaskManagerShutdownCancelsTasks(t *testing.T) {
+	mgr := NewTaskManager()
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	mgr.RegisterTask("blocker", TaskSpec{
+		Name: "blocker",
+		Handler: func(ctx context.Context, _ map[string]any) (*TaskResult, error) {
+			close(started)
+			<-ctx.Done()
+			close(done)
+			return nil, ctx.Err()
+		},
+	})
+
+	if _, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "blocker"}); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	<-started
+	mgr.Shutdown()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown did not cancel the running task's context")
+	}
+}
+
+// TestTaskRetentionEviction proves terminal tasks are evicted after the
+// retention window, bounding the registry.
+func TestTaskRetentionEviction(t *testing.T) {
+	mgr := NewTaskManager(WithTaskRetention(10 * time.Millisecond))
+
+	mgr.RegisterTask("quick", TaskSpec{
+		Name: "quick",
+		Handler: func(_ context.Context, _ map[string]any) (*TaskResult, error) {
+			return &TaskResult{Data: "ok"}, nil
+		},
+	})
+
+	first, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "quick"})
+	if err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	// Wait for the first task to reach a terminal state (so CompletedAt is set).
+	waitForStatus(t, mgr, first.ID, TaskStatusCompleted)
+
+	// Wait past the retention window, then a new CreateTask triggers a sweep.
+	time.Sleep(30 * time.Millisecond)
+	if _, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "quick"}); err != nil {
+		t.Fatalf("second CreateTask() error = %v", err)
+	}
+
+	if _, err := mgr.GetTask(first.ID); err == nil {
+		t.Error("expected the first (expired) task to be evicted, but it is still present")
+	}
+}
+
+// TestTaskRegistryCapRejects proves creation is rejected once the cap is full
+// of non-terminal tasks, so the map can never grow without bound.
+func TestTaskRegistryCapRejects(t *testing.T) {
+	mgr := NewTaskManager(WithMaxTasks(1), WithTaskRetention(0))
+	defer mgr.Shutdown()
+
+	started := make(chan struct{}, 1)
+	mgr.RegisterTask("hold", TaskSpec{
+		Name: "hold",
+		Handler: func(ctx context.Context, _ map[string]any) (*TaskResult, error) {
+			started <- struct{}{}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	if _, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "hold"}); err != nil {
+		t.Fatalf("first CreateTask() error = %v", err)
+	}
+	<-started // ensure the task is running (non-terminal) and occupies the cap
+
+	if _, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "hold"}); err == nil {
+		t.Error("expected CreateTask to be rejected when the registry is full of active tasks")
+	}
+}
+
+// TestListTasksCursorPaging proves ListTasks returns a deterministic order and
+// honours the cursor with a Next token across pages.
+func TestListTasksCursorPaging(t *testing.T) {
+	mgr := NewTaskManager()
+	mgr.RegisterTask("t", TaskSpec{
+		Name: "t",
+		Handler: func(_ context.Context, _ map[string]any) (*TaskResult, error) {
+			return &TaskResult{}, nil
+		},
+	})
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		if _, err := mgr.CreateTask(context.Background(), CreateTaskRequest{Name: "t"}); err != nil {
+			t.Fatalf("CreateTask() error = %v", err)
+		}
+		time.Sleep(time.Millisecond) // distinct CreatedAt for a stable order
+	}
+
+	seen := make(map[string]bool)
+	cursor := ""
+	pages := 0
+	for {
+		resp, err := mgr.ListTasks(2, cursor)
+		if err != nil {
+			t.Fatalf("ListTasks() error = %v", err)
+		}
+		pages++
+		for _, task := range resp.Tasks {
+			if seen[task.ID] {
+				t.Fatalf("task %s returned on more than one page", task.ID)
+			}
+			seen[task.ID] = true
+		}
+		if resp.Next == "" {
+			break
+		}
+		cursor = resp.Next
+		if pages > total+2 {
+			t.Fatal("cursor paging did not terminate")
+		}
+	}
+
+	if len(seen) != total {
+		t.Errorf("paged over %d tasks, want %d", len(seen), total)
+	}
+}
+
+func waitForStatus(t *testing.T, mgr *TaskManager, id string, want TaskStatus) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		task, err := mgr.GetTask(id)
+		if err == nil && task.Status == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("task %s did not reach status %v", id, want)
+}
+
 func TestServer_RegisterTask(t *testing.T) {
 	srv := New(Info{
 		Name:    "test-server",


### PR DESCRIPTION
## Summary

Lifecycle hardening for the server's task, cancellation, and subscription subsystems. These were deep-review findings where the code advertised a capability it didn't actually deliver (CancelTask a no-op, client cancellation dropped) or left an unbounded, client-controlled allocation (task registry, subscription maps) — plus an error-detail leak to the peer.

Scoped strictly to `server/tasks.go`, `server/subscriptions.go`, `server/resource_subscriptions.go`, and `mcp.go` (+ their tests). `server/server.go`, transports, and middleware are untouched.

## Fixes

- **[HIGH/DoS] Task registry leaked unbounded + goroutines uncancellable + CancelTask a no-op.** Each task now stores its context-cancel func; `CancelTask` calls it so the running goroutine's context is actually canceled (the goroutine's completion path re-checks terminal state so the cancel decision wins). Task goroutines derive from a **manager-owned context** that a new `Shutdown()` cancels, so they don't outlive the server. Terminal tasks are evicted by **TTL** (`WithTaskRetention`) and a **max-count cap** (`WithMaxTasks`, evict-oldest-terminal / reject-when-full). The cancel map is guarded by the registry mutex.
- **[LOW] `Server.tasks` lazy-init data race.** `RegisterTask` / `Tasks()` now read/assign `s.tasks` under `s.mu` (kept the fix inside the allowed files — no `server.go` edit).
- **[LOW] `ListTasks` ignored cursor / random order.** Now ordered by `CreatedAt` (ID tie-break) with real cursor paging and a `Next` token.
- **[MED] Client cancellation was a complete no-op.** Added a `notifications/cancelled` handler in `mcp.go` that calls `CancellationManager.Cancel(id)`, and `Track`/`Untrack` wrap dispatch keyed by `req.ID` so in-flight requests are cancellable.
- **[MED/DoS] Unbounded subscription registries.** Both `SubscriptionManager` and the wired resource-subscription registry enforce a **configurable per-client cap**, rejecting beyond it (idempotent re-subscribe still accepted; unsubscribe/removeClient free the budget).
- **[MED] Error-message info leak.** `publicError` is a single handler-return chokepoint: deliberate protocol errors (InvalidParams, MethodNotFound, NotFound, …) pass through verbatim; any other error is logged server-side (stderr) and replaced with a generic `-32603 "internal error"`, covering all transports uniformly.

## Scoped-down note

On the **wired** `resources/subscribe` request path, the per-client cap bounds the registry but the rejection is **silent to the client**: `handleResourcesSubscribe` reaches the registry only through `Server.SubscribeResource` (in `server.go`, which this PR may not edit and which discards the return). The DoS is fully closed (the map cannot exceed the cap); surfacing an explicit client error would need a one-line signature change in `server.go`. Direct users of `SubscriptionManager` / the registry do get the boolean accept/reject result.

## Tests (TDD)

- `CancelTask` cancels a running task's context; `Shutdown` cancels in-flight tasks.
- Terminal tasks evicted after retention; registry rejects creation when full of active tasks.
- `ListTasks` cursor paging is deterministic and non-overlapping.
- `notifications/cancelled` cancels a matching in-flight request.
- A handler returning a raw `error` with a secret path yields a generic client error while the detail is logged server-side.
- Per-client subscription cap enforced on both registries.

Verified GREEN: `go vet`, `golangci-lint` (0 issues), `go build`, `go test ./...`, and `go test -race ./...`.

https://claude.ai/code/session_01QKTcmXFTKoTQr7mB3HCuHZ
