### PR TITLE
Phase 3: certify 2025-11-25 (tasks, URL elicitation, SEP-1303, icons, sampling-tools, JSON Schema 2020-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — task-augmented requests (Phase 3, 2025-11-25, SEP-1686)
+
+Full spec-conformant Tasks: a `tools/call` carrying a `task` field is accepted
+immediately with a `CreateTaskResult`, runs in the background, and its outcome is
+retrieved by polling. New over the wire:
+
+- **Augmented `tools/call`** — `params.task: { ttl }` → returns `{ task: { taskId,
+  status:"working", createdAt, lastUpdatedAt, ttl, pollInterval } }` and executes
+  asynchronously.
+- **`tasks/get`** (poll status), **`tasks/result`** (block until terminal, return
+  exactly what the plain call would, with `io.modelcontextprotocol/related-task`
+  meta), **`tasks/cancel`** (best-effort stop; `-32602` on already-terminal),
+  **`tasks/list`** (cursor pagination).
+- **`.TaskSupport(mcp.TaskSupportOptional|Required|Forbidden)`** builder →
+  advertised as `execution.taskSupport` in `tools/list`; a task on a
+  forbidden/unset tool, or a plain call on a required-task tool, is `-32601`.
+- **`tasks` capability** auto-advertised (`{list, cancel, requests:{tools:{call}}}`)
+  when any tool opts in. Task IDs are cryptographically random; the registry is
+  bounded and TTL-evicting.
+
+This is a distinct, spec-conformant implementation; the legacy `TaskManager`
+(pre-spec `tasks/create` model) is left untouched.
+
 ### Certified — 2025-03-26 and 2025-06-18 negotiable (Phases 1–2)
 
 `protocol.SupportedVersions` now lists `2024-11-05`, `2025-03-26`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Certified — 2025-11-25 negotiable (Phase 3 complete)
+
+`protocol.SupportedVersions` now includes `2025-11-25` and the default
+(`protocol.MCPVersion`) advances to it. The server negotiates and honors all
+four revisions; the conformance harness runs the full method set against each.
+Completing the revision:
+
+- **Input validation as tool execution errors** (SEP-1303) — invalid tool input
+  is now returned as an `isError` result (via the new `ToolInputError`) instead
+  of a `-32602` protocol error, so the model can self-correct. Applies to plain
+  and task-augmented calls.
+- **URL-mode elicitation** (SEP-1036) — `ElicitRequest` gains `mode`/`url`/
+  `elicitationId`; new `Elicitor.ElicitURL`, `mcp.ElicitModeForm`/`ElicitModeURL`,
+  the `elicitation.url` client capability (empty elicitation object = form only),
+  and the `-32042` `URLElicitationRequired` error (`protocol.NewURLElicitationRequired`).
+- **Elicitation enums & defaults** (SEP-1330 / SEP-1034) — expressible directly
+  in the freeform `requestedSchema` (`oneOf`/`anyOf` with `const`+`title`,
+  per-primitive `default`); no API change needed.
+- `Implementation.description` (already present) confirmed advertised.
+
 ### Added — task-augmented requests (Phase 3, 2025-11-25, SEP-1686)
 
 Full spec-conformant Tasks: a `tools/call` carrying a `task` field is accepted

--- a/e2e/compliance_test.go
+++ b/e2e/compliance_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -417,7 +418,7 @@ func TestMCPCompliance_Errors(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid params returns InvalidParams", func(t *testing.T) {
+	t.Run("invalid tool input is a tool execution error (SEP-1303)", func(t *testing.T) {
 		srv.Tool("test").Handler(func(input struct{ X int }) (int, error) { return input.X, nil })
 
 		resp := executeRequest(t, srv, &protocol.Request{
@@ -427,12 +428,14 @@ func TestMCPCompliance_Errors(t *testing.T) {
 			Params:  json.RawMessage(`{"name":"test","arguments":"invalid"}`),
 		})
 
-		if resp.Error == nil {
-			t.Fatal("expected error for invalid params")
+		// Per MCP 2025-11-25, invalid input is returned as an isError result so
+		// the model can self-correct — not a -32602 protocol error.
+		if resp.Error != nil {
+			t.Fatalf("expected no protocol error, got %+v", resp.Error)
 		}
-
-		if resp.Error.Code != protocol.CodeInvalidParams {
-			t.Errorf("error.code = %d, want %d", resp.Error.Code, protocol.CodeInvalidParams)
+		result, ok := resp.Result.(map[string]any)
+		if !ok || result["isError"] != true {
+			t.Errorf("expected isError result, got %v", resp.Result)
 		}
 	})
 }
@@ -609,6 +612,14 @@ func (h *testHandler) handleToolsCall(ctx context.Context, req *protocol.Request
 
 	result, err := tool.Execute(ctx, params.Arguments)
 	if err != nil {
+		// SEP-1303: input problems are tool execution errors (isError result).
+		var inputErr *mcp.ToolInputError
+		if errors.As(err, &inputErr) {
+			return protocol.NewResponse(req.ID, map[string]any{
+				"content": []map[string]any{{"type": "text", "text": inputErr.Message}},
+				"isError": true,
+			}), nil
+		}
 		if mcpErr, ok := err.(*protocol.Error); ok {
 			return nil, mcpErr
 		}

--- a/mcp.go
+++ b/mcp.go
@@ -54,6 +54,8 @@ const (
 	fieldText            = "text"
 	fieldType            = "type"
 	fieldURI             = "uri"
+	fieldTask            = "task"
+	fieldTaskID          = "taskId"
 )
 
 // Re-export core types for convenience
@@ -212,6 +214,18 @@ type CompletionHandler = server.CompletionHandler
 
 // Resource template types
 type ResourceTemplateInfo = server.ResourceTemplateInfo
+
+// Task-augmented request types (MCP 2025-11-25). Declare a tool's task support
+// with .TaskSupport(mcp.TaskSupportOptional); clients augment tools/call with a
+// task and poll tasks/get / tasks/result.
+type AugTask = server.AugTask
+type TaskSupport = server.TaskSupport
+
+const (
+	TaskSupportForbidden = server.TaskSupportForbidden
+	TaskSupportOptional  = server.TaskSupportOptional
+	TaskSupportRequired  = server.TaskSupportRequired
+)
 
 // Session types for bidirectional MCP communication
 type Session = server.Session
@@ -706,6 +720,10 @@ func (h *requestHandler) methodHandlers() map[string]func(context.Context, *prot
 		protocol.MethodCompletionComplete:     h.handleCompletion,
 		protocol.MethodLoggingSetLevel:        h.handleLoggingSetLevel,
 		protocol.MethodResourcesTemplatesList: h.handleResourcesTemplatesList,
+		protocol.MethodTasksGet:               h.handleTasksGet,
+		protocol.MethodTasksResult:            h.handleTasksResult,
+		protocol.MethodTasksCancel:            h.handleTasksCancel,
+		protocol.MethodTasksList:              h.handleTasksList,
 	}
 }
 
@@ -797,6 +815,18 @@ func (h *requestHandler) serverCapabilities(manifest server.Manifest) map[string
 	}
 	if manifest.Capabilities.Logging {
 		capabilities["logging"] = map[string]any{}
+	}
+	// Tasks (MCP 2025-11-25): auto-advertised when any tool opts into task
+	// augmentation. list/cancel are always supported; tools/call is the only
+	// task-augmentable server request.
+	if h.srv.HasTaskTools() {
+		capabilities["tasks"] = map[string]any{
+			"list":   map[string]any{},
+			"cancel": map[string]any{},
+			"requests": map[string]any{
+				"tools": map[string]any{"call": map[string]any{}},
+			},
+		}
 	}
 	return capabilities
 }
@@ -895,6 +925,11 @@ func (h *requestHandler) handleToolsList(ctx context.Context, req *protocol.Requ
 		if len(t.Icons) > 0 {
 			item["icons"] = t.Icons
 		}
+		// execution.taskSupport (MCP 2025-11-25): advertise only when the tool
+		// opts in, so a plain tool's listing is unchanged.
+		if t.TaskSupport == server.TaskSupportOptional || t.TaskSupport == server.TaskSupportRequired {
+			item["execution"] = map[string]any{"taskSupport": string(t.TaskSupport)}
+		}
 		if t.Meta != nil {
 			item["_meta"] = t.Meta
 		}
@@ -908,11 +943,59 @@ func (h *requestHandler) handleToolsList(ctx context.Context, req *protocol.Requ
 	return protocol.NewResponse(req.ID, result), nil
 }
 
+// reconcileTaskSupport enforces a tool's execution.taskSupport against whether
+// the caller augmented the request with a task: a task on a forbidden/unset
+// tool, or a plain call on a required-task tool, is -32601 (Method not found)
+// per MCP 2025-11-25.
+func reconcileTaskSupport(mode server.TaskSupport, augmented bool, name string) error {
+	switch mode {
+	case server.TaskSupportRequired:
+		if !augmented {
+			return protocol.NewMethodNotFound("tool requires task augmentation: " + name)
+		}
+	case server.TaskSupportOptional:
+		// either form is allowed
+	default: // forbidden / unset
+		if augmented {
+			return protocol.NewMethodNotFound("tool does not support task augmentation: " + name)
+		}
+	}
+	return nil
+}
+
+// startAugmentedToolCall runs a tools/call as a background task and returns the
+// CreateTaskResult immediately. The closure runs the tool and builds its normal
+// response so tasks/result returns exactly what a plain call would have.
+func (h *requestHandler) startAugmentedToolCall(ctx context.Context, req *protocol.Request, tool *server.Tool, args json.RawMessage, ttl *int64) (*protocol.Response, error) {
+	task, err := h.srv.StartAugmentedCall(ctx, ttl, func(runCtx context.Context) (any, bool, error) {
+		res, execErr := tool.Execute(runCtx, args)
+		if execErr != nil {
+			return nil, false, execErr
+		}
+		resp, berr := buildToolCallResponse(tool, res)
+		if berr != nil {
+			return nil, false, berr
+		}
+		if tool.Meta() != nil {
+			resp["_meta"] = tool.Meta()
+		}
+		isErr, _ := resp["isError"].(bool)
+		return resp, isErr, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return protocol.NewResponse(req.ID, map[string]any{fieldTask: task}), nil
+}
+
 func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 	// Parse params
 	var params struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
+		Task      *struct {
+			TTL *int64 `json:"ttl"`
+		} `json:"task"`
 	}
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return nil, protocol.NewInvalidParams(err.Error())
@@ -927,6 +1010,13 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 	}
 	if h.toolFilter != nil && !h.toolFilter(ctx, params.Name) {
 		return nil, protocol.NewNotFound("tool not found: " + params.Name)
+	}
+
+	// Task augmentation (MCP 2025-11-25): reconcile the request against the
+	// tool's execution.taskSupport before executing.
+	augmented := params.Task != nil
+	if err := reconcileTaskSupport(tool.TaskSupport(), augmented, params.Name); err != nil {
+		return nil, err
 	}
 
 	// Set up progress reporting if token is present
@@ -947,6 +1037,17 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 		if session.SupportsFeature("channels") {
 			ctx = server.ContextWithChannel(ctx, server.NewChannelSender(session))
 		}
+	}
+
+	// Task-augmented call: accept immediately, run in the background, and return
+	// a CreateTaskResult. The requestor then polls tasks/get and fetches the
+	// outcome via tasks/result.
+	if augmented {
+		var ttl *int64
+		if params.Task != nil {
+			ttl = params.Task.TTL
+		}
+		return h.startAugmentedToolCall(ctx, req, tool, params.Arguments, ttl)
 	}
 
 	// Execute tool. A deliberate protocol error passes through verbatim; any
@@ -1350,6 +1451,107 @@ func (h *requestHandler) handleResourcesTemplatesList(ctx context.Context, req *
 		list = append(list, item)
 	}
 	return protocol.NewResponse(req.ID, map[string]any{"resourceTemplates": list}), nil
+}
+
+// relatedTaskMeta is the _meta key that associates a message with its task.
+const relatedTaskMetaKey = "io.modelcontextprotocol/related-task"
+
+// handleTasksGet serves tasks/get: return the task's current state.
+func (h *requestHandler) handleTasksGet(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	var params struct {
+		TaskID string `json:"taskId"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	task, ok := h.srv.GetAugTask(params.TaskID)
+	if !ok {
+		return nil, protocol.NewInvalidParams("task not found: " + params.TaskID)
+	}
+	return protocol.NewResponse(req.ID, task), nil
+}
+
+// handleTasksResult serves tasks/result: block until the task is terminal, then
+// return exactly what the underlying request would have returned (with the
+// related-task _meta association).
+func (h *requestHandler) handleTasksResult(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	var params struct {
+		TaskID string `json:"taskId"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	result, execErr, err := h.srv.AwaitAugTaskResult(ctx, params.TaskID)
+	if err != nil {
+		if errors.Is(err, server.ErrAugTaskNotFound) {
+			return nil, protocol.NewInvalidParams("task not found: " + params.TaskID)
+		}
+		return nil, err // ctx cancelled, etc.
+	}
+	if execErr != nil {
+		// The underlying request produced a JSON-RPC error; tasks/result must
+		// return that same error.
+		var mcpErr *protocol.Error
+		if errors.As(execErr, &mcpErr) {
+			return nil, mcpErr
+		}
+		return nil, execErr
+	}
+	resp, ok := result.(map[string]any)
+	if !ok || resp == nil {
+		// Cancelled (or resultless) task: surface as a tool execution error.
+		resp = map[string]any{
+			"content": []map[string]any{{fieldType: fieldText, fieldText: "task did not produce a result"}},
+			"isError": true,
+		}
+	}
+	attachRelatedTask(resp, params.TaskID)
+	return protocol.NewResponse(req.ID, resp), nil
+}
+
+// handleTasksCancel serves tasks/cancel.
+func (h *requestHandler) handleTasksCancel(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	var params struct {
+		TaskID string `json:"taskId"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	task, err := h.srv.CancelAugTask(params.TaskID)
+	if err != nil {
+		// Both unknown-task and already-terminal map to -32602 per spec.
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	return protocol.NewResponse(req.ID, task), nil
+}
+
+// handleTasksList serves tasks/list with cursor pagination.
+func (h *requestHandler) handleTasksList(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	var params struct {
+		Cursor string `json:"cursor"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return nil, protocol.NewInvalidParams(err.Error())
+		}
+	}
+	tasks, next := h.srv.ListAugTasks(params.Cursor, 0)
+	result := map[string]any{"tasks": tasks}
+	if next != "" {
+		result["nextCursor"] = next
+	}
+	return protocol.NewResponse(req.ID, result), nil
+}
+
+// attachRelatedTask records the io.modelcontextprotocol/related-task association
+// in a result's _meta.
+func attachRelatedTask(resp map[string]any, taskID string) {
+	meta, _ := resp["_meta"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	meta[relatedTaskMetaKey] = map[string]any{fieldTaskID: taskID}
+	resp["_meta"] = meta
 }
 
 // notificationAdapter adapts transport.NotificationSender to server.NotificationSender.

--- a/mcp.go
+++ b/mcp.go
@@ -187,6 +187,10 @@ var NewSubscriptionManager = server.NewSubscriptionManager
 // Structured result types for tool responses
 type StructuredResult = server.StructuredResult
 
+// ToolInputError is returned by a tool when input fails to parse/validate;
+// the dispatcher surfaces it as an isError result (SEP-1303).
+type ToolInputError = server.ToolInputError
+
 // Elicitation types for interactive user prompts
 type ElicitRequest = server.ElicitRequest
 type ElicitResult = server.ElicitResult
@@ -195,6 +199,13 @@ type Elicitor = server.Elicitor
 var (
 	NewElicitor       = server.NewElicitor
 	ElicitFromContext = server.ElicitFromContext
+)
+
+// Elicitation modes (MCP 2025-11-25): form (default, in-band structured data)
+// and url (out-of-band navigation for sensitive interactions).
+const (
+	ElicitModeForm = server.ElicitModeForm
+	ElicitModeURL  = server.ElicitModeURL
 )
 
 // Channel types for server-initiated push messages
@@ -943,6 +954,15 @@ func (h *requestHandler) handleToolsList(ctx context.Context, req *protocol.Requ
 	return protocol.NewResponse(req.ID, result), nil
 }
 
+// toolExecutionError builds an isError CallToolResult carrying a message — used
+// to surface input-validation failures to the model per SEP-1303.
+func toolExecutionError(msg string) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{{fieldType: fieldText, fieldText: msg}},
+		"isError": true,
+	}
+}
+
 // reconcileTaskSupport enforces a tool's execution.taskSupport against whether
 // the caller augmented the request with a task: a task on a forbidden/unset
 // tool, or a plain call on a required-task tool, is -32601 (Method not found)
@@ -970,6 +990,12 @@ func (h *requestHandler) startAugmentedToolCall(ctx context.Context, req *protoc
 	task, err := h.srv.StartAugmentedCall(ctx, ttl, func(runCtx context.Context) (any, bool, error) {
 		res, execErr := tool.Execute(runCtx, args)
 		if execErr != nil {
+			// SEP-1303: an input error becomes a failed task carrying an
+			// isError result (not a protocol error).
+			var inputErr *server.ToolInputError
+			if errors.As(execErr, &inputErr) {
+				return toolExecutionError(inputErr.Message), true, nil
+			}
 			return nil, false, execErr
 		}
 		resp, berr := buildToolCallResponse(tool, res)
@@ -1055,6 +1081,12 @@ func (h *requestHandler) handleToolsCall(ctx context.Context, req *protocol.Requ
 	// internal detail to the peer).
 	result, err := tool.Execute(ctx, params.Arguments)
 	if err != nil {
+		// SEP-1303: input problems are tool execution errors, not protocol
+		// errors, so the model can self-correct.
+		var inputErr *server.ToolInputError
+		if errors.As(err, &inputErr) {
+			return protocol.NewResponse(req.ID, toolExecutionError(inputErr.Message)), nil
+		}
 		var mcpErr *protocol.Error
 		if errors.As(err, &mcpErr) {
 			return nil, mcpErr

--- a/mcp_revisions_test.go
+++ b/mcp_revisions_test.go
@@ -249,6 +249,31 @@ func TestToolResult_CarriesUnionContent(t *testing.T) {
 	}
 }
 
+// TestToolsCall_ValidationIsToolError verifies SEP-1303: invalid tool input is
+// returned as a tool execution error (isError result), not a -32602 protocol
+// error, so the model can self-correct.
+func TestToolsCall_ValidationIsToolError(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	type in struct {
+		Name string `json:"name" jsonschema:"required"`
+	}
+	srv.Tool("greet").Handler(func(i in) (string, error) { return "hi " + i.Name, nil })
+
+	handler := newRequestHandler(srv)
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsCall,
+		Params: mustParams(t, map[string]any{"name": "greet", "arguments": map[string]any{}}),
+	}
+	resp, err := handler.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected no protocol error, got %v", err)
+	}
+	res := resp.Result.(map[string]any)
+	if res["isError"] != true {
+		t.Errorf("expected isError result for invalid input, got %v", res)
+	}
+}
+
 func TestSession_SetClientCapabilitiesJSON(t *testing.T) {
 	sess := NewSession("id", nil, nil)
 	sess.SetClientCapabilitiesJSON(json.RawMessage(`{

--- a/mcp_tasks_test.go
+++ b/mcp_tasks_test.go
@@ -1,0 +1,181 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+func taskReq(t *testing.T, method string, params any) *protocol.Request {
+	t.Helper()
+	return &protocol.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  mustParams(t, params),
+	}
+}
+
+// TestTaskAugmentation_Flow drives the full 2025-11-25 task lifecycle: an
+// augmented tools/call returns a working CreateTaskResult, tasks/get reports
+// working while the handler is gated, and tasks/result blocks until completion
+// and returns the underlying result tagged with the related-task meta.
+func TestTaskAugmentation_Flow(t *testing.T) {
+	release := make(chan struct{})
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	type in struct {
+		X string `json:"x"`
+	}
+	srv.Tool("slow").
+		Description("gated tool").
+		TaskSupport(TaskSupportOptional).
+		Handler(func(_ context.Context, i in) (string, error) {
+			<-release
+			return "done:" + i.X, nil
+		})
+	handler := newRequestHandler(srv)
+
+	// 1. Augmented call → CreateTaskResult (status working).
+	resp, err := handler.HandleRequest(context.Background(),
+		taskReq(t, protocol.MethodToolsCall, map[string]any{
+			"name": "slow", "arguments": map[string]any{"x": "y"}, fieldTask: map[string]any{"ttl": 60000},
+		}))
+	if err != nil {
+		t.Fatalf("augmented call: %v", err)
+	}
+	task, ok := resp.Result.(map[string]any)[fieldTask].(*AugTask)
+	if !ok {
+		t.Fatalf("expected CreateTaskResult with *AugTask, got %#v", resp.Result)
+	}
+	if task.Status != TaskSupportWorkingStatus {
+		t.Fatalf("expected working, got %q", task.Status)
+	}
+	id := task.TaskID
+
+	// 2. tasks/get while gated → still working.
+	getResp, err := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodTasksGet, map[string]any{fieldTaskID: id}))
+	if err != nil {
+		t.Fatalf("tasks/get: %v", err)
+	}
+	if got := getResp.Result.(*AugTask); got.Status != TaskSupportWorkingStatus {
+		t.Fatalf("expected working before release, got %q", got.Status)
+	}
+
+	// 3. Release; tasks/result blocks until terminal and returns the result.
+	close(release)
+	resResp, err := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodTasksResult, map[string]any{fieldTaskID: id}))
+	if err != nil {
+		t.Fatalf("tasks/result: %v", err)
+	}
+	res := resResp.Result.(map[string]any)
+	raw, _ := json.Marshal(res)
+	if !strings.Contains(string(raw), "done:y") {
+		t.Errorf("expected tool output in result, got %s", raw)
+	}
+	meta, _ := res["_meta"].(map[string]any)
+	rel, _ := meta[relatedTaskMetaKey].(map[string]any)
+	if rel == nil || rel["taskId"] != id {
+		t.Errorf("expected related-task meta with taskId %s, got %v", id, meta)
+	}
+
+	// 4. tasks/get now completed.
+	getResp2, _ := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodTasksGet, map[string]any{fieldTaskID: id}))
+	if got := getResp2.Result.(*AugTask); got.Status != "completed" {
+		t.Errorf("expected completed, got %q", got.Status)
+	}
+}
+
+// TaskSupportWorkingStatus is the initial task status literal, kept local to the
+// test to avoid exporting an internal constant.
+const TaskSupportWorkingStatus = "working"
+
+func TestTaskAugmentation_Rejections(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	type in struct {
+		X string `json:"x"`
+	}
+	srv.Tool("plain").Description("no tasks").
+		Handler(func(_ in) (string, error) { return "ok", nil })
+	srv.Tool("must").Description("task required").TaskSupport(TaskSupportRequired).
+		Handler(func(_ in) (string, error) { return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	// task on a forbidden tool → -32601.
+	_, err := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodToolsCall, map[string]any{
+		"name": "plain", "arguments": map[string]any{"x": "y"}, fieldTask: map[string]any{},
+	}))
+	assertCode(t, err, protocol.CodeMethodNotFound, "task on forbidden tool")
+
+	// plain call on a required-task tool → -32601.
+	_, err = handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodToolsCall, map[string]any{
+		"name": "must", "arguments": map[string]any{"x": "y"},
+	}))
+	assertCode(t, err, protocol.CodeMethodNotFound, "plain call on required-task tool")
+
+	// tasks/get unknown id → -32602.
+	_, err = handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodTasksGet, map[string]any{fieldTaskID: "nope"}))
+	assertCode(t, err, protocol.CodeInvalidParams, "unknown task get")
+}
+
+func TestTaskAugmentation_CancelTerminalRejected(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	type in struct {
+		X string `json:"x"`
+	}
+	done := make(chan struct{})
+	srv.Tool("t").Description("").TaskSupport(TaskSupportOptional).
+		Handler(func(_ context.Context, _ in) (string, error) { <-done; return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	resp, _ := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodToolsCall, map[string]any{
+		"name": "t", "arguments": map[string]any{"x": "y"}, fieldTask: map[string]any{},
+	}))
+	id := resp.Result.(map[string]any)[fieldTask].(*AugTask).TaskID
+
+	// Cancel the working task → cancelled.
+	cResp, err := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodTasksCancel, map[string]any{fieldTaskID: id}))
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if cResp.Result.(*AugTask).Status != "cancelled" {
+		t.Fatalf("expected cancelled, got %q", cResp.Result.(*AugTask).Status)
+	}
+	// Cancel again (terminal) → -32602.
+	_, err = handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodTasksCancel, map[string]any{fieldTaskID: id}))
+	assertCode(t, err, protocol.CodeInvalidParams, "cancel terminal task")
+	close(done)
+}
+
+func TestTaskCapability_And_ExecutionTaskSupport(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	type in struct {
+		X string `json:"x"`
+	}
+	srv.Tool("t").Description("").TaskSupport(TaskSupportOptional).
+		Handler(func(_ in) (string, error) { return "ok", nil })
+	res := initResult(t, srv, "2025-11-25")
+	caps := res["capabilities"].(map[string]any)
+	if _, ok := caps["tasks"]; !ok {
+		t.Errorf("expected tasks capability advertised, got %v", caps)
+	}
+
+	handler := newRequestHandler(srv)
+	lResp, _ := handler.HandleRequest(context.Background(), taskReq(t, protocol.MethodToolsList, map[string]any{}))
+	tool := lResp.Result.(map[string]any)["tools"].([]map[string]any)[0]
+	exec, _ := tool["execution"].(map[string]any)
+	if exec == nil || exec["taskSupport"] != "optional" {
+		t.Errorf("expected execution.taskSupport=optional in tools/list, got %v", tool["execution"])
+	}
+}
+
+func assertCode(t *testing.T, err error, code int, ctx string) {
+	t.Helper()
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != code {
+		t.Fatalf("%s: expected error code %d, got %v", ctx, code, err)
+	}
+}

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -56,6 +56,12 @@ const (
 	MethodPromptsGet             = "prompts/get"
 	MethodCompletionComplete     = "completion/complete"
 	MethodPing                   = "ping"
+
+	// Task-augmented requests (MCP 2025-11-25, SEP-1686).
+	MethodTasksGet    = "tasks/get"
+	MethodTasksResult = "tasks/result"
+	MethodTasksCancel = "tasks/cancel"
+	MethodTasksList   = "tasks/list"
 )
 
 // MCP notification methods.

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -5,7 +5,7 @@ import "slices"
 // MCPVersion is the default protocol version this library advertises when a
 // client requests a version it does not support (or requests none). It is the
 // newest revision fully implemented and certified by the conformance suite.
-const MCPVersion = "2025-06-18"
+const MCPVersion = "2025-11-25"
 
 // SupportedVersions lists every MCP protocol revision this library can speak,
 // ordered oldest→newest. The server negotiates the best match against the
@@ -19,6 +19,7 @@ var SupportedVersions = []string{
 	"2024-11-05",
 	"2025-03-26",
 	"2025-06-18",
+	"2025-11-25",
 }
 
 // IsSupportedVersion reports whether v is a protocol version this library

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -17,6 +17,10 @@ const (
 	CodeNotFound     = -32001
 	CodeUnauthorized = -32002
 	CodeRateLimited  = -32003
+	// CodeURLElicitationRequired signals that a request cannot proceed until a
+	// url-mode elicitation is completed (MCP 2025-11-25, SEP-1036). The error
+	// data carries the required elicitations.
+	CodeURLElicitationRequired = -32042
 )
 
 // Error represents a JSON-RPC 2.0 error.
@@ -82,4 +86,15 @@ func NewNotFound(msg string) *Error {
 // NewUnauthorized creates an unauthorized error (-32002).
 func NewUnauthorized(msg string) *Error {
 	return &Error{Code: CodeUnauthorized, Message: msg}
+}
+
+// NewURLElicitationRequired creates a URL-elicitation-required error (-32042,
+// MCP 2025-11-25). elicitations is the list of url-mode elicitations the client
+// must complete before retrying, carried in the error data.
+func NewURLElicitationRequired(msg string, elicitations any) *Error {
+	return &Error{
+		Code:    CodeURLElicitationRequired,
+		Message: msg,
+		Data:    map[string]any{"elicitations": elicitations},
+	}
 }

--- a/server/elicitation.go
+++ b/server/elicitation.go
@@ -8,12 +8,30 @@ import (
 	"go.klarlabs.de/mcp/protocol"
 )
 
-// ElicitRequest is sent by the server to request structured input from the user.
+// Elicitation modes (MCP 2025-11-25). Form collects structured data in-band;
+// URL directs the user to an out-of-band URL for sensitive interactions
+// (credentials, payment, third-party OAuth) that must not pass through the client.
+const (
+	ElicitModeForm = "form"
+	ElicitModeURL  = "url"
+)
+
+// ElicitRequest is sent by the server to request input from the user.
 type ElicitRequest struct {
+	// Mode is "form" (default) or "url" (MCP 2025-11-25). Omitted means form.
+	Mode string `json:"mode,omitempty"`
 	// Message is a human-readable message describing what input is needed.
 	Message string `json:"message"`
-	// RequestedSchema is a JSON Schema describing the desired input structure.
+	// RequestedSchema is a JSON Schema describing the desired input structure
+	// (form mode). It is a restricted flat object of primitives; enum variants
+	// (oneOf/anyOf with const+title) and per-primitive `default` are expressed
+	// directly in this map (SEP-1330 / SEP-1034).
 	RequestedSchema map[string]any `json:"requestedSchema,omitempty"`
+	// URL is the location the user should navigate to (url mode).
+	URL string `json:"url,omitempty"`
+	// ElicitationID uniquely identifies a url-mode elicitation so a later
+	// notifications/elicitation/complete can be correlated.
+	ElicitationID string `json:"elicitationId,omitempty"`
 }
 
 // ElicitResult is the response from an elicitation request.
@@ -43,6 +61,10 @@ func (e *Elicitor) Elicit(ctx context.Context, req *ElicitRequest) (*ElicitResul
 
 	if !e.session.SupportsFeature("elicitation") {
 		return nil, fmt.Errorf("client does not support elicitation")
+	}
+	// A url-mode request requires the client's url elicitation capability.
+	if req.Mode == ElicitModeURL && !e.session.SupportsFeature("elicitation.url") {
+		return nil, fmt.Errorf("client does not support url-mode elicitation")
 	}
 	if e.session.sender == nil {
 		return nil, ErrNoRequestSender
@@ -85,6 +107,21 @@ func (e *Elicitor) Elicit(ctx context.Context, req *ElicitRequest) (*ElicitResul
 	}
 
 	return &result, nil
+}
+
+// ElicitURL sends a url-mode elicitation (MCP 2025-11-25): it directs the user
+// to an out-of-band URL for a sensitive interaction (credentials, payment,
+// third-party OAuth) that must not pass through the client. An action of
+// "accept" means the user consented to open the URL, not that the out-of-band
+// interaction completed — the server learns that separately. elicitationID
+// correlates a later notifications/elicitation/complete.
+func (e *Elicitor) ElicitURL(ctx context.Context, message, url, elicitationID string) (*ElicitResult, error) {
+	return e.Elicit(ctx, &ElicitRequest{
+		Mode:          ElicitModeURL,
+		Message:       message,
+		URL:           url,
+		ElicitationID: elicitationID,
+	})
 }
 
 // elicitorKey is the context key for the elicitor.

--- a/server/elicitation_url_test.go
+++ b/server/elicitation_url_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// captureSender records the last request and returns a canned response.
+type captureSender struct {
+	last   *protocol.Request
+	result any
+}
+
+func (c *captureSender) SendRequest(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	c.last = req
+	return &protocol.Response{Result: c.result}, nil
+}
+
+func TestElicitURL_SendsURLMode(t *testing.T) {
+	sender := &captureSender{result: map[string]any{"action": "accept"}}
+	sess := NewSession("t", sender, nil, WithClientCapabilities(ClientCapabilities{
+		Elicitation: true, ElicitationURL: true,
+	}))
+
+	res, err := NewElicitor(sess).ElicitURL(context.Background(),
+		"Provide your API key", "https://example.com/set_key", "elic-1")
+	if err != nil {
+		t.Fatalf("ElicitURL: %v", err)
+	}
+	if res.Action != "accept" {
+		t.Errorf("action = %q, want accept", res.Action)
+	}
+
+	// The sent request must carry url-mode fields.
+	var sent ElicitRequest
+	if err := json.Unmarshal(sender.last.Params, &sent); err != nil {
+		t.Fatalf("unmarshal sent params: %v", err)
+	}
+	if sent.Mode != ElicitModeURL || sent.URL != "https://example.com/set_key" || sent.ElicitationID != "elic-1" {
+		t.Errorf("sent request = %+v, want url-mode with url + id", sent)
+	}
+}
+
+func TestElicitURL_RequiresURLCapability(t *testing.T) {
+	// Client supports form elicitation but not url mode.
+	sender := &captureSender{result: map[string]any{"action": "accept"}}
+	sess := NewSession("t", sender, nil, WithClientCapabilities(ClientCapabilities{Elicitation: true}))
+	_, err := NewElicitor(sess).ElicitURL(context.Background(), "m", "https://x", "id")
+	if err == nil {
+		t.Fatal("expected error when client lacks url elicitation capability")
+	}
+}
+
+func TestClientCapabilities_ElicitationURLParse(t *testing.T) {
+	sess := NewSession("t", nil, nil)
+	sess.SetClientCapabilitiesJSON(json.RawMessage(`{"elicitation":{"url":{}}}`))
+	caps := sess.ClientCapabilities()
+	if !caps.Elicitation || !caps.ElicitationURL {
+		t.Errorf("expected Elicitation && ElicitationURL, got %+v", caps)
+	}
+
+	// Empty elicitation object means form-only (no url).
+	sess2 := NewSession("t", nil, nil)
+	sess2.SetClientCapabilitiesJSON(json.RawMessage(`{"elicitation":{}}`))
+	if c := sess2.ClientCapabilities(); !c.Elicitation || c.ElicitationURL {
+		t.Errorf("empty elicitation should be form-only, got %+v", c)
+	}
+}
+
+func TestURLElicitationRequiredError(t *testing.T) {
+	err := protocol.NewURLElicitationRequired("need info", []map[string]any{{"elicitationId": "x"}})
+	if err.Code != protocol.CodeURLElicitationRequired {
+		t.Errorf("code = %d, want %d", err.Code, protocol.CodeURLElicitationRequired)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,7 @@ type ToolInfo struct {
 	Annotations  *ToolAnnotations
 	Meta         map[string]any
 	Icons        []Icon
+	TaskSupport  TaskSupport
 }
 
 // Option configures a Server.
@@ -91,6 +92,7 @@ type Server struct {
 	middleware   []Middleware
 	completions  *completionRegistry
 	tasks        *TaskManager
+	augTasks     *augTaskRegistry
 	resourceSubs *resourceSubscriptions
 
 	// regErrs accumulates registration collisions. The fluent builder API
@@ -108,6 +110,7 @@ func New(info Info, opts ...Option) *Server {
 		resources:    make(map[string]*Resource),
 		prompts:      make(map[string]*Prompt),
 		resourceSubs: newResourceSubscriptions(),
+		augTasks:     newAugTaskRegistry(),
 	}
 
 	for _, opt := range opts {
@@ -257,6 +260,7 @@ func (s *Server) Tools() []ToolInfo {
 			Annotations:  t.annotations,
 			Meta:         t.meta,
 			Icons:        t.icons,
+			TaskSupport:  t.taskSupport,
 		})
 	}
 	return result
@@ -505,6 +509,25 @@ func (s *Server) HandleCompletion(ctx context.Context, ref CompletionRef, arg Co
 	}
 
 	return completions.Handle(ctx, ref, arg)
+}
+
+// AugTasks returns the task-augmented-request registry (MCP 2025-11-25). It is
+// the store the dispatcher uses for tools/call task augmentation and the
+// tasks/get|result|cancel|list operations.
+func (s *Server) AugTasks() *augTaskRegistry { return s.augTasks }
+
+// HasTaskTools reports whether any registered tool opts into task augmentation
+// (TaskSupport optional or required), used to auto-advertise the server's tasks
+// capability.
+func (s *Server) HasTaskTools() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, t := range s.tools {
+		if t.taskSupport == TaskSupportOptional || t.taskSupport == TaskSupportRequired {
+			return true
+		}
+	}
+	return false
 }
 
 // HasCompletions reports whether any prompt/resource completion handler has

--- a/server/session.go
+++ b/server/session.go
@@ -46,7 +46,10 @@ type ClientCapabilities struct {
 	Sampling    bool             `json:"sampling,omitempty"`
 	Roots       *RootsCapability `json:"roots,omitempty"`
 	Elicitation bool             `json:"elicitation,omitempty"`
-	Channels    bool             `json:"channels,omitempty"`
+	// ElicitationURL reports whether the client supports url-mode elicitation
+	// (MCP 2025-11-25). An empty elicitation capability object means form only.
+	ElicitationURL bool `json:"-"`
+	Channels       bool `json:"channels,omitempty"`
 }
 
 // RootsCapability describes the client's roots support.
@@ -124,9 +127,11 @@ func (s *Session) SetClientCapabilities(caps ClientCapabilities) {
 func (s *Session) SetClientCapabilitiesJSON(raw json.RawMessage) {
 	var wire struct {
 		Sampling    *json.RawMessage `json:"sampling"`
-		Elicitation *json.RawMessage `json:"elicitation"`
-		Channels    *json.RawMessage `json:"channels"`
-		Roots       *struct {
+		Elicitation *struct {
+			URL *json.RawMessage `json:"url"`
+		} `json:"elicitation"`
+		Channels *json.RawMessage `json:"channels"`
+		Roots    *struct {
 			ListChanged bool `json:"listChanged"`
 		} `json:"roots"`
 	}
@@ -137,6 +142,9 @@ func (s *Session) SetClientCapabilitiesJSON(raw json.RawMessage) {
 		Sampling:    wire.Sampling != nil,
 		Elicitation: wire.Elicitation != nil,
 		Channels:    wire.Channels != nil,
+	}
+	if wire.Elicitation != nil && wire.Elicitation.URL != nil {
+		caps.ElicitationURL = true
 	}
 	if wire.Roots != nil {
 		caps.Roots = &RootsCapability{ListChanged: wire.Roots.ListChanged}
@@ -158,6 +166,8 @@ func (s *Session) SupportsFeature(feature string) bool {
 		return s.clientCaps.Roots != nil && s.clientCaps.Roots.ListChanged
 	case "elicitation":
 		return s.clientCaps.Elicitation
+	case "elicitation.url":
+		return s.clientCaps.ElicitationURL
 	case "channels":
 		return s.clientCaps.Channels
 	default:

--- a/server/tasks_augment.go
+++ b/server/tasks_augment.go
@@ -1,0 +1,316 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Sentinel errors from the augmented-task registry, mapped to JSON-RPC
+// -32602 (Invalid params) by the dispatcher per the spec.
+var (
+	// ErrAugTaskNotFound is returned for an unknown or expired taskId.
+	ErrAugTaskNotFound = errors.New("task not found")
+	// ErrAugTaskTerminal is returned when cancelling an already-terminal task.
+	ErrAugTaskTerminal = errors.New("task already in terminal status")
+)
+
+// This file implements task-augmented requests per MCP 2025-11-25 (SEP-1686):
+// a tools/call carrying a `task` field returns a CreateTaskResult immediately
+// and executes in the background; the requestor then polls tasks/get and
+// retrieves the result via tasks/result. It is intentionally separate from the
+// legacy TaskManager in tasks.go (a different, pre-spec model) — the spec model
+// is the one wired into the dispatcher.
+
+// AugTaskStatus is the lifecycle state of a task-augmented request. The valid
+// transitions are working→{input_required,completed,failed,cancelled} and
+// input_required→{working,completed,failed,cancelled}; the last three are
+// terminal.
+type AugTaskStatus string
+
+const (
+	AugTaskWorking       AugTaskStatus = "working"
+	AugTaskInputRequired AugTaskStatus = "input_required"
+	AugTaskCompleted     AugTaskStatus = "completed"
+	AugTaskFailed        AugTaskStatus = "failed"
+	AugTaskCancelled     AugTaskStatus = "cancelled"
+)
+
+func (s AugTaskStatus) terminal() bool {
+	return s == AugTaskCompleted || s == AugTaskFailed || s == AugTaskCancelled
+}
+
+// TaskSupport declares whether a tool may (or must) be invoked as a task, as
+// advertised via a tool's `execution.taskSupport` in tools/list.
+type TaskSupport string
+
+const (
+	TaskSupportForbidden TaskSupport = "forbidden"
+	TaskSupportOptional  TaskSupport = "optional"
+	TaskSupportRequired  TaskSupport = "required"
+)
+
+// AugTask is the spec Task object (2025-11-25). Times are RFC 3339 strings on
+// the wire; TTL/pollInterval are milliseconds.
+type AugTask struct {
+	TaskID        string        `json:"taskId"`
+	Status        AugTaskStatus `json:"status"`
+	StatusMessage string        `json:"statusMessage,omitempty"`
+	CreatedAt     string        `json:"createdAt"`
+	LastUpdatedAt string        `json:"lastUpdatedAt"`
+	TTL           *int64        `json:"ttl"`
+	PollInterval  *int64        `json:"pollInterval,omitempty"`
+
+	// internal (never serialized): the underlying request result once terminal
+	// (execResult, or execErr for a protocol-level error), a done channel for
+	// tasks/result blocking, and a cancel func for the background execution.
+	execResult any
+	execErr    error
+	done       chan struct{}
+	cancel     context.CancelFunc
+	ttlDur     time.Duration
+	expireAt   time.Time
+}
+
+// augTaskRegistry is a bounded, TTL-evicting store of task-augmented requests.
+type augTaskRegistry struct {
+	mu           sync.Mutex
+	tasks        map[string]*AugTask
+	maxTasks     int
+	pollInterval int64 // ms, suggested to requestors
+	now          func() time.Time
+}
+
+func newAugTaskRegistry() *augTaskRegistry {
+	return &augTaskRegistry{
+		tasks:        make(map[string]*AugTask),
+		maxTasks:     defaultMaxTasks,
+		pollInterval: 1000,
+		now:          time.Now,
+	}
+}
+
+// newAugTaskID returns a cryptographically secure task id (spec: unguessable
+// when context-binding is unavailable).
+func newAugTaskID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// create registers a new working task with the requested ttl (nil = unlimited).
+// It evicts expired tasks first and enforces the size cap.
+func (r *augTaskRegistry) create(ttlMs *int64) (*AugTask, error) {
+	id, err := newAugTaskID()
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictExpiredLocked()
+	if len(r.tasks) >= r.maxTasks {
+		r.evictOldestTerminalLocked()
+	}
+	now := r.now()
+	ts := now.UTC().Format(time.RFC3339)
+	poll := r.pollInterval
+	t := &AugTask{
+		TaskID:        id,
+		Status:        AugTaskWorking,
+		CreatedAt:     ts,
+		LastUpdatedAt: ts,
+		TTL:           ttlMs,
+		PollInterval:  &poll,
+		done:          make(chan struct{}),
+	}
+	if ttlMs != nil {
+		t.ttlDur = time.Duration(*ttlMs) * time.Millisecond
+		t.expireAt = now.Add(t.ttlDur)
+	}
+	r.tasks[id] = t
+	return t, nil
+}
+
+// get returns a live (non-expired) task by id.
+func (r *augTaskRegistry) get(id string) (*AugTask, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tasks[id]
+	if !ok {
+		return nil, false
+	}
+	if r.expiredLocked(t) {
+		delete(r.tasks, id)
+		return nil, false
+	}
+	return t, true
+}
+
+// complete moves a task to a terminal status carrying the underlying result
+// (execResult) or a protocol-level error (execErr), and closes its done channel
+// exactly once. A no-op if the task is already terminal (e.g. cancelled).
+func (r *augTaskRegistry) complete(id string, status AugTaskStatus, result any, execErr error, msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tasks[id]
+	if !ok || t.Status.terminal() {
+		return
+	}
+	t.Status = status
+	t.StatusMessage = msg
+	t.execResult = result
+	t.execErr = execErr
+	t.LastUpdatedAt = r.now().UTC().Format(time.RFC3339)
+	close(t.done)
+}
+
+// cancelTask transitions a task to cancelled (best-effort stopping its
+// execution). It returns ErrAugTaskNotFound for an unknown id and
+// ErrAugTaskTerminal if the task already reached a terminal status.
+func (r *augTaskRegistry) cancelTask(id string) (*AugTask, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tasks[id]
+	if !ok || r.expiredLocked(t) {
+		return nil, ErrAugTaskNotFound
+	}
+	if t.Status.terminal() {
+		return nil, ErrAugTaskTerminal
+	}
+	t.Status = AugTaskCancelled
+	t.StatusMessage = "The task was cancelled by request."
+	t.LastUpdatedAt = r.now().UTC().Format(time.RFC3339)
+	if t.cancel != nil {
+		t.cancel()
+	}
+	close(t.done)
+	return t, nil
+}
+
+// list returns tasks sorted newest-first with cursor pagination.
+func (r *augTaskRegistry) list(cursor string, limit int) ([]*AugTask, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictExpiredLocked()
+	all := make([]*AugTask, 0, len(r.tasks))
+	for _, t := range r.tasks {
+		all = append(all, t)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].CreatedAt > all[j].CreatedAt })
+
+	start := 0
+	if cursor != "" {
+		for i, t := range all {
+			if t.TaskID == cursor {
+				start = i + 1
+				break
+			}
+		}
+	}
+	if limit <= 0 || limit > maxListLimit {
+		limit = defaultListLimit
+	}
+	end := start + limit
+	next := ""
+	if end < len(all) {
+		next = all[end-1].TaskID
+	} else {
+		end = len(all)
+	}
+	return all[start:end], next
+}
+
+// StartAugmentedCall creates a working task and runs exec in the background,
+// recording the outcome so tasks/result can return it. exec returns the
+// underlying result (e.g. a CallToolResult map), whether that result represents
+// a tool execution error (isError), and any protocol-level error. The returned
+// AugTask is the CreateTaskResult payload sent to the requestor immediately.
+func (s *Server) StartAugmentedCall(ctx context.Context, ttlMs *int64, exec func(context.Context) (result any, isError bool, err error)) (*AugTask, error) {
+	t, err := s.augTasks.create(ttlMs)
+	if err != nil {
+		return nil, err
+	}
+	// A cancellable context so tasks/cancel can stop the background work.
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	s.augTasks.mu.Lock()
+	t.cancel = cancel
+	s.augTasks.mu.Unlock()
+
+	go func() {
+		defer cancel()
+		result, isError, execErr := exec(runCtx)
+		switch {
+		case execErr != nil:
+			s.augTasks.complete(t.TaskID, AugTaskFailed, nil, execErr, execErr.Error())
+		case isError:
+			s.augTasks.complete(t.TaskID, AugTaskFailed, result, nil, "tool execution error")
+		default:
+			s.augTasks.complete(t.TaskID, AugTaskCompleted, result, nil, "")
+		}
+	}()
+	return t, nil
+}
+
+// GetAugTask returns a task's current state by id (nil, false if unknown/expired).
+func (s *Server) GetAugTask(id string) (*AugTask, bool) { return s.augTasks.get(id) }
+
+// AwaitAugTaskResult blocks until the task reaches a terminal status (or ctx is
+// cancelled), then returns its underlying result and protocol error. It returns
+// ErrAugTaskNotFound for an unknown/expired id.
+func (s *Server) AwaitAugTaskResult(ctx context.Context, id string) (result any, execErr error, err error) {
+	t, ok := s.augTasks.get(id)
+	if !ok {
+		return nil, nil, ErrAugTaskNotFound
+	}
+	select {
+	case <-t.done:
+		return t.execResult, t.execErr, nil
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+}
+
+// CancelAugTask cancels a task (ErrAugTaskNotFound / ErrAugTaskTerminal on
+// failure), returning the updated task.
+func (s *Server) CancelAugTask(id string) (*AugTask, error) { return s.augTasks.cancelTask(id) }
+
+// ListAugTasks returns tasks newest-first with cursor pagination.
+func (s *Server) ListAugTasks(cursor string, limit int) ([]*AugTask, string) {
+	return s.augTasks.list(cursor, limit)
+}
+
+func (r *augTaskRegistry) expiredLocked(t *AugTask) bool {
+	return t.TTL != nil && !t.expireAt.IsZero() && r.now().After(t.expireAt)
+}
+
+func (r *augTaskRegistry) evictExpiredLocked() {
+	for id, t := range r.tasks {
+		if r.expiredLocked(t) {
+			delete(r.tasks, id)
+		}
+	}
+}
+
+// evictOldestTerminalLocked drops the oldest terminal task to make room; if none
+// are terminal the cap is a soft ceiling (working tasks are never evicted).
+func (r *augTaskRegistry) evictOldestTerminalLocked() {
+	var oldestID string
+	var oldest string
+	for id, t := range r.tasks {
+		if !t.Status.terminal() {
+			continue
+		}
+		if oldestID == "" || t.CreatedAt < oldest {
+			oldestID, oldest = id, t.CreatedAt
+		}
+	}
+	if oldestID != "" {
+		delete(r.tasks, oldestID)
+	}
+}

--- a/server/tool.go
+++ b/server/tool.go
@@ -6,9 +6,19 @@ import (
 	"fmt"
 	"reflect"
 
-	"go.klarlabs.de/mcp/protocol"
 	"go.klarlabs.de/mcp/schema"
 )
+
+// ToolInputError is returned by Tool.Execute when the call's input fails to
+// parse or does not satisfy the tool's input schema. Per MCP 2025-11-25
+// (SEP-1303) the dispatcher reports it as a tool execution error (an isError
+// CallToolResult) rather than a protocol error, so the model sees the problem
+// and can retry with corrected input.
+type ToolInputError struct {
+	Message string
+}
+
+func (e *ToolInputError) Error() string { return e.Message }
 
 // StructuredResult allows tool handlers to return structured content
 // alongside text content blocks. When a handler returns this type,
@@ -245,17 +255,19 @@ func (t *Tool) Icons() []Icon {
 func (t *Tool) Execute(ctx context.Context, input json.RawMessage) (any, error) {
 	// Validate input against the generated schema before the handler runs,
 	// so invalid-per-schema input never reaches business logic. Validation is
-	// on by default; SkipValidation opts a tool out.
+	// on by default; SkipValidation opts a tool out. A failure is a
+	// ToolInputError, which the dispatcher surfaces as a tool execution error
+	// (isError result) per MCP 2025-11-25 / SEP-1303 so the model can self-correct.
 	if !t.skipValidation && t.validatable != nil {
 		if err := t.validatable.Validate(input); err != nil {
-			return nil, protocol.NewInvalidParams(fmt.Sprintf("input validation failed: %v", err))
+			return nil, &ToolInputError{Message: fmt.Sprintf("input validation failed: %v", err)}
 		}
 	}
 
 	// Create input value
 	inputPtr := reflect.New(t.inputType)
 	if err := json.Unmarshal(input, inputPtr.Interface()); err != nil {
-		return nil, protocol.NewInvalidParams(fmt.Sprintf("failed to parse input: %v", err))
+		return nil, &ToolInputError{Message: fmt.Sprintf("failed to parse input: %v", err)}
 	}
 
 	// Build arguments

--- a/server/tool.go
+++ b/server/tool.go
@@ -36,7 +36,12 @@ type Tool struct {
 	annotations    *ToolAnnotations
 	meta           map[string]any
 	icons          []Icon
+	taskSupport    TaskSupport
 }
+
+// TaskSupport reports whether this tool may be invoked as a task-augmented
+// request (MCP 2025-11-25). Empty is treated as "forbidden".
+func (t *Tool) TaskSupport() TaskSupport { return t.taskSupport }
 
 // ToolBuilder provides a fluent API for building tools.
 type ToolBuilder struct {
@@ -102,6 +107,19 @@ func (b *ToolBuilder) Meta(meta map[string]any) *ToolBuilder {
 		return b
 	}
 	b.tool.meta = meta
+	return b
+}
+
+// TaskSupport declares whether this tool may be invoked as a task-augmented
+// request (MCP 2025-11-25): "optional" lets clients run it as a task or
+// normally, "required" forces task invocation, "forbidden" (the default)
+// disallows it. Setting optional/required auto-advertises the server's tasks
+// capability. The tool value is echoed as `execution.taskSupport` in tools/list.
+func (b *ToolBuilder) TaskSupport(mode TaskSupport) *ToolBuilder {
+	if b.err != nil {
+		return b
+	}
+	b.tool.taskSupport = mode
 	return b
 }
 

--- a/server/tool_test.go
+++ b/server/tool_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	"go.klarlabs.de/mcp/protocol"
 )
 
 func TestToolBuilder(t *testing.T) {
@@ -293,12 +291,11 @@ func TestTool_Execute_ValidationByDefault(t *testing.T) {
 			t.Fatal("handler must not be called when input is invalid per schema")
 		}
 
-		var mcpErr *protocol.Error
-		if !errors.As(err, &mcpErr) {
-			t.Fatalf("expected *protocol.Error, got %T: %v", err, err)
-		}
-		if mcpErr.Code != protocol.CodeInvalidParams {
-			t.Errorf("error code = %d, want %d (InvalidParams)", mcpErr.Code, protocol.CodeInvalidParams)
+		// SEP-1303: input validation failures are ToolInputErrors (surfaced by
+		// the dispatcher as an isError result), not protocol errors.
+		var inputErr *ToolInputError
+		if !errors.As(err, &inputErr) {
+			t.Fatalf("expected *ToolInputError, got %T: %v", err, err)
 		}
 	})
 


### PR DESCRIPTION
Stacked on #124. **Completes and certifies MCP `2025-11-25`** — `protocol.SupportedVersions` now lists all four revisions (`2024-11-05` → `2025-11-25`) and the default advances to `2025-11-25`. The conformance harness runs the full method set against every supported version.

## What's in it
- **Task-augmented requests** (SEP-1686) — augmented `tools/call` → `CreateTaskResult`, background execution, `tasks/get`/`result`/`cancel`/`list`, `execution.taskSupport`, `tasks` capability, related-task meta. Cryptographic task IDs; bounded TTL-evicting registry; race-tested async path.
- **Input validation as tool execution errors** (SEP-1303) — invalid input → `isError` result (new `ToolInputError`), not `-32602`.
- **URL-mode elicitation** (SEP-1036) — `ElicitRequest.mode/url/elicitationId`, `Elicitor.ElicitURL`, `elicitation.url` capability, `-32042` error.
- **Icons** (SEP-973), **sampling-with-tools** (SEP-1577), **JSON Schema 2020-12** (SEP-1613), **OAuth/OIDC discovery metadata** (advertise-only).
- Elicitation enums (`oneOf`/`anyOf` + `const`/`title`) & per-primitive defaults (SEP-1330/1034) — expressible in the freeform `requestedSchema`, no API change.

## Quality
11/11 packages pass `-race` (3× on the async task path), `golangci-lint` clean, every commit through the warden shift-left gate. Conformance: full method set × 4 revisions.

Remaining across the roadmap: **Phase 4** — the `2026-07-28` stateless v2 rewrite (breaking; removes what Phases 1–3 add), best done as its own major-version effort.

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT