### PR TITLE
Phase 4 (foundation): 2026-07-28 stateless — server/discover + per-request _meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ is deliberately NOT yet in `SupportedVersions`.
   connection state), and the result is stamped `resultType:"complete"`. A
   request without the modern `_meta` is served unchanged under legacy semantics
   (dual-era).
+- **CacheableResult** (SEP-2549) — `WithResultCache(ttlMs, scope)` stamps
+  `ttlMs`/`cacheScope` on cacheable results (`tools/list`, `prompts/list`,
+  `resources/list`, `resources/read`, `resources/templates/list`) for modern
+  clients; legacy responses are unaffected.
+- **Modern error renumbering** — resource-not-found is `-32602` on the modern
+  path (vs `-32001` on legacy), per the retirement of the `-32002` not-found code.
 
 ### Certified — 2025-11-25 negotiable (Phase 3 complete)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,15 +50,20 @@ is deliberately NOT yet in `SupportedVersions`.
   A client opts into notification types and resource `uris`; the server registers
   the URIs on the request-scoped session's SubscriptionManager and returns a
   `subscriptionId` (correlates the `io.modelcontextprotocol/subscriptionId` tag on
-  subsequent notifications). No session → `-32602`. Note: the long-lived
-  POST-response stream that carries the tagged notifications is a deferred
-  transport follow-up; this increment lands the protocol method + registration.
+  subsequent notifications). No session → `-32602`. On Streamable HTTP the method
+  is served as a **long-lived POST-response SSE stream**: the handler runs once to
+  register + return the `subscriptionId`, then the response stays open forwarding
+  notifications pushed via `HTTP.NotifySubscription` (each tagged with the
+  `subscriptionId` in `_meta`) until the client disconnects, reusing the standing-
+  stream registry for backpressure/cleanup.
 - **Streamable HTTP routing headers** — `Mcp-Method` / `Mcp-Name` on the
   streamable POST path are validated against the JSON-RPC body (method, and the
   name/uri target for `tools/call`/`prompts/get`/`resources/read`); a mismatch
   returns `-32020` HeaderMismatch (`protocol.NewHeaderMismatch`). Validation is
-  applied when the headers are present; hard-requiring them is a deferred
-  follow-up (likely gated behind the Stateless option).
+  applied when the headers are present by default; `WithStreamableStateless()`
+  additionally **hard-requires** `Mcp-Method` (absent → `-32020`) and **drops the
+  `Mcp-Session-Id` lifecycle** (no minting, no per-request requirement) — the
+  modern (MCP 2026-07-28) streamable model, opt-in until v2.
 - **Modern Icon fields** (SEP-973 evolution) — the `Icon` type gains additive
   modern fields `src` / `sizes` / `theme` alongside the legacy `uri` / `mimeType`
   / `size` (legacy JSON output is unchanged). `NewIcon(src)` + `WithMimeType` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ is deliberately NOT yet in `SupportedVersions`.
   legacy (session + RequestSender) path is unchanged. New public types
   `InputRequest`, `InputResponse`, `InputRequiredResult`, sentinel
   `ErrInputRequired`, and `InputKind{Sampling,Elicitation,Roots}`.
+- **`subscriptions/listen`** (SEP; MCP 2026-07-28) — the stateless subscription
+  method that replaces the GET SSE stream + `resources/subscribe`/`unsubscribe`.
+  A client opts into notification types and resource `uris`; the server registers
+  the URIs on the request-scoped session's SubscriptionManager and returns a
+  `subscriptionId` (correlates the `io.modelcontextprotocol/subscriptionId` tag on
+  subsequent notifications). No session → `-32602`. Note: the long-lived
+  POST-response stream that carries the tagged notifications is a deferred
+  transport follow-up; this increment lands the protocol method + registration.
+- **Streamable HTTP routing headers** — `Mcp-Method` / `Mcp-Name` on the
+  streamable POST path are validated against the JSON-RPC body (method, and the
+  name/uri target for `tools/call`/`prompts/get`/`resources/read`); a mismatch
+  returns `-32020` HeaderMismatch (`protocol.NewHeaderMismatch`). Validation is
+  applied when the headers are present; hard-requiring them is a deferred
+  follow-up (likely gated behind the Stateless option).
+- **Modern Icon fields** (SEP-973 evolution) — the `Icon` type gains additive
+  modern fields `src` / `sizes` / `theme` alongside the legacy `uri` / `mimeType`
+  / `size` (legacy JSON output is unchanged). `NewIcon(src)` + `WithMimeType` /
+  `WithSizes` / `WithTheme` builders and `Normalize()` (fills each era's empty
+  fields from the other) ease dual-era construction.
 - **CacheableResult** (SEP-2549) — `WithResultCache(ttlMs, scope)` stamps
   `ttlMs`/`cacheScope` on cacheable results (`tools/list`, `prompts/list`,
   `resources/list`, `resources/read`, `resources/templates/list`) for modern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ is deliberately NOT yet in `SupportedVersions`.
 - **Reserved `_meta` key + resultType constants** — `protocol.MetaKey*`
   (protocolVersion/clientInfo/clientCapabilities/logLevel/subscriptionId/
   related-task), `protocol.ResultTypeComplete`/`InputRequired`, `protocol.DraftVersion`.
+- **Stateless per-request `_meta` handling.** A request carrying
+  `io.modelcontextprotocol/protocolVersion` in `_meta` is served on the modern
+  path: required fields (protocolVersion/clientInfo/clientCapabilities) are
+  enforced (`-32602` if missing), the version is checked (`-32022` if
+  unsupported; `server/discover` exempt), a request-scoped session is built from
+  the declared capabilities (so sampling/elicitation gating works with no
+  connection state), and the result is stamped `resultType:"complete"`. A
+  request without the modern `_meta` is served unchanged under legacy semantics
+  (dual-era).
 
 ### Certified — 2025-11-25 negotiable (Phase 3 complete)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ is deliberately NOT yet in `SupportedVersions`.
   clients; legacy responses are unaffected.
 - **Modern error renumbering** — resource-not-found is `-32602` on the modern
   path (vs `-32001` on legacy), per the retirement of the `-32002` not-found code.
+- **Deprecation posture** (SEP-2577) — sampling, roots, and logging are
+  documented as deprecated in 2026-07-28 (12-month window; still fully
+  functional) with their migration paths (provider APIs / tool params / stderr
+  + OpenTelemetry).
 
 ### Certified — 2025-11-25 negotiable (Phase 3 complete)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ is deliberately NOT yet in `SupportedVersions`.
   connection state), and the result is stamped `resultType:"complete"`. A
   request without the modern `_meta` is served unchanged under legacy semantics
   (dual-era).
+- **MRTR — Multi Round-Trip Requests** (SEP-2575) — the stateless replacement
+  for every server-initiated request. A modern tool handler that calls sampling,
+  elicitation, or `roots/list` without a supplied response no longer fails with
+  `ErrNoRequestSender`: the call is recorded and the request returns
+  `resultType:"input_required"` with the `inputRequests` it needs (`InputRequest`
+  ID/kind/payload). The client fulfills them and retries the same call carrying
+  `io.modelcontextprotocol/inputResponses` in `_meta`; the handler is replayed
+  and its input calls resolve from those responses (correlated by stable
+  `ir-N` IDs). `requestState` is echoed back for client-side correlation. The
+  legacy (session + RequestSender) path is unchanged. New public types
+  `InputRequest`, `InputResponse`, `InputRequiredResult`, sentinel
+  `ErrInputRequired`, and `InputKind{Sampling,Elicitation,Roots}`.
 - **CacheableResult** (SEP-2549) — `WithResultCache(ttlMs, scope)` stamps
   `ttlMs`/`cacheScope` on cacheable results (`tools/list`, `prompts/list`,
   `resources/list`, `resources/read`, `resources/templates/list`) for modern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — 2026-07-28 stateless foundation (Phase 4, experimental)
+
+First increment of the modern, stateless MCP revision (RC, SEP-2575). This lays
+the foundation; the full stateless request path (per-request `_meta`, MRTR,
+`subscriptions/listen`, routing headers) is built incrementally and `2026-07-28`
+is deliberately NOT yet in `SupportedVersions`.
+
+- **`server/discover`** (SEP-2575) — the stateless replacement for the
+  `initialize` handshake. Returns `{ resultType:"complete", supportedVersions,
+  capabilities (incl. the extensions map), serverInfo, instructions }` in one
+  cacheable request. mcp-go is dual-era: it keeps `initialize` for legacy clients.
+- **Extensions capability map** (SEP-2133) — `capabilities.extensions` advertises
+  reverse-DNS extension ids: `io.modelcontextprotocol/ui` (MCP Apps, always) and
+  `io.modelcontextprotocol/tasks` (when a tool opts into task augmentation).
+- **Modern error codes** — `-32020` HeaderMismatch, `-32021`
+  MissingRequiredClientCapability, `-32022` UnsupportedProtocolVersion, with
+  `protocol.NewUnsupportedProtocolVersion` / `NewMissingRequiredClientCapability`.
+- **Reserved `_meta` key + resultType constants** — `protocol.MetaKey*`
+  (protocolVersion/clientInfo/clientCapabilities/logLevel/subscriptionId/
+  related-task), `protocol.ResultTypeComplete`/`InputRequired`, `protocol.DraftVersion`.
+
 ### Certified — 2025-11-25 negotiable (Phase 3 complete)
 
 `protocol.SupportedVersions` now includes `2025-11-25` and the default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,24 @@ is deliberately NOT yet in `SupportedVersions`.
   additionally **hard-requires** `Mcp-Method` (absent → `-32020`) and **drops the
   `Mcp-Session-Id` lifecycle** (no minting, no per-request requirement) — the
   modern (MCP 2026-07-28) streamable model, opt-in until v2.
+- **W3C Trace Context propagation** — a modern request carrying
+  `io.modelcontextprotocol/traceparent` / `tracestate` / `baggage` in `_meta` has
+  its distributed-trace position extracted (via the OTel `TraceContext`/`Baggage`
+  propagators) so the server span joins the client's trace. The OTel middleware
+  parents the top-level span onto the incoming remote span; `applyModern`
+  propagates it to handler-level spans. `WithOTelPropagator` option added.
+- **`tasks/update` + modern `tasks/list` retirement** — `tasks/update` refreshes
+  a non-terminal task's `ttl` (null clears the deadline) so a slow task is not
+  evicted before completion (`Server.UpdateAugTask`); `tasks/list` is served for
+  legacy sessions but returns `MethodNotFound` for modern (2026-07-28) requests,
+  per the tasks extension favoring direct task handles over listing.
+- **Deterministic `tools/list` ordering** — tools are sorted by name, so
+  `tools/list` returns a stable order across calls (was Go map-iteration order).
+- **Full JSON Schema 2020-12** for `inputSchema`/`outputSchema` — the `schema`
+  package now supports `$ref`/`$defs` (auto-emitted to break recursive types),
+  `oneOf`/`anyOf`/`allOf`, and `if`/`then`/`else`: generated, marshaled, and
+  enforced by the validator (`$ref` resolved against root `$defs`; unresolvable
+  refs treated leniently). Legacy non-recursive output is unchanged.
 - **Modern Icon fields** (SEP-973 evolution) — the `Icon` type gains additive
   modern fields `src` / `sizes` / `theme` alongside the legacy `uri` / `mimeType`
   / `size` (legacy JSON output is unchanged). `NewIcon(src)` + `WithMimeType` /

--- a/docs/revisions-roadmap.md
+++ b/docs/revisions-roadmap.md
@@ -172,10 +172,12 @@ clients keep working, then make it the default in v2.
   types; tag with `io.modelcontextprotocol/subscriptionId`.
 
 **Multi Round-Trip Requests (MRTR)** — replaces all server-initiated requests
-- [ ] Every result carries required `resultType` (`"complete"` | `"input_required"`).
-- [ ] Replace server-initiated `roots/list`, `sampling/createMessage`,
+- [x] Every result carries required `resultType` (`"complete"` | `"input_required"`).
+- [x] Replace server-initiated `roots/list`, `sampling/createMessage`,
   `elicitation/create` with `InputRequiredResult` + client retry carrying
-  `inputResponses`; correlate via `requestState`.
+  `inputResponses`; correlate via `requestState`. (Replay/continuation model:
+  broker fulfills input calls from client-supplied responses or records them as
+  pending `input_required`; handler is re-run each round.)
 
 **Transport**
 - [ ] **Drop `Mcp-Session-Id`** (sessions removed from the protocol layer).

--- a/docs/revisions-roadmap.md
+++ b/docs/revisions-roadmap.md
@@ -167,9 +167,11 @@ clients keep working, then make it the default in v2.
 - [ ] **Remove** `initialize`/`notifications/initialized`, `ping`,
   `logging/setLevel`, `notifications/roots/list_changed`,
   `resources/subscribe`/`unsubscribe`, the GET stream (all gated to this version).
-- [ ] **`subscriptions/listen`** — single long-lived POST-response stream
+- [~] **`subscriptions/listen`** — single long-lived POST-response stream
   replacing the GET endpoint + subscribe/unsubscribe; clients opt into notif
-  types; tag with `io.modelcontextprotocol/subscriptionId`.
+  types; tag with `io.modelcontextprotocol/subscriptionId`. (Protocol method +
+  server-side registration + `subscriptionId` landed; the long-lived POST stream
+  transport realization is the remaining piece.)
 
 **Multi Round-Trip Requests (MRTR)** — replaces all server-initiated requests
 - [x] Every result carries required `resultType` (`"complete"` | `"input_required"`).
@@ -182,7 +184,9 @@ clients keep working, then make it the default in v2.
 **Transport**
 - [ ] **Drop `Mcp-Session-Id`** (sessions removed from the protocol layer).
 - [ ] **Remove SSE resumability** (`Last-Event-ID`, event IDs).
-- [ ] **Required routing headers** `Mcp-Method`, `Mcp-Name` on Streamable HTTP POST.
+- [~] **Required routing headers** `Mcp-Method`, `Mcp-Name` on Streamable HTTP POST.
+  (Validated-when-present against the body → `-32020` on mismatch; hard-requiring
+  them is deferred, likely gated behind the Stateless option.)
 - [ ] **`CacheableResult`** — `ttlMs` + `cacheScope` on `tools/list`,
   `prompts/list`, `resources/list`, `resources/read`, `resources/templates/list`.
 - [ ] **W3C Trace Context** in `_meta` (`traceparent`/`tracestate`/`baggage`) —

--- a/docs/revisions-roadmap.md
+++ b/docs/revisions-roadmap.md
@@ -167,11 +167,11 @@ clients keep working, then make it the default in v2.
 - [ ] **Remove** `initialize`/`notifications/initialized`, `ping`,
   `logging/setLevel`, `notifications/roots/list_changed`,
   `resources/subscribe`/`unsubscribe`, the GET stream (all gated to this version).
-- [~] **`subscriptions/listen`** — single long-lived POST-response stream
+- [x] **`subscriptions/listen`** — single long-lived POST-response stream
   replacing the GET endpoint + subscribe/unsubscribe; clients opt into notif
   types; tag with `io.modelcontextprotocol/subscriptionId`. (Protocol method +
-  server-side registration + `subscriptionId` landed; the long-lived POST stream
-  transport realization is the remaining piece.)
+  server-side registration + `subscriptionId` + the long-lived POST-response SSE
+  stream with `subscriptionId`-tagged notifications all landed.)
 
 **Multi Round-Trip Requests (MRTR)** — replaces all server-initiated requests
 - [x] Every result carries required `resultType` (`"complete"` | `"input_required"`).
@@ -182,11 +182,12 @@ clients keep working, then make it the default in v2.
   pending `input_required`; handler is re-run each round.)
 
 **Transport**
-- [ ] **Drop `Mcp-Session-Id`** (sessions removed from the protocol layer).
+- [x] **Drop `Mcp-Session-Id`** (sessions removed from the protocol layer).
+  (`WithStreamableStateless()` drops the session-id lifecycle on the POST path.)
 - [ ] **Remove SSE resumability** (`Last-Event-ID`, event IDs).
-- [~] **Required routing headers** `Mcp-Method`, `Mcp-Name` on Streamable HTTP POST.
-  (Validated-when-present against the body → `-32020` on mismatch; hard-requiring
-  them is deferred, likely gated behind the Stateless option.)
+- [x] **Required routing headers** `Mcp-Method`, `Mcp-Name` on Streamable HTTP POST.
+  (Validated-when-present by default; `WithStreamableStateless()` hard-requires
+  `Mcp-Method` → `-32020` on absence/mismatch.)
 - [ ] **`CacheableResult`** — `ttlMs` + `cacheScope` on `tools/list`,
   `prompts/list`, `resources/list`, `resources/read`, `resources/templates/list`.
 - [ ] **W3C Trace Context** in `_meta` (`traceparent`/`tracestate`/`baggage`) —

--- a/docs/revisions-roadmap.md
+++ b/docs/revisions-roadmap.md
@@ -190,18 +190,19 @@ clients keep working, then make it the default in v2.
   `Mcp-Method` → `-32020` on absence/mismatch.)
 - [ ] **`CacheableResult`** — `ttlMs` + `cacheScope` on `tools/list`,
   `prompts/list`, `resources/list`, `resources/read`, `resources/templates/list`.
-- [ ] **W3C Trace Context** in `_meta` (`traceparent`/`tracestate`/`baggage`) —
+- [x] **W3C Trace Context** in `_meta` (`traceparent`/`tracestate`/`baggage`) —
   ties into existing OTel middleware.
-- [ ] Deterministic ordering of `tools/list`.
+- [x] Deterministic ordering of `tools/list`.
 
 **Extensions framework (SEP-2133)**
 - [ ] Add the **`extensions` capability map** (reverse-DNS ids) to client/server
   capabilities.
 - [ ] Re-express **MCP Apps** through the extensions framework (today it's raw
   `_meta.ui.resourceUri`); certify against `io.modelcontextprotocol/apps`.
-- [ ] Move **Tasks** to the `io.modelcontextprotocol/tasks` extension: polling
+- [~] Move **Tasks** to the `io.modelcontextprotocol/tasks` extension: polling
   `tasks/get`, new `tasks/update`, **remove `tasks/list`**, allow unsolicited task
-  handles.
+  handles. (tasks/update added; tasks/list gated off for modern; extension
+  already advertised. Unsolicited task handles remain.)
 
 **Auth / errors / deprecations**
 - [ ] `iss` validation (RFC 9207); `application_type` in DCR; Client ID Metadata
@@ -210,7 +211,7 @@ clients keep working, then make it the default in v2.
   `HeaderMismatch` `-32001`→`-32020`, etc.; adopt the `-32020..-32099` MCP range.
 - [ ] **Deprecate (keep working 12 mo)** Roots, Sampling, Logging; document the
   migrations (tool params / provider APIs / stderr+OTel).
-- [ ] Loosen `inputSchema`/`outputSchema` to full JSON Schema 2020-12 (`$ref`,
+- [x] Loosen `inputSchema`/`outputSchema` to full JSON Schema 2020-12 (`$ref`,
   `oneOf`/`anyOf`, conditionals).
 - [ ] Make `Stateless` the default; tag **v2.0.0**.
 

--- a/docs/revisions-roadmap.md
+++ b/docs/revisions-roadmap.md
@@ -197,16 +197,24 @@ clients keep working, then make it the default in v2.
 **Extensions framework (SEP-2133)**
 - [ ] Add the **`extensions` capability map** (reverse-DNS ids) to client/server
   capabilities.
-- [ ] Re-express **MCP Apps** through the extensions framework (today it's raw
-  `_meta.ui.resourceUri`); certify against `io.modelcontextprotocol/apps`.
+- [x] Re-express **MCP Apps** through the extensions framework. RESOLVED: the MCP
+  Apps extension identifier is `io.modelcontextprotocol/ui` (NOT `/apps` — the
+  feature is "MCP Apps" but the negotiated id is `/ui`, per the ext-apps spec
+  2026-01-26). mcp-go already advertises it via `capabilities.extensions`
+  (`ExtensionUI`) and associates tools via `_meta.ui.resourceUri` (+ the flat
+  `_meta["ui/resourceUri"]`, which the spec deprecates for removal before GA — we
+  keep emitting it for host compat). Already conformant.
 - [~] Move **Tasks** to the `io.modelcontextprotocol/tasks` extension: polling
   `tasks/get`, new `tasks/update`, **remove `tasks/list`**, allow unsolicited task
   handles. (tasks/update added; tasks/list gated off for modern; extension
   already advertised. Unsolicited task handles remain.)
 
 **Auth / errors / deprecations**
-- [ ] `iss` validation (RFC 9207); `application_type` in DCR; Client ID Metadata
-  Documents over DCR.
+- [~] `iss` validation (RFC 9207); `application_type` in DCR; Client ID Metadata
+  Documents over DCR. RESOLVED as OUT OF SCOPE: in-library auth was deliberately
+  removed (see Cross-cutting "Auth stance") — enforcement (iss validation, DCR)
+  belongs at the gateway, and mcp-go stays advertise-only. Not implemented by
+  design; revisit only if the auth stance changes.
 - [ ] Error renumbering: resource-not-found `-32002` → `-32602`;
   `HeaderMismatch` `-32001`→`-32020`, etc.; adopt the `-32020..-32099` MCP range.
 - [ ] **Deprecate (keep working 12 mo)** Roots, Sampling, Logging; document the

--- a/mcp.go
+++ b/mcp.go
@@ -760,6 +760,7 @@ func (h *requestHandler) methodHandlers() map[string]func(context.Context, *prot
 		protocol.MethodTasksResult:            h.handleTasksResult,
 		protocol.MethodTasksCancel:            h.handleTasksCancel,
 		protocol.MethodTasksList:              h.handleTasksList,
+		protocol.MethodTasksUpdate:            h.handleTasksUpdate,
 		protocol.MethodServerDiscover:         h.handleServerDiscover,
 		protocol.MethodSubscriptionsListen:    h.handleSubscriptionsListen,
 	}
@@ -787,6 +788,12 @@ func (h *requestHandler) handle(ctx context.Context, req *protocol.Request) (*pr
 		ctx, err = h.applyModern(ctx, req.Method, meta)
 		if err != nil {
 			return nil, h.publicError(req, err)
+		}
+		// tasks/list is retired in the modern (2026-07-28) tasks extension, which
+		// favors direct task handles over listing. The legacy method stays for
+		// negotiated 2025-11-25 sessions; a modern caller gets MethodNotFound.
+		if req.Method == protocol.MethodTasksList {
+			return nil, h.publicError(req, protocol.NewMethodNotFound(req.Method))
 		}
 	}
 
@@ -1698,6 +1705,24 @@ func (h *requestHandler) handleTasksCancel(_ context.Context, req *protocol.Requ
 	task, err := h.srv.CancelAugTask(params.TaskID)
 	if err != nil {
 		// Both unknown-task and already-terminal map to -32602 per spec.
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	return protocol.NewResponse(req.ID, task), nil
+}
+
+// handleTasksUpdate serves tasks/update (MCP 2026-07-28 tasks extension): refresh
+// a non-terminal task's ttl so a slow task is not evicted before it finishes. A
+// null ttl clears the deadline. Unknown/terminal tasks map to -32602.
+func (h *requestHandler) handleTasksUpdate(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	var params struct {
+		TaskID string `json:"taskId"`
+		TTL    *int64 `json:"ttl"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, protocol.NewInvalidParams(err.Error())
+	}
+	task, err := h.srv.UpdateAugTask(params.TaskID, params.TTL)
+	if err != nil {
 		return nil, protocol.NewInvalidParams(err.Error())
 	}
 	return protocol.NewResponse(req.ID, task), nil

--- a/mcp.go
+++ b/mcp.go
@@ -735,6 +735,7 @@ func (h *requestHandler) methodHandlers() map[string]func(context.Context, *prot
 		protocol.MethodTasksResult:            h.handleTasksResult,
 		protocol.MethodTasksCancel:            h.handleTasksCancel,
 		protocol.MethodTasksList:              h.handleTasksList,
+		protocol.MethodServerDiscover:         h.handleServerDiscover,
 	}
 }
 
@@ -872,13 +873,27 @@ func (h *requestHandler) handleInitialize(ctx context.Context, req *protocol.Req
 
 	capabilities := h.serverCapabilities(manifest)
 
-	// Build serverInfo with required fields
+	result := map[string]any{
+		fieldProtocolVersion: negotiatedVersion,
+		"serverInfo":         serverInfoMap(manifest),
+		"capabilities":       capabilities,
+	}
+
+	// Include instructions if set
+	if instructions := h.srv.Instructions(); instructions != "" {
+		result["instructions"] = instructions
+	}
+
+	return protocol.NewResponse(req.ID, result), nil
+}
+
+// serverInfoMap builds the serverInfo/implementation object shared by
+// initialize and server/discover.
+func serverInfoMap(manifest server.Manifest) map[string]any {
 	serverInfo := map[string]any{
 		fieldName:    manifest.Name,
 		fieldVersion: manifest.Version,
 	}
-
-	// Add optional MCP spec fields if set
 	if manifest.Title != "" {
 		serverInfo["title"] = manifest.Title
 	}
@@ -891,22 +906,47 @@ func (h *requestHandler) handleInitialize(ctx context.Context, req *protocol.Req
 	if len(manifest.Icons) > 0 {
 		serverInfo["icons"] = manifest.Icons
 	}
-	// Add extension field (not in MCP spec)
 	if manifest.BuildInfo != nil {
-		serverInfo["buildInfo"] = manifest.BuildInfo
+		serverInfo["buildInfo"] = manifest.BuildInfo // extension field, not in MCP spec
 	}
+	return serverInfo
+}
+
+// extensionsMap advertises the reverse-DNS extensions the server supports in
+// capabilities.extensions (MCP 2026-07-28). MCP Apps is always offered (mcp-go
+// serves ui:// resources); Tasks when any tool opts into augmentation.
+func (h *requestHandler) extensionsMap() map[string]any {
+	ext := map[string]any{
+		protocol.ExtensionUI: map[string]any{},
+	}
+	if h.srv.HasTaskTools() {
+		ext[protocol.ExtensionTasks] = map[string]any{}
+	}
+	return ext
+}
+
+// handleServerDiscover serves server/discover (MCP 2026-07-28): the stateless
+// replacement for the initialize handshake. It reports the server's supported
+// protocol versions, capabilities (including the extensions map), and identity
+// in a single cacheable result.
+func (h *requestHandler) handleServerDiscover(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+	manifest := h.srv.Manifest()
+	capabilities := h.serverCapabilities(manifest)
+	capabilities["extensions"] = h.extensionsMap()
+
+	supported := make([]string, 0, len(protocol.SupportedVersions)+1)
+	supported = append(supported, protocol.DraftVersion)
+	supported = append(supported, protocol.SupportedVersions...)
 
 	result := map[string]any{
-		fieldProtocolVersion: negotiatedVersion,
-		"serverInfo":         serverInfo,
-		"capabilities":       capabilities,
+		"resultType":        protocol.ResultTypeComplete,
+		"supportedVersions": supported,
+		"capabilities":      capabilities,
+		"serverInfo":        serverInfoMap(manifest),
 	}
-
-	// Include instructions if set
 	if instructions := h.srv.Instructions(); instructions != "" {
 		result["instructions"] = instructions
 	}
-
 	return protocol.NewResponse(req.ID, result), nil
 }
 

--- a/mcp.go
+++ b/mcp.go
@@ -53,6 +53,7 @@ const (
 	fieldListChanged     = "listChanged"
 	fieldText            = "text"
 	fieldType            = "type"
+	fieldContent         = "content"
 	fieldURI             = "uri"
 	fieldTask            = "task"
 	fieldTaskID          = "taskId"
@@ -206,6 +207,27 @@ var (
 const (
 	ElicitModeForm = server.ElicitModeForm
 	ElicitModeURL  = server.ElicitModeURL
+)
+
+// MRTR types (MCP 2026-07-28): the stateless Multi Round-Trip Request model that
+// replaces server-initiated sampling, elicitation, and roots. A stateless
+// handler's input calls are fulfilled from client-supplied InputResponses or, on
+// the first round, returned as an InputRequiredResult for the client to fulfill
+// and retry.
+type InputRequest = server.InputRequest
+type InputResponse = server.InputResponse
+type InputRequiredResult = server.InputRequiredResult
+
+// ErrInputRequired is the sentinel a stateless handler receives from an input
+// call (CreateMessage / Elicit / ListRoots) when the client has not yet supplied
+// that input; propagate it unchanged.
+var ErrInputRequired = server.ErrInputRequired
+
+// Input request kinds carried in InputRequest.Kind.
+const (
+	InputKindSampling    = server.InputKindSampling
+	InputKindElicitation = server.InputKindElicitation
+	InputKindRoots       = server.InputKindRoots
 )
 
 // Channel types for server-initiated push messages
@@ -768,6 +790,15 @@ func (h *requestHandler) handle(ctx context.Context, req *protocol.Request) (*pr
 	}
 
 	resp, err := h.dispatch(ctx, req)
+	// MRTR (MCP 2026-07-28): a stateless handler that called sampling/elicitation/
+	// roots without a supplied response is paused, not failed — surface the
+	// recorded inputRequests as an input_required result for the client to
+	// fulfill and retry.
+	if modern {
+		if r, ok := inputRequiredResponse(ctx, req); ok {
+			return r, nil
+		}
+	}
 	if err != nil {
 		if modern {
 			err = modernizeError(err)
@@ -1022,8 +1053,8 @@ func (h *requestHandler) handleToolsList(ctx context.Context, req *protocol.Requ
 // to surface input-validation failures to the model per SEP-1303.
 func toolExecutionError(msg string) map[string]any {
 	return map[string]any{
-		"content": []map[string]any{{fieldType: fieldText, fieldText: msg}},
-		"isError": true,
+		fieldContent: []map[string]any{{fieldType: fieldText, fieldText: msg}},
+		"isError":    true,
 	}
 }
 
@@ -1213,7 +1244,7 @@ func buildToolCallResponse(tool *server.Tool, result any) (map[string]any, error
 		textContent = string(data)
 		marshaled = data
 	}
-	response["content"] = []map[string]any{
+	response[fieldContent] = []map[string]any{
 		{
 			fieldType: fieldText,
 			fieldText: textContent,
@@ -1233,9 +1264,9 @@ func buildToolCallResponse(tool *server.Tool, result any) (map[string]any, error
 // a missing content field.
 func applyStructuredResult(response map[string]any, v *server.StructuredResult) {
 	if len(v.Content) > 0 {
-		response["content"] = v.Content
+		response[fieldContent] = v.Content
 	} else {
-		response["content"] = []map[string]any{}
+		response[fieldContent] = []map[string]any{}
 	}
 	response["structuredContent"] = v.StructuredContent
 	if v.IsError {
@@ -1597,8 +1628,8 @@ func (h *requestHandler) handleTasksResult(ctx context.Context, req *protocol.Re
 	if !ok || resp == nil {
 		// Cancelled (or resultless) task: surface as a tool execution error.
 		resp = map[string]any{
-			"content": []map[string]any{{fieldType: fieldText, fieldText: "task did not produce a result"}},
-			"isError": true,
+			fieldContent: []map[string]any{{fieldType: fieldText, fieldText: "task did not produce a result"}},
+			"isError":    true,
 		}
 	}
 	attachRelatedTask(resp, params.TaskID)

--- a/mcp.go
+++ b/mcp.go
@@ -761,6 +761,7 @@ func (h *requestHandler) methodHandlers() map[string]func(context.Context, *prot
 		protocol.MethodTasksCancel:            h.handleTasksCancel,
 		protocol.MethodTasksList:              h.handleTasksList,
 		protocol.MethodServerDiscover:         h.handleServerDiscover,
+		protocol.MethodSubscriptionsListen:    h.handleSubscriptionsListen,
 	}
 }
 
@@ -1396,6 +1397,56 @@ func (h *requestHandler) handleResourcesUnsubscribe(ctx context.Context, req *pr
 		h.srv.UnsubscribeResource(clientID, params.URI)
 	}
 	return protocol.NewResponse(req.ID, map[string]any{}), nil
+}
+
+// handleSubscriptionsListen serves subscriptions/listen (MCP 2026-07-28, SEP):
+// the stateless replacement for the GET SSE stream plus resources/subscribe and
+// resources/unsubscribe. A modern client declares the notification methods it
+// wants delivered (e.g. notifications/resources/updated) and, optionally, the
+// resource URIs it cares about. The requested URIs are registered on the
+// request-scoped session's SubscriptionManager — the same machinery
+// resources/subscribe drives — and the handler returns a stable, non-empty
+// subscriptionId. Subsequent notifications carry that id under
+// _meta[io.modelcontextprotocol/subscriptionId] so the client can correlate
+// them with this listen call.
+//
+// This increment covers protocol negotiation and server-side registration only.
+// Realizing the long-lived POST-response stream over which the tagged
+// notifications actually flow is a deferred transport follow-up; nothing under
+// transport/ is wired to it yet.
+func (h *requestHandler) handleSubscriptionsListen(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+	// subscriptions/listen is a modern (stateless) method: the request-scoped
+	// session is built from the per-request _meta. Its absence means the caller
+	// did not send a modern request, so there is nothing to register against.
+	session := server.SessionFromContext(ctx)
+	if session == nil {
+		return nil, protocol.NewInvalidParams("subscriptions/listen requires a modern request (per-request _meta)")
+	}
+
+	var params struct {
+		Notifications []string `json:"notifications"`
+		URIs          []string `json:"uris"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return nil, protocol.NewInvalidParams(err.Error())
+		}
+	}
+
+	// Register each requested resource URI on the session's subscription
+	// manager. An empty URI is rejected rather than silently registered.
+	for _, uri := range params.URIs {
+		if uri == "" {
+			return nil, protocol.NewInvalidParams("subscriptions/listen uris must be non-empty")
+		}
+		session.Subscribe(uri)
+	}
+
+	id, err := newSubscriptionID()
+	if err != nil {
+		return nil, err
+	}
+	return protocol.NewResponse(req.ID, map[string]any{"subscriptionId": id}), nil
 }
 
 func (h *requestHandler) handlePromptsList(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {

--- a/mcp.go
+++ b/mcp.go
@@ -455,6 +455,9 @@ var (
 	WithIcons = server.WithIcons
 	// WithBuildInfo sets build metadata for debugging and version verification.
 	WithBuildInfo = server.WithBuildInfo
+	// WithResultCache sets the cache hint (ttlMs, cacheScope) advertised on
+	// cacheable list/read results to modern (2026-07-28) clients.
+	WithResultCache = server.WithResultCache
 )
 
 // ServeStdio runs the server using stdio transport.
@@ -766,10 +769,14 @@ func (h *requestHandler) handle(ctx context.Context, req *protocol.Request) (*pr
 
 	resp, err := h.dispatch(ctx, req)
 	if err != nil {
+		if modern {
+			err = modernizeError(err)
+		}
 		return nil, h.publicError(req, err)
 	}
 	if modern {
 		withResultType(resp)
+		h.applyCacheHint(req.Method, resp)
 	}
 	return resp, nil
 }

--- a/mcp.go
+++ b/mcp.go
@@ -750,9 +750,26 @@ func (h *requestHandler) handle(ctx context.Context, req *protocol.Request) (*pr
 		defer cancel()
 	}
 
+	// Modern (stateless) path: a request carrying the per-request protocol
+	// _meta is validated and served with a request-scoped session built from
+	// its declared capabilities. Legacy requests fall through unchanged.
+	meta, modern, err := parseModernMeta(req.Params)
+	if err != nil {
+		return nil, h.publicError(req, err)
+	}
+	if modern {
+		ctx, err = h.applyModern(ctx, req.Method, meta)
+		if err != nil {
+			return nil, h.publicError(req, err)
+		}
+	}
+
 	resp, err := h.dispatch(ctx, req)
 	if err != nil {
 		return nil, h.publicError(req, err)
+	}
+	if modern {
+		withResultType(resp)
 	}
 	return resp, nil
 }

--- a/mcp.go
+++ b/mcp.go
@@ -28,12 +28,14 @@
 package mcp
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"go.klarlabs.de/mcp/middleware"
@@ -1015,6 +1017,13 @@ func (h *requestHandler) handleServerDiscover(_ context.Context, req *protocol.R
 
 func (h *requestHandler) handleToolsList(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
 	tools := h.srv.Tools()
+
+	// Sort by name so tools/list returns a deterministic order on every call
+	// (MCP 2026-07-28). Server.Tools() is backed by a Go map, whose iteration
+	// order is randomized; without this the response would vary between calls.
+	slices.SortFunc(tools, func(a, b server.ToolInfo) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	toolList := make([]map[string]any, 0, len(tools))
 	for _, t := range tools {

--- a/mcp_discover_test.go
+++ b/mcp_discover_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+func discover(t *testing.T, srv *Server) map[string]any {
+	t.Helper()
+	handler := newRequestHandler(srv)
+	req := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodServerDiscover, Params: json.RawMessage(`{}`)}
+	resp, err := handler.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("server/discover: %v", err)
+	}
+	return resp.Result.(map[string]any)
+}
+
+func TestServerDiscover_Shape(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "disc", Version: "1.0.0"})
+	srv.Tool("t").Description("").Handler(func(_ struct{}) (string, error) { return "ok", nil })
+
+	res := discover(t, srv)
+
+	if res["resultType"] != protocol.ResultTypeComplete {
+		t.Errorf("resultType = %v, want complete", res["resultType"])
+	}
+	// supportedVersions must include the modern draft plus the legacy set.
+	versions := toStrings(res["supportedVersions"])
+	if !slices.Contains(versions, protocol.DraftVersion) {
+		t.Errorf("supportedVersions missing %s: %v", protocol.DraftVersion, versions)
+	}
+	if !slices.Contains(versions, "2025-11-25") {
+		t.Errorf("supportedVersions missing legacy 2025-11-25: %v", versions)
+	}
+	si := res["serverInfo"].(map[string]any)
+	if si[fieldName] != "disc" {
+		t.Errorf("serverInfo.name = %v", si[fieldName])
+	}
+	// Apps extension always advertised; tools capability present.
+	caps := res["capabilities"].(map[string]any)
+	ext := caps["extensions"].(map[string]any)
+	if _, ok := ext[protocol.ExtensionUI]; !ok {
+		t.Errorf("expected %s extension advertised, got %v", protocol.ExtensionUI, ext)
+	}
+	if _, ok := caps["tools"]; !ok {
+		t.Errorf("expected tools capability in discover, got %v", caps)
+	}
+}
+
+func TestServerDiscover_TasksExtensionWhenOptedIn(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "disc", Version: "1"})
+	srv.Tool("t").Description("").TaskSupport(TaskSupportOptional).
+		Handler(func(_ struct{}) (string, error) { return "ok", nil })
+	ext := discover(t, srv)["capabilities"].(map[string]any)["extensions"].(map[string]any)
+	if _, ok := ext[protocol.ExtensionTasks]; !ok {
+		t.Errorf("expected %s extension when a tool opts into tasks, got %v", protocol.ExtensionTasks, ext)
+	}
+}
+
+func TestModernErrorConstructors(t *testing.T) {
+	upv := protocol.NewUnsupportedProtocolVersion([]string{"2026-07-28"}, "1900-01-01")
+	if upv.Code != protocol.CodeUnsupportedProtocolVersion {
+		t.Errorf("code = %d, want %d", upv.Code, protocol.CodeUnsupportedProtocolVersion)
+	}
+	data := upv.Data.(map[string]any)
+	if data["requested"] != "1900-01-01" {
+		t.Errorf("data.requested = %v", data["requested"])
+	}
+
+	mrc := protocol.NewMissingRequiredClientCapability("sampling")
+	if mrc.Code != protocol.CodeMissingRequiredClientCapability {
+		t.Errorf("code = %d, want %d", mrc.Code, protocol.CodeMissingRequiredClientCapability)
+	}
+}
+
+func toStrings(v any) []string { return v.([]string) }

--- a/mcp_modern.go
+++ b/mcp_modern.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"slices"
 
 	"go.klarlabs.de/mcp/protocol"
@@ -99,4 +100,48 @@ func withResultType(resp *protocol.Response) {
 			m["resultType"] = protocol.ResultTypeComplete
 		}
 	}
+}
+
+// cacheableMethods are the read/list operations whose results carry a
+// CacheableResult hint (ttlMs/cacheScope) in the modern protocol.
+var cacheableMethods = map[string]bool{
+	protocol.MethodToolsList:              true,
+	protocol.MethodPromptsList:            true,
+	protocol.MethodResourcesList:          true,
+	protocol.MethodResourcesRead:          true,
+	protocol.MethodResourcesTemplatesList: true,
+}
+
+// applyCacheHint stamps ttlMs/cacheScope onto a cacheable modern result when the
+// server has a cache hint configured (WithResultCache). server/discover sets its
+// own hint. A no-op otherwise.
+func (h *requestHandler) applyCacheHint(method string, resp *protocol.Response) {
+	if resp == nil || !cacheableMethods[method] {
+		return
+	}
+	ttlMs, scope, ok := h.srv.ResultCache()
+	if !ok {
+		return
+	}
+	if m, mok := resp.Result.(map[string]any); mok {
+		if _, present := m["ttlMs"]; !present {
+			m["ttlMs"] = ttlMs
+		}
+		if scope != "" {
+			if _, present := m["cacheScope"]; !present {
+				m["cacheScope"] = scope
+			}
+		}
+	}
+}
+
+// modernizeError adapts a legacy protocol error to the modern code scheme: the
+// resource-not-found code (mcp-go emits -32001; the spec's -32002 is likewise
+// retired) is replaced by -32602 (Invalid params), per MCP 2026-07-28.
+func modernizeError(err error) error {
+	var mcpErr *protocol.Error
+	if errors.As(err, &mcpErr) && mcpErr.Code == protocol.CodeNotFound {
+		return &protocol.Error{Code: protocol.CodeInvalidParams, Message: mcpErr.Message, Data: mcpErr.Data}
+	}
+	return err
 }

--- a/mcp_modern.go
+++ b/mcp_modern.go
@@ -8,6 +8,10 @@ import (
 	"errors"
 	"slices"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
 	"go.klarlabs.de/mcp/protocol"
 	"go.klarlabs.de/mcp/server"
 	"go.klarlabs.de/mcp/transport"
@@ -35,6 +39,12 @@ type modernMeta struct {
 	// input_required result; requestState is the opaque token echoed back.
 	inputResponses []server.InputResponse
 	requestState   json.RawMessage
+	// W3C Trace Context carried in _meta so the server joins the caller's
+	// distributed trace. traceparent/tracestate feed propagation.TraceContext;
+	// baggage feeds propagation.Baggage.
+	traceparent string
+	tracestate  string
+	baggage     string
 }
 
 // parseModernMeta inspects a request's params `_meta`. It returns (meta, true)
@@ -66,6 +76,15 @@ func parseModernMeta(params json.RawMessage) (*modernMeta, bool, error) {
 		_ = json.Unmarshal(ir, &m.inputResponses)
 	}
 	m.requestState = envelope.Meta[protocol.MetaKeyRequestState]
+	if tp, ok := envelope.Meta[protocol.MetaKeyTraceparent]; ok {
+		_ = json.Unmarshal(tp, &m.traceparent)
+	}
+	if ts, ok := envelope.Meta[protocol.MetaKeyTracestate]; ok {
+		_ = json.Unmarshal(ts, &m.tracestate)
+	}
+	if bg, ok := envelope.Meta[protocol.MetaKeyBaggage]; ok {
+		_ = json.Unmarshal(bg, &m.baggage)
+	}
 	return m, true, nil
 }
 
@@ -95,7 +114,35 @@ func (h *requestHandler) applyModern(ctx context.Context, method string, m *mode
 	// roots) resolve statelessly: fulfilled from inputResponses on a retry, or
 	// recorded as pending for an input_required result on the first round.
 	sess.SetInputBroker(server.NewInputBroker(m.inputResponses, m.requestState))
+	ctx = withRemoteTraceContext(ctx, m)
 	return server.ContextWithSession(ctx, sess), nil
+}
+
+// withRemoteTraceContext joins the caller's distributed trace using the W3C
+// Trace Context carried in _meta, so spans started within a handler parent onto
+// the client's trace. It uses the globally-registered propagator (a no-op
+// unless the application installed one). When a span is already active on ctx —
+// the OTel tracing middleware runs outside this path and joins the trace itself
+// — re-extracting would detach handler child spans from that span, so this
+// leaves ctx untouched in that case.
+func withRemoteTraceContext(ctx context.Context, m *modernMeta) context.Context {
+	if m.traceparent == "" && m.tracestate == "" && m.baggage == "" {
+		return ctx
+	}
+	if trace.SpanContextFromContext(ctx).IsValid() {
+		return ctx
+	}
+	carrier := propagation.MapCarrier{}
+	if m.traceparent != "" {
+		carrier["traceparent"] = m.traceparent
+	}
+	if m.tracestate != "" {
+		carrier["tracestate"] = m.tracestate
+	}
+	if m.baggage != "" {
+		carrier["baggage"] = m.baggage
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
 }
 
 func isModernVersion(v string) bool {

--- a/mcp_modern.go
+++ b/mcp_modern.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"slices"
@@ -98,6 +100,19 @@ func (h *requestHandler) applyModern(ctx context.Context, method string, m *mode
 
 func isModernVersion(v string) bool {
 	return slices.Contains(modernVersions, v)
+}
+
+// newSubscriptionID mints a stable, non-empty identifier for a
+// subscriptions/listen call (MCP 2026-07-28). It is cryptographically random so
+// a client cannot guess or collide with another listener's id. The value is
+// what would populate _meta[protocol.MetaKeySubscriptionID] on the notifications
+// delivered for this subscription.
+func newSubscriptionID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // inputRequiredResponse converts a paused stateless handler into an MRTR

--- a/mcp_modern.go
+++ b/mcp_modern.go
@@ -29,6 +29,10 @@ type modernMeta struct {
 	clientInfo      json.RawMessage
 	clientCaps      json.RawMessage
 	logLevel        string
+	// MRTR retry fields: inputResponses fulfills the inputRequests of an earlier
+	// input_required result; requestState is the opaque token echoed back.
+	inputResponses []server.InputResponse
+	requestState   json.RawMessage
 }
 
 // parseModernMeta inspects a request's params `_meta`. It returns (meta, true)
@@ -56,6 +60,10 @@ func parseModernMeta(params json.RawMessage) (*modernMeta, bool, error) {
 	if ll, ok := envelope.Meta[protocol.MetaKeyLogLevel]; ok {
 		_ = json.Unmarshal(ll, &m.logLevel)
 	}
+	if ir, ok := envelope.Meta[protocol.MetaKeyInputResponses]; ok {
+		_ = json.Unmarshal(ir, &m.inputResponses)
+	}
+	m.requestState = envelope.Meta[protocol.MetaKeyRequestState]
 	return m, true, nil
 }
 
@@ -81,11 +89,32 @@ func (h *requestHandler) applyModern(ctx context.Context, method string, m *mode
 	if m.logLevel != "" {
 		sess.SetLogLevel(server.LogLevel(m.logLevel))
 	}
+	// Attach an MRTR broker so server→client requests (sampling, elicitation,
+	// roots) resolve statelessly: fulfilled from inputResponses on a retry, or
+	// recorded as pending for an input_required result on the first round.
+	sess.SetInputBroker(server.NewInputBroker(m.inputResponses, m.requestState))
 	return server.ContextWithSession(ctx, sess), nil
 }
 
 func isModernVersion(v string) bool {
 	return slices.Contains(modernVersions, v)
+}
+
+// inputRequiredResponse converts a paused stateless handler into an MRTR
+// input_required result (MCP 2026-07-28). It returns (response, true) when the
+// request's broker recorded unfulfilled input requests — the handler called
+// sampling/elicitation/roots without a supplied response — and (nil, false)
+// otherwise, so the caller handles a genuine error normally.
+func inputRequiredResponse(ctx context.Context, req *protocol.Request) (*protocol.Response, bool) {
+	sess := server.SessionFromContext(ctx)
+	if sess == nil {
+		return nil, false
+	}
+	broker := sess.InputBroker()
+	if broker == nil || !broker.HasPending() {
+		return nil, false
+	}
+	return protocol.NewResponse(req.ID, broker.Result()), true
 }
 
 // withResultType stamps resultType:"complete" on a modern result that does not

--- a/mcp_modern.go
+++ b/mcp_modern.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	"go.klarlabs.de/mcp/protocol"
+	"go.klarlabs.de/mcp/server"
+	"go.klarlabs.de/mcp/transport"
+)
+
+// This file implements the stateless "modern" request path (MCP 2026-07-28,
+// SEP-2575). A modern request carries its protocol version, client identity,
+// and capabilities in `_meta` on every request instead of establishing them
+// once via an initialize handshake. mcp-go is dual-era: a request without the
+// modern `_meta` keys is served under the legacy (session-negotiated) semantics
+// unchanged.
+
+// modernVersions is the set of stateless protocol revisions this server can
+// serve. Kept separate from protocol.SupportedVersions (which drives the legacy
+// initialize handshake) while the modern path is built out.
+var modernVersions = []string{protocol.DraftVersion}
+
+// modernMeta holds the reserved per-request _meta fields of a modern request.
+type modernMeta struct {
+	protocolVersion string
+	clientInfo      json.RawMessage
+	clientCaps      json.RawMessage
+	logLevel        string
+}
+
+// parseModernMeta inspects a request's params `_meta`. It returns (meta, true)
+// when the modern protocolVersion key is present, (nil, false) for a legacy
+// request, and an error only on malformed params.
+func parseModernMeta(params json.RawMessage) (*modernMeta, bool, error) {
+	if len(params) == 0 {
+		return nil, false, nil
+	}
+	var envelope struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return nil, false, protocol.NewInvalidParams(err.Error())
+	}
+	raw, ok := envelope.Meta[protocol.MetaKeyProtocolVersion]
+	if !ok {
+		return nil, false, nil // legacy request
+	}
+	m := &modernMeta{
+		clientInfo: envelope.Meta[protocol.MetaKeyClientInfo],
+		clientCaps: envelope.Meta[protocol.MetaKeyClientCapabilities],
+	}
+	_ = json.Unmarshal(raw, &m.protocolVersion)
+	if ll, ok := envelope.Meta[protocol.MetaKeyLogLevel]; ok {
+		_ = json.Unmarshal(ll, &m.logLevel)
+	}
+	return m, true, nil
+}
+
+// applyModern validates a modern request's metadata and, on success, returns a
+// context carrying a per-request session built from the client's declared
+// capabilities. A validation failure returns a protocol error (the caller maps
+// it to the response): missing required fields → -32602, unsupported version →
+// -32022. server/discover is exempt from the version check since a client uses
+// it precisely to learn which versions the server supports.
+func (h *requestHandler) applyModern(ctx context.Context, method string, m *modernMeta) (context.Context, error) {
+	// Required per-request fields (SEP-2575). Absent → malformed → -32602.
+	if m.protocolVersion == "" || len(m.clientInfo) == 0 || len(m.clientCaps) == 0 {
+		return ctx, protocol.NewInvalidParams("modern request missing required _meta (protocolVersion, clientInfo, clientCapabilities)")
+	}
+	if method != protocol.MethodServerDiscover && !isModernVersion(m.protocolVersion) {
+		return ctx, protocol.NewUnsupportedProtocolVersion(modernVersions, m.protocolVersion)
+	}
+
+	// Build a request-scoped session from the declared capabilities so
+	// per-request feature gating works without any connection state.
+	sess := server.NewSession("modern", nil, transport.NotificationSenderFromContext(ctx))
+	sess.SetClientCapabilitiesJSON(m.clientCaps)
+	if m.logLevel != "" {
+		sess.SetLogLevel(server.LogLevel(m.logLevel))
+	}
+	return server.ContextWithSession(ctx, sess), nil
+}
+
+func isModernVersion(v string) bool {
+	return slices.Contains(modernVersions, v)
+}
+
+// withResultType stamps resultType:"complete" on a modern result that does not
+// already carry one (server/discover and MRTR set their own). Legacy responses
+// are left untouched — an absent resultType is treated as "complete" by clients.
+func withResultType(resp *protocol.Response) {
+	if resp == nil {
+		return
+	}
+	if m, ok := resp.Result.(map[string]any); ok {
+		if _, present := m["resultType"]; !present {
+			m["resultType"] = protocol.ResultTypeComplete
+		}
+	}
+}

--- a/mcp_modern_test.go
+++ b/mcp_modern_test.go
@@ -91,6 +91,58 @@ func TestModern_MissingRequiredMeta(t *testing.T) {
 	}
 }
 
+// TestModern_CacheHintStamped verifies WithResultCache stamps ttlMs/cacheScope
+// on a cacheable modern result, and only for modern requests.
+func TestModern_CacheHintStamped(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"}, WithResultCache(60000, "public"))
+	srv.Tool("t").Handler(func(_ struct{}) (string, error) { return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	// Modern tools/list → cache hint present.
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsList,
+		Params: modernParams(t, protocol.DraftVersion, nil),
+	}
+	resp, _ := handler.HandleRequest(context.Background(), req)
+	res := resp.Result.(map[string]any)
+	if res["ttlMs"] != int64(60000) || res["cacheScope"] != "public" {
+		t.Errorf("expected cache hint on modern result, got %v", res)
+	}
+
+	// Legacy tools/list → no cache hint.
+	lreq := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: protocol.MethodToolsList, Params: json.RawMessage(`{}`)}
+	lresp, _ := handler.HandleRequest(context.Background(), lreq)
+	if _, present := lresp.Result.(map[string]any)["ttlMs"]; present {
+		t.Errorf("legacy result must not carry a cache hint")
+	}
+}
+
+// TestModern_ResourceNotFoundRenumbered verifies a resource-not-found error is
+// -32602 on the modern path (vs -32001 on legacy).
+func TestModern_ResourceNotFoundRenumbered(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	handler := newRequestHandler(srv)
+
+	modReq := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodResourcesRead,
+		Params: modernParams(t, protocol.DraftVersion, map[string]any{"uri": "missing://x"}),
+	}
+	_, err := handler.HandleRequest(context.Background(), modReq)
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeInvalidParams {
+		t.Fatalf("modern resource-not-found: expected -32602, got %v", err)
+	}
+
+	legReq := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: protocol.MethodResourcesRead,
+		Params: mustParams(t, map[string]any{"uri": "missing://x"}),
+	}
+	_, err = handler.HandleRequest(context.Background(), legReq)
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeNotFound {
+		t.Fatalf("legacy resource-not-found: expected -32001, got %v", err)
+	}
+}
+
 // TestLegacy_NoResultType confirms a legacy request (no modern _meta) is served
 // unchanged — no resultType is stamped.
 func TestLegacy_NoResultType(t *testing.T) {

--- a/mcp_modern_test.go
+++ b/mcp_modern_test.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// modernParams wraps method params with the required modern per-request _meta.
+func modernParams(t *testing.T, version string, extra map[string]any) json.RawMessage {
+	t.Helper()
+	meta := map[string]any{
+		protocol.MetaKeyClientInfo:         map[string]any{"name": "c", "version": "1"},
+		protocol.MetaKeyClientCapabilities: map[string]any{},
+	}
+	if version != "" {
+		meta[protocol.MetaKeyProtocolVersion] = version
+	}
+	p := map[string]any{"_meta": meta}
+	maps.Copy(p, extra)
+	return mustParams(t, p)
+}
+
+// TestModern_ResultTypeStamped verifies that a modern request (carrying the
+// per-request _meta) gets resultType:"complete" stamped on its result.
+func TestModern_ResultTypeStamped(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("t").Handler(func(_ struct{}) (string, error) { return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsList,
+		Params: modernParams(t, protocol.DraftVersion, nil),
+	}
+	resp, err := handler.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("tools/list (modern): %v", err)
+	}
+	if resp.Result.(map[string]any)["resultType"] != protocol.ResultTypeComplete {
+		t.Errorf("expected resultType complete, got %v", resp.Result)
+	}
+}
+
+// TestModern_UnsupportedVersion verifies a modern request for a version the
+// server does not serve gets -32022 (except server/discover).
+func TestModern_UnsupportedVersion(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("t").Handler(func(_ struct{}) (string, error) { return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsList,
+		Params: modernParams(t, "1900-01-01", nil),
+	}
+	_, err := handler.HandleRequest(context.Background(), req)
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeUnsupportedProtocolVersion {
+		t.Fatalf("expected -32022, got %v", err)
+	}
+
+	// server/discover is exempt from the version check.
+	dreq := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: protocol.MethodServerDiscover,
+		Params: modernParams(t, "1900-01-01", nil),
+	}
+	if _, err := handler.HandleRequest(context.Background(), dreq); err != nil {
+		t.Errorf("server/discover should be exempt from version check, got %v", err)
+	}
+}
+
+// TestModern_MissingRequiredMeta verifies a modern request missing a required
+// _meta field is rejected with -32602.
+func TestModern_MissingRequiredMeta(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("t").Handler(func(_ struct{}) (string, error) { return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	// protocolVersion present (marks it modern) but clientInfo/caps omitted.
+	params := mustParams(t, map[string]any{
+		"_meta": map[string]any{protocol.MetaKeyProtocolVersion: protocol.DraftVersion},
+	})
+	req := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsList, Params: params}
+	_, err := handler.HandleRequest(context.Background(), req)
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeInvalidParams {
+		t.Fatalf("expected -32602 for missing required _meta, got %v", err)
+	}
+}
+
+// TestLegacy_NoResultType confirms a legacy request (no modern _meta) is served
+// unchanged — no resultType is stamped.
+func TestLegacy_NoResultType(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("t").Handler(func(_ struct{}) (string, error) { return "ok", nil })
+	handler := newRequestHandler(srv)
+
+	req := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsList, Params: json.RawMessage(`{}`)}
+	resp, err := handler.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("tools/list (legacy): %v", err)
+	}
+	if _, present := resp.Result.(map[string]any)["resultType"]; present {
+		t.Errorf("legacy result must not carry resultType, got %v", resp.Result)
+	}
+}

--- a/mcp_modern_test.go
+++ b/mcp_modern_test.go
@@ -7,7 +7,12 @@ import (
 	"maps"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
 	"go.klarlabs.de/mcp/protocol"
+	"go.klarlabs.de/mcp/server"
 )
 
 // modernParams wraps method params with the required modern per-request _meta.
@@ -69,6 +74,94 @@ func TestModern_UnsupportedVersion(t *testing.T) {
 	}
 	if _, err := handler.HandleRequest(context.Background(), dreq); err != nil {
 		t.Errorf("server/discover should be exempt from version check, got %v", err)
+	}
+}
+
+// TestModern_ParseTraceContext verifies the W3C Trace Context keys are lifted
+// out of a modern request's _meta into modernMeta.
+func TestModern_ParseTraceContext(t *testing.T) {
+	const (
+		traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+		tracestate  = "vendor=abc"
+		baggage     = "userId=alice"
+	)
+	params := mustParams(t, map[string]any{
+		"_meta": map[string]any{
+			protocol.MetaKeyProtocolVersion:    protocol.DraftVersion,
+			protocol.MetaKeyClientInfo:         map[string]any{"name": "c", "version": "1"},
+			protocol.MetaKeyClientCapabilities: map[string]any{},
+			protocol.MetaKeyTraceparent:        traceparent,
+			protocol.MetaKeyTracestate:         tracestate,
+			protocol.MetaKeyBaggage:            baggage,
+		},
+	})
+
+	m, modern, err := parseModernMeta(params)
+	if err != nil || !modern {
+		t.Fatalf("parseModernMeta: modern=%v err=%v", modern, err)
+	}
+	if m.traceparent != traceparent || m.tracestate != tracestate || m.baggage != baggage {
+		t.Fatalf("trace fields mismatch: %+v", m)
+	}
+}
+
+// TestModern_ApplyTraceContext verifies applyModern joins the caller's trace:
+// with a TraceContext propagator installed, the returned context carries the
+// incoming remote span context so handler spans parent onto it.
+func TestModern_ApplyTraceContext(t *testing.T) {
+	const incomingTraceID = "0af7651916cd43dd8448eb211c80319c"
+	traceparent := "00-" + incomingTraceID + "-b7ad6b7169203331-01"
+
+	prev := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	defer otel.SetTextMapPropagator(prev)
+
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	h := newRequestHandler(srv)
+	m := &modernMeta{
+		protocolVersion: protocol.DraftVersion,
+		clientInfo:      json.RawMessage(`{"name":"c","version":"1"}`),
+		clientCaps:      json.RawMessage(`{}`),
+		traceparent:     traceparent,
+	}
+
+	ctx, err := h.applyModern(context.Background(), protocol.MethodToolsList, m)
+	if err != nil {
+		t.Fatalf("applyModern: %v", err)
+	}
+	if server.SessionFromContext(ctx) == nil {
+		t.Fatal("expected request-scoped session on context")
+	}
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() || !sc.IsRemote() {
+		t.Fatalf("expected valid remote span context, got %+v", sc)
+	}
+	if sc.TraceID().String() != incomingTraceID {
+		t.Errorf("expected trace id %q, got %q", incomingTraceID, sc.TraceID().String())
+	}
+}
+
+// TestModern_ApplyNoTraceContext verifies applyModern leaves the context free of
+// a remote span context when no trace context is supplied.
+func TestModern_ApplyNoTraceContext(t *testing.T) {
+	prev := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	defer otel.SetTextMapPropagator(prev)
+
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	h := newRequestHandler(srv)
+	m := &modernMeta{
+		protocolVersion: protocol.DraftVersion,
+		clientInfo:      json.RawMessage(`{"name":"c","version":"1"}`),
+		clientCaps:      json.RawMessage(`{}`),
+	}
+
+	ctx, err := h.applyModern(context.Background(), protocol.MethodToolsList, m)
+	if err != nil {
+		t.Fatalf("applyModern: %v", err)
+	}
+	if trace.SpanContextFromContext(ctx).IsValid() {
+		t.Error("expected no span context when trace context absent")
 	}
 }
 

--- a/mcp_mrtr_test.go
+++ b/mcp_mrtr_test.go
@@ -1,0 +1,176 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+	"go.klarlabs.de/mcp/server"
+)
+
+// modernMRTRParams builds tools/call params carrying the modern per-request
+// _meta with the given client capabilities plus optional MRTR retry fields.
+func modernMRTRParams(t *testing.T, caps map[string]any, extra map[string]any) json.RawMessage {
+	t.Helper()
+	meta := map[string]any{
+		protocol.MetaKeyProtocolVersion:    protocol.DraftVersion,
+		protocol.MetaKeyClientInfo:         map[string]any{"name": "c", "version": "1"},
+		protocol.MetaKeyClientCapabilities: caps,
+	}
+	maps.Copy(meta, extra)
+	return mustParams(t, map[string]any{
+		"name":      "ask",
+		"arguments": map[string]any{},
+		"_meta":     meta,
+	})
+}
+
+// TestMRTR_SamplingRoundTrip drives the full stateless sampling round-trip: the
+// first modern tools/call pauses with an input_required result naming the
+// sampling request; the retry carries the client's completion and the handler
+// runs to a complete result.
+func TestMRTR_SamplingRoundTrip(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("ask").Handler(func(ctx context.Context, _ struct{}) (string, error) {
+		sess := server.SessionFromContext(ctx)
+		res, err := sess.CreateMessage(ctx, &server.CreateMessageRequest{MaxTokens: 16})
+		if err != nil {
+			return "", err
+		}
+		return "model said: " + res.Content.Text, nil
+	})
+	handler := newRequestHandler(srv)
+
+	caps := map[string]any{"sampling": map[string]any{}}
+
+	// Round 1: no inputResponses → input_required.
+	req1 := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsCall,
+		Params: modernMRTRParams(t, caps, nil),
+	}
+	resp1, err := handler.HandleRequest(context.Background(), req1)
+	if err != nil {
+		t.Fatalf("round 1: %v", err)
+	}
+	res1, ok := resp1.Result.(server.InputRequiredResult)
+	if !ok {
+		t.Fatalf("round 1 result type = %T, want InputRequiredResult", resp1.Result)
+	}
+	if res1.ResultType != protocol.ResultTypeInputRequired {
+		t.Errorf("resultType = %q, want input_required", res1.ResultType)
+	}
+	if len(res1.InputRequests) != 1 || res1.InputRequests[0].Kind != server.InputKindSampling {
+		t.Fatalf("inputRequests = %+v, want one sampling request", res1.InputRequests)
+	}
+	irID := res1.InputRequests[0].ID
+
+	// Round 2: supply the completion, retry the same call.
+	completion := map[string]any{
+		"role": "assistant", "model": "test", "content": map[string]any{"type": "text", "text": "hello"},
+	}
+	retryMeta := map[string]any{
+		protocol.MetaKeyInputResponses: []any{map[string]any{"id": irID, "payload": completion}},
+	}
+	req2 := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: protocol.MethodToolsCall,
+		Params: modernMRTRParams(t, caps, retryMeta),
+	}
+	resp2, err := handler.HandleRequest(context.Background(), req2)
+	if err != nil {
+		t.Fatalf("round 2: %v", err)
+	}
+	result := resp2.Result.(map[string]any)
+	if result["resultType"] != protocol.ResultTypeComplete {
+		t.Errorf("round 2 resultType = %v, want complete", result["resultType"])
+	}
+	content := result["content"].([]map[string]any)
+	if content[0]["text"] != "model said: hello" {
+		t.Errorf("round 2 text = %v, want %q", content[0]["text"], "model said: hello")
+	}
+}
+
+// TestMRTR_ElicitationRoundTrip drives the same round-trip through the elicitor
+// injected into a tool handler's context.
+func TestMRTR_ElicitationRoundTrip(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("ask").Handler(func(ctx context.Context, _ struct{}) (string, error) {
+		el := server.ElicitFromContext(ctx)
+		if el == nil {
+			t.Fatal("elicitor not injected into handler context")
+		}
+		res, err := el.Elicit(ctx, &server.ElicitRequest{Message: "your name?"})
+		if err != nil {
+			return "", err
+		}
+		return "hi " + res.Content["name"].(string), nil
+	})
+	handler := newRequestHandler(srv)
+
+	caps := map[string]any{"elicitation": map[string]any{}}
+
+	req1 := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsCall,
+		Params: modernMRTRParams(t, caps, nil),
+	}
+	resp1, err := handler.HandleRequest(context.Background(), req1)
+	if err != nil {
+		t.Fatalf("round 1: %v", err)
+	}
+	res1 := resp1.Result.(server.InputRequiredResult)
+	if len(res1.InputRequests) != 1 || res1.InputRequests[0].Kind != server.InputKindElicitation {
+		t.Fatalf("inputRequests = %+v, want one elicitation request", res1.InputRequests)
+	}
+
+	answer := map[string]any{"action": "accept", "content": map[string]any{"name": "Ada"}}
+	retryMeta := map[string]any{
+		protocol.MetaKeyInputResponses: []any{map[string]any{"id": res1.InputRequests[0].ID, "payload": answer}},
+	}
+	req2 := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: protocol.MethodToolsCall,
+		Params: modernMRTRParams(t, caps, retryMeta),
+	}
+	resp2, err := handler.HandleRequest(context.Background(), req2)
+	if err != nil {
+		t.Fatalf("round 2: %v", err)
+	}
+	content := resp2.Result.(map[string]any)["content"].([]map[string]any)
+	if content[0]["text"] != "hi Ada" {
+		t.Errorf("round 2 text = %v, want %q", content[0]["text"], "hi Ada")
+	}
+}
+
+// TestMRTR_LegacyStillErrors confirms a legacy (non-modern) request with no
+// request sender is unaffected by MRTR — sampling still returns the transport
+// error rather than an input_required result.
+func TestMRTR_LegacyStillErrors(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("ask").Handler(func(ctx context.Context, _ struct{}) (string, error) {
+		sess := server.SessionFromContext(ctx)
+		if sess == nil {
+			return "no-session", nil
+		}
+		_, err := sess.CreateMessage(ctx, &server.CreateMessageRequest{MaxTokens: 1})
+		if err != nil {
+			return "", err
+		}
+		return "ok", nil
+	})
+	handler := newRequestHandler(srv)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodToolsCall,
+		Params: mustParams(t, map[string]any{"name": "ask", "arguments": map[string]any{}}),
+	}
+	resp, err := handler.HandleRequest(context.Background(), req)
+	// No modern _meta → no session in context → handler returns "no-session"
+	// (there is no legacy session wired in this bare handler harness). The key
+	// assertion is that no input_required result is produced.
+	if err != nil {
+		t.Fatalf("legacy call: %v", err)
+	}
+	if _, ok := resp.Result.(server.InputRequiredResult); ok {
+		t.Fatal("legacy request must not yield an input_required result")
+	}
+}

--- a/mcp_subscriptions_listen_test.go
+++ b/mcp_subscriptions_listen_test.go
@@ -1,0 +1,135 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+	"go.klarlabs.de/mcp/server"
+)
+
+// TestSubscriptionsListen_ReturnsSubscriptionID verifies that a modern
+// subscriptions/listen request yields a non-empty subscriptionId and, being a
+// modern request, gets resultType:"complete" stamped.
+func TestSubscriptionsListen_ReturnsSubscriptionID(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	handler := newRequestHandler(srv)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodSubscriptionsListen,
+		Params: modernParams(t, protocol.DraftVersion, map[string]any{
+			"notifications": []string{protocol.MethodResourceUpdated},
+			"uris":          []string{"email://inbox"},
+		}),
+	}
+	resp, err := handler.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("subscriptions/listen: %v", err)
+	}
+	result, _ := resp.Result.(map[string]any)
+	if id, _ := result["subscriptionId"].(string); id == "" {
+		t.Fatalf("expected a non-empty subscriptionId, got %v", result)
+	}
+	if result["resultType"] != protocol.ResultTypeComplete {
+		t.Errorf("expected resultType complete, got %v", result["resultType"])
+	}
+}
+
+// TestSubscriptionsListen_RegistersURIs verifies the requested resource URIs are
+// registered on the session's SubscriptionManager, reusing the same machinery
+// resources/subscribe drives. The handler is invoked directly with a manually
+// attached session so the registration can be observed after the call.
+func TestSubscriptionsListen_RegistersURIs(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	handler := newRequestHandler(srv)
+
+	session := server.NewSession("modern", nil, nil)
+	ctx := server.ContextWithSession(context.Background(), session)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodSubscriptionsListen,
+		Params: mustParams(t, map[string]any{
+			"notifications": []string{protocol.MethodResourceUpdated},
+			"uris":          []string{"email://inbox", "docs://readme"},
+		}),
+	}
+	if _, err := handler.handleSubscriptionsListen(ctx, req); err != nil {
+		t.Fatalf("handleSubscriptionsListen: %v", err)
+	}
+
+	mgr := session.SubscriptionManager()
+	for _, uri := range []string{"email://inbox", "docs://readme"} {
+		if !mgr.IsSubscribed(session.ID(), uri) {
+			t.Errorf("URI %q was not registered on the subscription manager", uri)
+		}
+	}
+}
+
+// TestSubscriptionsListen_NoURIsStillReturnsID verifies a listen with no URIs
+// (notification-type opt-in only) still returns a subscription id and registers
+// nothing.
+func TestSubscriptionsListen_NoURIsStillReturnsID(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	handler := newRequestHandler(srv)
+
+	session := server.NewSession("modern", nil, nil)
+	ctx := server.ContextWithSession(context.Background(), session)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodSubscriptionsListen,
+		Params: mustParams(t, map[string]any{
+			"notifications": []string{protocol.MethodToolListChanged},
+		}),
+	}
+	resp, err := handler.handleSubscriptionsListen(ctx, req)
+	if err != nil {
+		t.Fatalf("handleSubscriptionsListen: %v", err)
+	}
+	if id, _ := resp.Result.(map[string]any)["subscriptionId"].(string); id == "" {
+		t.Fatalf("expected a non-empty subscriptionId, got %v", resp.Result)
+	}
+	if n := session.SubscriptionManager().SubscriptionCount(); n != 0 {
+		t.Errorf("expected no subscriptions registered, got %d", n)
+	}
+}
+
+// TestSubscriptionsListen_EmptyURIRejected verifies an empty URI in the list is
+// rejected with -32602 rather than silently registered.
+func TestSubscriptionsListen_EmptyURIRejected(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	handler := newRequestHandler(srv)
+
+	session := server.NewSession("modern", nil, nil)
+	ctx := server.ContextWithSession(context.Background(), session)
+
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodSubscriptionsListen,
+		Params: mustParams(t, map[string]any{"uris": []string{""}}),
+	}
+	_, err := handler.handleSubscriptionsListen(ctx, req)
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeInvalidParams {
+		t.Fatalf("expected -32602 for empty uri, got %v", err)
+	}
+}
+
+// TestSubscriptionsListen_NoSessionRejected verifies that a request without a
+// session in context (i.e. a non-modern request) is rejected with a protocol
+// error instead of panicking.
+func TestSubscriptionsListen_NoSessionRejected(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	handler := newRequestHandler(srv)
+
+	// Legacy request (no modern _meta) → no session attached by the dispatcher.
+	req := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: protocol.MethodSubscriptionsListen,
+		Params: json.RawMessage(`{"uris":["email://inbox"]}`),
+	}
+	_, err := handler.HandleRequest(context.Background(), req)
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeInvalidParams {
+		t.Fatalf("expected -32602 when no session in context, got %v", err)
+	}
+}

--- a/mcp_tasks_update_test.go
+++ b/mcp_tasks_update_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// newWorkingTask registers a gated tool and starts an augmented call, returning
+// the handler and the working task's id (the tool blocks on release, so the task
+// stays non-terminal until the caller closes it).
+func newWorkingTask(t *testing.T) (*requestHandler, string, chan struct{}) {
+	t.Helper()
+	release := make(chan struct{})
+	srv := NewServer(ServerInfo{Name: "s", Version: "1"})
+	srv.Tool("slow").Description("gated").TaskSupport(TaskSupportOptional).
+		Handler(func(_ context.Context, _ struct{}) (string, error) {
+			<-release
+			return "done", nil
+		})
+	handler := newRequestHandler(srv)
+	resp, err := handler.HandleRequest(context.Background(),
+		taskReq(t, protocol.MethodToolsCall, map[string]any{
+			"name": "slow", "arguments": map[string]any{}, fieldTask: map[string]any{"ttl": 60000},
+		}))
+	if err != nil {
+		t.Fatalf("augmented call: %v", err)
+	}
+	task := resp.Result.(map[string]any)[fieldTask].(*AugTask)
+	return handler, task.TaskID, release
+}
+
+// TestTasksUpdate_RefreshesTTL confirms tasks/update refreshes a working task's
+// ttl and returns the updated task.
+func TestTasksUpdate_RefreshesTTL(t *testing.T) {
+	handler, id, release := newWorkingTask(t)
+	defer close(release)
+
+	resp, err := handler.HandleRequest(context.Background(),
+		taskReq(t, protocol.MethodTasksUpdate, map[string]any{fieldTaskID: id, "ttl": 120000}))
+	if err != nil {
+		t.Fatalf("tasks/update: %v", err)
+	}
+	task, ok := resp.Result.(*AugTask)
+	if !ok {
+		t.Fatalf("expected *AugTask, got %#v", resp.Result)
+	}
+	if task.TTL == nil || *task.TTL != 120000 {
+		t.Errorf("ttl = %v, want 120000", task.TTL)
+	}
+	if task.Status != "working" {
+		t.Errorf("status = %q, want working (update must not change status)", task.Status)
+	}
+}
+
+// TestTasksUpdate_UnknownTask confirms tasks/update on an unknown id is -32602.
+func TestTasksUpdate_UnknownTask(t *testing.T) {
+	handler, _, release := newWorkingTask(t)
+	defer close(release)
+
+	_, err := handler.HandleRequest(context.Background(),
+		taskReq(t, protocol.MethodTasksUpdate, map[string]any{fieldTaskID: "nope", "ttl": 1000}))
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeInvalidParams {
+		t.Fatalf("got %v, want -32602 for unknown task", err)
+	}
+}
+
+// TestTasksList_GatedOffForModern confirms tasks/list is served for a legacy
+// request but returns MethodNotFound for a modern (2026-07-28) request, per the
+// tasks extension retiring the listing method.
+func TestTasksList_GatedOffForModern(t *testing.T) {
+	handler, _, release := newWorkingTask(t)
+	defer close(release)
+
+	// Legacy tasks/list → served.
+	legacy := &protocol.Request{JSONRPC: "2.0", ID: json.RawMessage(`9`), Method: protocol.MethodTasksList}
+	if _, err := handler.HandleRequest(context.Background(), legacy); err != nil {
+		t.Fatalf("legacy tasks/list should be served: %v", err)
+	}
+
+	// Modern tasks/list → MethodNotFound.
+	modern := &protocol.Request{
+		JSONRPC: "2.0", ID: json.RawMessage(`10`), Method: protocol.MethodTasksList,
+		Params: modernParams(t, protocol.DraftVersion, nil),
+	}
+	_, err := handler.HandleRequest(context.Background(), modern)
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Code != protocol.CodeMethodNotFound {
+		t.Fatalf("got %v, want MethodNotFound for modern tasks/list", err)
+	}
+}

--- a/mcp_tools_order_test.go
+++ b/mcp_tools_order_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// TestHandleToolsList_DeterministicOrder verifies that tools/list returns tools
+// sorted by name ascending, and that the order is identical across repeated
+// calls. Server.Tools() is backed by a Go map with randomized iteration order,
+// so the handler must sort to guarantee determinism (MCP 2026-07-28).
+func TestHandleToolsList_DeterministicOrder(t *testing.T) {
+	srv := NewServer(ServerInfo{Name: "test", Version: "1.0.0"})
+
+	type Input struct {
+		Q string `json:"q"`
+	}
+
+	// Register in deliberately out-of-order names.
+	for _, name := range []string{"zebra", "apple", "mango", "banana", "cherry"} {
+		srv.Tool(name).
+			Description("tool " + name).
+			Handler(func(input Input) (string, error) { return input.Q, nil })
+	}
+
+	handler := newRequestHandler(srv)
+
+	listNames := func() []string {
+		req := &protocol.Request{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage(`1`),
+			Method:  "tools/list",
+		}
+		resp, err := handler.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result, ok := resp.Result.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected result type: %T", resp.Result)
+		}
+		toolList, ok := result["tools"].([]map[string]any)
+		if !ok {
+			t.Fatalf("unexpected tools type: %T", result["tools"])
+		}
+		names := make([]string, 0, len(toolList))
+		for _, item := range toolList {
+			names = append(names, item[fieldName].(string))
+		}
+		return names
+	}
+
+	want := []string{"apple", "banana", "cherry", "mango", "zebra"}
+
+	first := listNames()
+	if !slices.Equal(first, want) {
+		t.Fatalf("tools/list not sorted ascending: got %v, want %v", first, want)
+	}
+
+	// Call several more times; order must be stable and identical each time.
+	for i := 0; i < 5; i++ {
+		got := listNames()
+		if !slices.Equal(got, first) {
+			t.Fatalf("tools/list order not deterministic on call %d: got %v, want %v", i, got, first)
+		}
+	}
+}

--- a/middleware/otel.go
+++ b/middleware/otel.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.klarlabs.de/mcp/protocol"
@@ -24,6 +26,7 @@ type OTelOption func(*otelConfig)
 type otelConfig struct {
 	tracerProvider trace.TracerProvider
 	meterProvider  metric.MeterProvider
+	propagator     propagation.TextMapPropagator
 	serviceName    string
 	skipMethods    map[string]bool
 }
@@ -58,12 +61,25 @@ func WithOTelSkipMethods(methods ...string) OTelOption {
 	}
 }
 
+// WithOTelPropagator sets the text-map propagator used to extract W3C Trace
+// Context (traceparent/tracestate/baggage) carried in a modern request's
+// _meta. It defaults to the globally-registered propagator
+// (otel.GetTextMapPropagator), so an application that installs a propagator at
+// startup gets remote-parent joining for free. Supply one explicitly to avoid
+// depending on global state.
+func WithOTelPropagator(p propagation.TextMapPropagator) OTelOption {
+	return func(c *otelConfig) {
+		c.propagator = p
+	}
+}
+
 // OTel returns middleware that adds OpenTelemetry tracing and metrics.
 // It creates spans for each request and records request counts and latency.
 func OTel(opts ...OTelOption) Middleware {
 	cfg := &otelConfig{
 		tracerProvider: otel.GetTracerProvider(),
 		meterProvider:  otel.GetMeterProvider(),
+		propagator:     otel.GetTextMapPropagator(),
 		serviceName:    "mcp-server",
 		skipMethods:    make(map[string]bool),
 	}
@@ -108,6 +124,13 @@ func OTel(opts ...OTelOption) Middleware {
 			if cfg.skipMethods[req.Method] {
 				return next(ctx, req)
 			}
+
+			// Join the client's distributed trace: a modern (stateless) request
+			// carries W3C Trace Context in its _meta. Extracting it here — before
+			// the span is started — makes the server span a child of the caller's
+			// remote span. Absent trace context, ctx is unchanged and the span is
+			// a root.
+			ctx = extractModernTraceContext(ctx, req, cfg.propagator)
 
 			// Start span
 			spanName := "mcp." + req.Method
@@ -172,6 +195,53 @@ func OTel(opts ...OTelOption) Middleware {
 			return resp, err
 		}
 	}
+}
+
+// extractModernTraceContext reads W3C Trace Context (traceparent, tracestate,
+// baggage) from a modern request's _meta and, when present, returns a context
+// carrying the remote SpanContext so a span started next parents onto the
+// caller's trace. It returns ctx unchanged for a legacy request or one without
+// trace context. A nil propagator (or the no-op default) simply yields ctx.
+func extractModernTraceContext(ctx context.Context, req *protocol.Request, propagator propagation.TextMapPropagator) context.Context {
+	if propagator == nil || req == nil {
+		return ctx
+	}
+	carrier, ok := traceCarrierFromMeta(req.Params)
+	if !ok {
+		return ctx
+	}
+	return propagator.Extract(ctx, carrier)
+}
+
+// traceCarrierFromMeta pulls the reserved trace-context keys out of a request's
+// params _meta into a propagation carrier. It returns (carrier, false) when no
+// trace-context key is present, so callers can skip extraction entirely.
+func traceCarrierFromMeta(params json.RawMessage) (propagation.MapCarrier, bool) {
+	if len(params) == 0 {
+		return nil, false
+	}
+	var envelope struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return nil, false
+	}
+	carrier := propagation.MapCarrier{}
+	put := func(metaKey, carrierKey string) {
+		if raw, ok := envelope.Meta[metaKey]; ok {
+			var v string
+			if json.Unmarshal(raw, &v) == nil && v != "" {
+				carrier[carrierKey] = v
+			}
+		}
+	}
+	put(protocol.MetaKeyTraceparent, "traceparent")
+	put(protocol.MetaKeyTracestate, "tracestate")
+	put(protocol.MetaKeyBaggage, "baggage")
+	if len(carrier) == 0 {
+		return nil, false
+	}
+	return carrier, true
 }
 
 // SpanFromContext returns the current span from context.

--- a/middleware/otel_test.go
+++ b/middleware/otel_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -199,6 +200,101 @@ func TestOTelMiddleware(t *testing.T) {
 		_, err := handler(context.Background(), req)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestOTelTraceContextPropagation(t *testing.T) {
+	// A modern request whose _meta carries a valid W3C traceparent must produce
+	// a server span that joins the caller's trace: same trace id, and the span's
+	// parent is the incoming (remote) span.
+	const (
+		incomingTraceID = "0af7651916cd43dd8448eb211c80319c"
+		incomingSpanID  = "b7ad6b7169203331"
+	)
+	traceparent := "00-" + incomingTraceID + "-" + incomingSpanID + "-01"
+
+	metaParams := func(t *testing.T, meta map[string]string) json.RawMessage {
+		t.Helper()
+		m := map[string]any{"_meta": map[string]any{}}
+		inner := m["_meta"].(map[string]any)
+		for k, v := range meta {
+			inner[k] = v
+		}
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		return b
+	}
+
+	t.Run("joins incoming trace via _meta traceparent", func(t *testing.T) {
+		exporter := tracetest.NewInMemoryExporter()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+		defer tp.Shutdown(context.Background())
+
+		middleware := OTel(
+			WithTracerProvider(tp),
+			WithOTelPropagator(propagation.TraceContext{}),
+		)
+		handler := middleware(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			return &protocol.Response{ID: req.ID}, nil
+		})
+
+		req := &protocol.Request{
+			ID:     json.RawMessage("1"),
+			Method: "tools/list",
+			Params: metaParams(t, map[string]string{
+				protocol.MetaKeyTraceparent: traceparent,
+			}),
+		}
+		if _, err := handler(context.Background(), req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		spans := exporter.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(spans))
+		}
+		span := spans[0]
+		if got := span.SpanContext.TraceID().String(); got != incomingTraceID {
+			t.Errorf("expected span trace id %q, got %q", incomingTraceID, got)
+		}
+		if got := span.Parent.SpanID().String(); got != incomingSpanID {
+			t.Errorf("expected parent span id %q, got %q", incomingSpanID, got)
+		}
+		if !span.Parent.IsRemote() {
+			t.Error("expected parent span context to be remote")
+		}
+	})
+
+	t.Run("root span when trace context absent", func(t *testing.T) {
+		exporter := tracetest.NewInMemoryExporter()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+		defer tp.Shutdown(context.Background())
+
+		middleware := OTel(
+			WithTracerProvider(tp),
+			WithOTelPropagator(propagation.TraceContext{}),
+		)
+		handler := middleware(func(ctx context.Context, req *protocol.Request) (*protocol.Response, error) {
+			return &protocol.Response{ID: req.ID}, nil
+		})
+
+		req := &protocol.Request{ID: json.RawMessage("1"), Method: "tools/list"}
+		if _, err := handler(context.Background(), req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		spans := exporter.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(spans))
+		}
+		if spans[0].Parent.IsValid() {
+			t.Error("expected root span (no valid parent) when trace context absent")
+		}
+		if spans[0].SpanContext.TraceID().String() == incomingTraceID {
+			t.Error("root span must not reuse the sample incoming trace id")
 		}
 	})
 }

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -67,6 +67,13 @@ const (
 	// Stateless discovery (MCP 2026-07-28, SEP-2575) — replaces initialize for
 	// modern clients.
 	MethodServerDiscover = "server/discover"
+
+	// Stateless subscription (MCP 2026-07-28, SEP) — a modern client opts into
+	// the notification types (and resource URIs) it wants via a single method,
+	// replacing the GET SSE stream plus resources/subscribe and
+	// resources/unsubscribe. Delivered notifications are tagged with
+	// MetaKeySubscriptionID so the client can correlate them.
+	MethodSubscriptionsListen = "subscriptions/listen"
 )
 
 // DraftVersion is the 2026-07-28 release-candidate ("modern", stateless)

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -105,6 +105,14 @@ const (
 	// server's opaque MetaKeyRequestState.
 	MetaKeyInputResponses = "io.modelcontextprotocol/inputResponses"
 	MetaKeyRequestState   = "io.modelcontextprotocol/requestState"
+
+	// W3C Trace Context (MCP 2026-07-28): a modern request carries the caller's
+	// distributed-trace position in _meta so the server span joins the client's
+	// trace. traceparent/tracestate map to the propagation.TraceContext
+	// propagator; baggage to the propagation.Baggage propagator.
+	MetaKeyTraceparent = "io.modelcontextprotocol/traceparent"
+	MetaKeyTracestate  = "io.modelcontextprotocol/tracestate"
+	MetaKeyBaggage     = "io.modelcontextprotocol/baggage"
 )
 
 // Extension identifiers (reverse-DNS) negotiated via capabilities.extensions

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -64,6 +64,11 @@ const (
 	MethodTasksCancel = "tasks/cancel"
 	MethodTasksList   = "tasks/list"
 
+	// MethodTasksUpdate refreshes a task's ttl (MCP 2026-07-28 tasks extension).
+	// tasks/list, by contrast, is retired in the modern era (gated off for modern
+	// requests) — the tasks extension favors direct task handles over listing.
+	MethodTasksUpdate = "tasks/update"
+
 	// Stateless discovery (MCP 2026-07-28, SEP-2575) — replaces initialize for
 	// modern clients.
 	MethodServerDiscover = "server/discover"

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -86,6 +86,13 @@ const (
 	MetaKeyLogLevel           = "io.modelcontextprotocol/logLevel"
 	MetaKeySubscriptionID     = "io.modelcontextprotocol/subscriptionId"
 	MetaKeyRelatedTask        = "io.modelcontextprotocol/related-task"
+
+	// MRTR (Multi Round-Trip Requests, MCP 2026-07-28): a client retrying a
+	// call that returned resultType "input_required" carries its fulfillment of
+	// the earlier inputRequests under MetaKeyInputResponses and echoes the
+	// server's opaque MetaKeyRequestState.
+	MetaKeyInputResponses = "io.modelcontextprotocol/inputResponses"
+	MetaKeyRequestState   = "io.modelcontextprotocol/requestState"
 )
 
 // Extension identifiers (reverse-DNS) negotiated via capabilities.extensions

--- a/protocol/constants.go
+++ b/protocol/constants.go
@@ -63,6 +63,43 @@ const (
 	MethodTasksResult = "tasks/result"
 	MethodTasksCancel = "tasks/cancel"
 	MethodTasksList   = "tasks/list"
+
+	// Stateless discovery (MCP 2026-07-28, SEP-2575) — replaces initialize for
+	// modern clients.
+	MethodServerDiscover = "server/discover"
+)
+
+// DraftVersion is the 2026-07-28 release-candidate ("modern", stateless)
+// protocol revision. It is advertised via server/discover but is NOT yet in
+// SupportedVersions (which drives the legacy initialize handshake): the modern
+// stateless request path is being built incrementally (docs/revisions-roadmap.md
+// Phase 4).
+const DraftVersion = "2026-07-28"
+
+// Reserved per-request _meta keys for the stateless (modern) request model
+// (MCP 2026-07-28). Every modern request carries protocol version, client
+// identity, and capabilities here instead of via an initialize handshake.
+const (
+	MetaKeyProtocolVersion    = "io.modelcontextprotocol/protocolVersion"
+	MetaKeyClientInfo         = "io.modelcontextprotocol/clientInfo"
+	MetaKeyClientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+	MetaKeyLogLevel           = "io.modelcontextprotocol/logLevel"
+	MetaKeySubscriptionID     = "io.modelcontextprotocol/subscriptionId"
+	MetaKeyRelatedTask        = "io.modelcontextprotocol/related-task"
+)
+
+// Extension identifiers (reverse-DNS) negotiated via capabilities.extensions
+// (MCP 2026-07-28, SEP-2133).
+const (
+	ExtensionUI    = "io.modelcontextprotocol/ui"    // MCP Apps
+	ExtensionTasks = "io.modelcontextprotocol/tasks" // Tasks
+)
+
+// ResultType values for polymorphic results (MCP 2026-07-28). An absent
+// resultType is treated as "complete" for backward compatibility.
+const (
+	ResultTypeComplete      = "complete"
+	ResultTypeInputRequired = "input_required"
 )
 
 // MCP notification methods.

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -23,6 +23,20 @@ const (
 	CodeURLElicitationRequired = -32042
 )
 
+// MCP-reserved error codes for the modern (2026-07-28) protocol. The -32020..
+// -32099 sub-range is reserved for the MCP specification.
+const (
+	// CodeHeaderMismatch: an HTTP routing header disagrees with the request body.
+	CodeHeaderMismatch = -32020
+	// CodeMissingRequiredClientCapability: the request needs a client capability
+	// that was not declared in io.modelcontextprotocol/clientCapabilities. The
+	// error data carries requiredCapabilities.
+	CodeMissingRequiredClientCapability = -32021
+	// CodeUnsupportedProtocolVersion: the server does not implement the
+	// requested protocol version. The error data carries supported + requested.
+	CodeUnsupportedProtocolVersion = -32022
+)
+
 // Error represents a JSON-RPC 2.0 error.
 type Error struct {
 	Code    int    `json:"code"`
@@ -96,5 +110,26 @@ func NewURLElicitationRequired(msg string, elicitations any) *Error {
 		Code:    CodeURLElicitationRequired,
 		Message: msg,
 		Data:    map[string]any{"elicitations": elicitations},
+	}
+}
+
+// NewUnsupportedProtocolVersion creates a -32022 error (MCP 2026-07-28) listing
+// the versions the server supports and the one the client requested, so the
+// client can retry with a mutually supported version.
+func NewUnsupportedProtocolVersion(supported []string, requested string) *Error {
+	return &Error{
+		Code:    CodeUnsupportedProtocolVersion,
+		Message: "Unsupported protocol version",
+		Data:    map[string]any{"supported": supported, "requested": requested},
+	}
+}
+
+// NewMissingRequiredClientCapability creates a -32021 error (MCP 2026-07-28)
+// naming the client capabilities the request required but did not declare.
+func NewMissingRequiredClientCapability(required ...string) *Error {
+	return &Error{
+		Code:    CodeMissingRequiredClientCapability,
+		Message: "Missing required client capability",
+		Data:    map[string]any{"requiredCapabilities": required},
 	}
 }

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -124,6 +124,13 @@ func NewUnsupportedProtocolVersion(supported []string, requested string) *Error 
 	}
 }
 
+// NewHeaderMismatch creates a -32020 error (MCP 2026-07-28) reported when a
+// Streamable HTTP routing header (Mcp-Method / Mcp-Name) disagrees with the
+// JSON-RPC request body it is supposed to describe.
+func NewHeaderMismatch(msg string) *Error {
+	return &Error{Code: CodeHeaderMismatch, Message: msg}
+}
+
 // NewMissingRequiredClientCapability creates a -32021 error (MCP 2026-07-28)
 // naming the client capabilities the request required but did not declare.
 func NewMissingRequiredClientCapability(required ...string) *Error {

--- a/schema/composition_test.go
+++ b/schema/composition_test.go
@@ -1,0 +1,287 @@
+package schema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// recNode is a self-referential type used to prove that generation breaks
+// recursion with $ref/$defs rather than inlining forever.
+type recNode struct {
+	Value    string    `json:"value"`
+	Children []recNode `json:"children"`
+}
+
+// TestGenerate_RecursiveTypeEmitsDefs verifies that a self-referential Go type
+// generates a "#/$defs/..." reference plus a hoisted $defs entry instead of
+// inlining without bound.
+func TestGenerate_RecursiveTypeEmitsDefs(t *testing.T) {
+	s, err := Generate(recNode{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// The root type is itself recursive, so it is expressed as a reference
+	// into $defs.
+	if s.Ref != defRefPrefix+"recNode" {
+		t.Errorf("root Ref = %q, want %q", s.Ref, defRefPrefix+"recNode")
+	}
+	if s.Dialect != Dialect2020_12 {
+		t.Errorf("root Dialect = %q, want %q", s.Dialect, Dialect2020_12)
+	}
+
+	def, ok := s.Defs["recNode"]
+	if !ok {
+		t.Fatalf("expected $defs[recNode]; defs=%v", s.Defs)
+	}
+	if def.Type != typeObject {
+		t.Errorf("def.Type = %q, want object", def.Type)
+	}
+	// The definition must not carry the dialect marker (root-only convention).
+	if def.Dialect != "" {
+		t.Errorf("def.Dialect = %q, want empty", def.Dialect)
+	}
+
+	// The recursive field points back into $defs.
+	children := def.Properties["children"]
+	if children == nil || children.Items == nil {
+		t.Fatalf("children/items missing: %+v", def.Properties)
+	}
+	if children.Items.Ref != defRefPrefix+"recNode" {
+		t.Errorf("children.items.Ref = %q, want %q", children.Items.Ref, defRefPrefix+"recNode")
+	}
+
+	// Marshaled JSON must round-trip the reference and definitions and must
+	// not force a "properties" key onto the pure-reference root.
+	raw := marshalToMap(t, s)
+	if raw["$ref"] != defRefPrefix+"recNode" {
+		t.Errorf("marshaled $ref = %v, want %q", raw["$ref"], defRefPrefix+"recNode")
+	}
+	if _, has := raw["properties"]; has {
+		t.Errorf("reference root must not emit properties; raw=%v", raw)
+	}
+	if _, has := raw["$defs"]; !has {
+		t.Errorf("marshaled root must emit $defs; raw=%v", raw)
+	}
+}
+
+// TestGenerate_NestedRecursiveTypeHoistsDefs verifies recursion breaking when
+// the recursive type is a nested field rather than the root type: the root
+// stays a plain object and the recursive type is hoisted into $defs.
+func TestGenerate_NestedRecursiveTypeHoistsDefs(t *testing.T) {
+	type tree struct {
+		Root recNode `json:"root"`
+	}
+
+	s, err := Generate(tree{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if s.Type != typeObject {
+		t.Errorf("root Type = %q, want object", s.Type)
+	}
+	if _, ok := s.Defs["recNode"]; !ok {
+		t.Fatalf("expected $defs[recNode]; defs=%v", s.Defs)
+	}
+	root := s.Properties["root"]
+	if root == nil || root.Ref != defRefPrefix+"recNode" {
+		t.Errorf("root property Ref = %+v, want reference to recNode", root)
+	}
+}
+
+// TestSchema_MarshalCompositionKeywords proves the struct marshals the full
+// 2020-12 composition vocabulary and never forces "properties" onto a
+// combinator schema.
+func TestSchema_MarshalCompositionKeywords(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *Schema
+		key    string
+		count  int
+	}{
+		{
+			name: "oneOf",
+			schema: &Schema{OneOf: []*Schema{
+				{Type: typeString}, {Type: typeInteger},
+			}},
+			key:   "oneOf",
+			count: 2,
+		},
+		{
+			name: "anyOf",
+			schema: &Schema{AnyOf: []*Schema{
+				{Type: typeString}, {Type: typeBoolean},
+			}},
+			key:   "anyOf",
+			count: 2,
+		},
+		{
+			name: "allOf",
+			schema: &Schema{AllOf: []*Schema{
+				{Type: typeObject}, {Required: []string{"id"}},
+			}},
+			key:   "allOf",
+			count: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := marshalToMap(t, tt.schema)
+			arr, ok := raw[tt.key].([]any)
+			if !ok {
+				t.Fatalf("%s = %v, want array", tt.key, raw[tt.key])
+			}
+			if len(arr) != tt.count {
+				t.Errorf("len(%s) = %d, want %d", tt.key, len(arr), tt.count)
+			}
+			// Combinators are not plain objects: no forced properties.
+			if _, has := raw["properties"]; has {
+				t.Errorf("combinator must not emit properties; raw=%v", raw)
+			}
+		})
+	}
+}
+
+// TestSchema_MarshalIfThenElse verifies the conditional applicator round-trips.
+func TestSchema_MarshalIfThenElse(t *testing.T) {
+	s := &Schema{
+		Type: typeObject,
+		Properties: map[string]*Schema{
+			"kind": {Type: typeString},
+		},
+		If:   &Schema{Properties: map[string]*Schema{"kind": {Enum: []any{"a"}}}},
+		Then: &Schema{Required: []string{"a"}},
+		Else: &Schema{Required: []string{"b"}},
+	}
+
+	raw := marshalToMap(t, s)
+	for _, key := range []string{"if", "then", "else"} {
+		if _, has := raw[key]; !has {
+			t.Errorf("missing %q in marshaled schema; raw=%v", key, raw)
+		}
+	}
+	// A plain object that also carries if/then/else still gets properties.
+	if _, has := raw["properties"]; !has {
+		t.Errorf("object schema must still emit properties; raw=%v", raw)
+	}
+}
+
+// TestValidate_Ref confirms the validator resolves $ref against $defs and
+// enforces the referenced definition (both accept and reject paths), and that
+// recursive references terminate on finite data.
+func TestValidate_Ref(t *testing.T) {
+	s, err := Generate(recNode{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	valid := json.RawMessage(`{"value":"root","children":[{"value":"leaf","children":[]}]}`)
+	if err := s.Validate(valid); err != nil {
+		t.Errorf("expected valid recursive input, got: %v", err)
+	}
+
+	// A wrong type deep inside a referenced definition must be caught.
+	invalid := json.RawMessage(`{"value":123,"children":[]}`)
+	if err := s.Validate(invalid); err == nil {
+		t.Error("expected validation error for wrong-typed value field")
+	}
+}
+
+// TestValidate_UnresolvableRefIsLenient documents that an author-supplied
+// reference the validator cannot resolve never rejects valid input.
+func TestValidate_UnresolvableRefIsLenient(t *testing.T) {
+	s := &Schema{Ref: "#/$defs/Missing"}
+	if err := s.Validate(json.RawMessage(`{"anything":true}`)); err != nil {
+		t.Errorf("unresolvable $ref must be lenient, got: %v", err)
+	}
+}
+
+// TestValidate_OneOf enforces the exactly-one semantics of oneOf.
+func TestValidate_OneOf(t *testing.T) {
+	s := &Schema{OneOf: []*Schema{
+		{Type: typeString},
+		{Type: typeInteger},
+	}}
+
+	if err := s.Validate(json.RawMessage(`"hello"`)); err != nil {
+		t.Errorf("string should match exactly one branch, got: %v", err)
+	}
+	if err := s.Validate(json.RawMessage(`42`)); err != nil {
+		t.Errorf("integer should match exactly one branch, got: %v", err)
+	}
+	// Matches neither branch.
+	if err := s.Validate(json.RawMessage(`true`)); err == nil {
+		t.Error("expected oneOf failure when no branch matches")
+	}
+}
+
+// TestValidate_AnyOf enforces the at-least-one semantics of anyOf.
+func TestValidate_AnyOf(t *testing.T) {
+	s := &Schema{AnyOf: []*Schema{
+		{Type: typeString},
+		{Type: typeBoolean},
+	}}
+
+	if err := s.Validate(json.RawMessage(`"ok"`)); err != nil {
+		t.Errorf("string should satisfy anyOf, got: %v", err)
+	}
+	if err := s.Validate(json.RawMessage(`10`)); err == nil {
+		t.Error("expected anyOf failure when no branch matches")
+	}
+}
+
+// TestValidate_AllOf enforces that every branch must pass.
+func TestValidate_AllOf(t *testing.T) {
+	s := &Schema{AllOf: []*Schema{
+		{Type: typeObject, Properties: map[string]*Schema{"id": {Type: typeString}}},
+		{Type: typeObject, Required: []string{"id"}},
+	}}
+
+	if err := s.Validate(json.RawMessage(`{"id":"x"}`)); err != nil {
+		t.Errorf("object satisfying all branches should pass, got: %v", err)
+	}
+	// Missing required "id" fails the second branch.
+	if err := s.Validate(json.RawMessage(`{}`)); err == nil {
+		t.Error("expected allOf failure when a branch is unsatisfied")
+	}
+	// Wrong type for "id" fails the first branch.
+	err := s.Validate(json.RawMessage(`{"id":123}`))
+	if err == nil || !strings.Contains(err.Error(), "expected string") {
+		t.Errorf("expected string type failure from allOf branch, got: %v", err)
+	}
+}
+
+// TestValidate_IfThenElse enforces the conditional applicator on both the
+// then and else paths.
+func TestValidate_IfThenElse(t *testing.T) {
+	// If "kind" == "email", require "address"; otherwise require "phone".
+	s := &Schema{
+		Type: typeObject,
+		Properties: map[string]*Schema{
+			"kind":    {Type: typeString},
+			"address": {Type: typeString},
+			"phone":   {Type: typeString},
+		},
+		If: &Schema{
+			Type:       typeObject,
+			Properties: map[string]*Schema{"kind": {Type: typeString, Enum: []any{"email"}}},
+		},
+		Then: &Schema{Type: typeObject, Required: []string{"address"}},
+		Else: &Schema{Type: typeObject, Required: []string{"phone"}},
+	}
+
+	if err := s.Validate(json.RawMessage(`{"kind":"email","address":"a@b.com"}`)); err != nil {
+		t.Errorf("then branch should pass, got: %v", err)
+	}
+	if err := s.Validate(json.RawMessage(`{"kind":"email"}`)); err == nil {
+		t.Error("expected then-branch failure: address required")
+	}
+	if err := s.Validate(json.RawMessage(`{"kind":"sms","phone":"123"}`)); err != nil {
+		t.Errorf("else branch should pass, got: %v", err)
+	}
+	if err := s.Validate(json.RawMessage(`{"kind":"sms"}`)); err == nil {
+		t.Error("expected else-branch failure: phone required")
+	}
+}

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -65,4 +65,28 @@
 // default dialect required by the MCP specification revision 2025-11-25
 // (SEP-1613). The marker is set only on the document root; nested sub-schemas
 // leave it empty per JSON Schema convention.
+//
+// # 2020-12 Referencing and Composition
+//
+// The Schema type carries the full 2020-12 referencing and composition
+// vocabulary so that inputSchema/outputSchema are not limited to the flat
+// object/array subset:
+//
+//   - $ref / $defs — Ref points at a reusable definition inside the root
+//     document's Defs map (e.g. "#/$defs/Node").
+//   - oneOf / anyOf / allOf — boolean combinators (OneOf, AnyOf, AllOf).
+//   - if / then / else — the conditional applicator (If, Then, Else).
+//
+// Generation emits $ref/$defs automatically to break recursive Go types:
+// when a struct type refers back to itself (directly or transitively) the
+// self-reference becomes a "#/$defs/<TypeName>" pointer and the type's
+// definition is hoisted into the root schema's $defs, so a recursive type no
+// longer inlines forever. The combinator and conditional keywords are
+// author-supplied (reflection cannot infer a discriminated union from a Go
+// type); the struct marshals and validates against all of them.
+//
+// The runtime validator understands every one of these keywords: it resolves
+// $ref against the root $defs, enforces allOf (all branches), anyOf (at least
+// one), oneOf (exactly one), and if/then/else. Unresolvable references are
+// treated leniently and never reject otherwise-valid input.
 package schema

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -50,60 +50,80 @@ type Schema struct {
 	Minimum              *float64           `json:"minimum,omitempty"`
 	Maximum              *float64           `json:"maximum,omitempty"`
 	Items                *Schema            `json:"items,omitempty"`
+
+	// JSON Schema 2020-12 referencing and composition keywords. These make
+	// inputSchema/outputSchema express the full 2020-12 vocabulary rather than
+	// the flat object/array subset. Ref points at a definition inside Defs
+	// (e.g. "#/$defs/Node"); Defs is the document's reusable definition map and
+	// is carried only on root schemas. OneOf/AnyOf/AllOf are the boolean
+	// combinators, and If/Then/Else form a conditional applicator. All are
+	// optional and omitted from JSON when unset.
+	Ref   string             `json:"$ref,omitempty"`
+	Defs  map[string]*Schema `json:"$defs,omitempty"`
+	OneOf []*Schema          `json:"oneOf,omitempty"`
+	AnyOf []*Schema          `json:"anyOf,omitempty"`
+	AllOf []*Schema          `json:"allOf,omitempty"`
+	If    *Schema            `json:"if,omitempty"`
+	Then  *Schema            `json:"then,omitempty"`
+	Else  *Schema            `json:"else,omitempty"`
 }
 
-// MarshalJSON encodes the schema. For object-typed schemas it forces the
-// "properties" key to be present (emitting `{}` when empty) and writes
-// AdditionalProperties when set.
+// isComposition reports whether the schema is a reference or boolean
+// combinator rather than a plain object. Such schemas must not have an empty
+// "properties" key forced onto them by MarshalJSON: a $ref/oneOf/anyOf/allOf
+// node validates by delegation, and injecting "properties":{} would both be
+// meaningless and, for a closed ("additionalProperties":false) sibling,
+// actively wrong.
+func (s Schema) isComposition() bool {
+	return s.Ref != "" || len(s.OneOf) > 0 || len(s.AnyOf) > 0 || len(s.AllOf) > 0
+}
+
+// MarshalJSON encodes the schema. For plain object-typed schemas it forces
+// the "properties" key to be present (emitting `{}` when empty) and always
+// writes AdditionalProperties when set.
 //
-// Why: OpenAI's strict function-calling mode rejects object schemas that
-// omit "properties" with the error
-// `object schema missing properties. (format)`, which would otherwise
-// break any tool whose handler input is `struct{}`. Forcing properties
-// to materialize removes the footgun for downstream consumers.
+// Why force properties: OpenAI's strict function-calling mode rejects object
+// schemas that omit "properties" with the error
+// `object schema missing properties. (format)`, which would otherwise break
+// any tool whose handler input is `struct{}`. Forcing properties to
+// materialize removes the footgun for downstream consumers.
+//
+// The encoder marshals every field through the struct tags (so 2020-12
+// keywords such as $ref/$defs/oneOf/if round-trip automatically) and only
+// patches in the two keys the tags cannot express: the forced "properties"
+// and the "-"-tagged AdditionalProperties. Composition schemas
+// ($ref/oneOf/anyOf/allOf) are deliberately excluded from the properties
+// forcing so they are not mistaken for closed objects.
 func (s Schema) MarshalJSON() ([]byte, error) {
-	if s.Type != typeObject {
-		type plain Schema
-		return json.Marshal(plain(s))
+	type plain Schema
+	data, err := json.Marshal(plain(s))
+	if err != nil {
+		return nil, err
 	}
 
-	out := map[string]any{"type": typeObject}
-	if s.Dialect != "" {
-		out["$schema"] = s.Dialect
+	forceProps := s.Type == typeObject && !s.isComposition()
+	if !forceProps && s.AdditionalProperties == nil {
+		return data, nil
 	}
-	if s.Format != "" {
-		out["format"] = s.Format
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
 	}
-	props := s.Properties
-	if props == nil {
-		props = map[string]*Schema{}
+
+	if forceProps {
+		if _, ok := m["properties"]; !ok {
+			m["properties"] = json.RawMessage(`{}`)
+		}
 	}
-	out["properties"] = props
 	if s.AdditionalProperties != nil {
-		out["additionalProperties"] = s.AdditionalProperties
+		ap, err := json.Marshal(s.AdditionalProperties)
+		if err != nil {
+			return nil, err
+		}
+		m["additionalProperties"] = ap
 	}
-	if len(s.Required) > 0 {
-		out[tagRequired] = s.Required
-	}
-	if s.Description != "" {
-		out["description"] = s.Description
-	}
-	if s.Default != nil {
-		out["default"] = s.Default
-	}
-	if len(s.Enum) > 0 {
-		out["enum"] = s.Enum
-	}
-	if s.Minimum != nil {
-		out["minimum"] = *s.Minimum
-	}
-	if s.Maximum != nil {
-		out["maximum"] = *s.Maximum
-	}
-	if s.Items != nil {
-		out["items"] = s.Items
-	}
-	return json.Marshal(out)
+	return json.Marshal(m)
 }
 
 // Generate creates a JSON Schema from a Go value. The returned root schema
@@ -130,7 +150,50 @@ func GenerateFromType(t reflect.Type) (*Schema, error) {
 	return s, nil
 }
 
+// defRefPrefix is the JSON-pointer prefix under which generated definitions
+// are registered and referenced ("#/$defs/<TypeName>").
+const defRefPrefix = "#/$defs/"
+
+// defRef returns the "$ref" string that points at the definition for t.
+func defRef(t reflect.Type) string {
+	return defRefPrefix + t.Name()
+}
+
+// genContext threads the state needed to break recursive Go types across a
+// single generation. visiting holds the struct types currently on the
+// generation stack (a back-edge to one of them is a cycle); recursive records
+// which of those were actually referenced recursively and therefore need a
+// hoisted definition; defs collects those hoisted definitions, which are
+// attached to the root schema's $defs.
+type genContext struct {
+	visiting  map[reflect.Type]struct{}
+	recursive map[reflect.Type]bool
+	defs      map[string]*Schema
+}
+
+func newGenContext() *genContext {
+	return &genContext{
+		visiting:  make(map[reflect.Type]struct{}),
+		recursive: make(map[reflect.Type]bool),
+		defs:      make(map[string]*Schema),
+	}
+}
+
 func generateFromType(t reflect.Type) (*Schema, error) {
+	ctx := newGenContext()
+	s, err := ctx.gen(t)
+	if err != nil {
+		return nil, err
+	}
+	// Hoist any recursion-breaking definitions onto the root document so the
+	// "#/$defs/..." references resolve.
+	if len(ctx.defs) > 0 {
+		s.Defs = ctx.defs
+	}
+	return s, nil
+}
+
+func (c *genContext) gen(t reflect.Type) (*Schema, error) {
 	// Handle pointers
 	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
@@ -148,7 +211,7 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 
 	switch t.Kind() {
 	case reflect.Struct:
-		return generateStructSchema(t)
+		return c.genStruct(t)
 	case reflect.String:
 		return &Schema{Type: typeString}, nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
@@ -159,7 +222,7 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 	case reflect.Bool:
 		return &Schema{Type: typeBoolean}, nil
 	case reflect.Slice, reflect.Array:
-		return generateArraySchema(t)
+		return c.genArray(t)
 	case reflect.Map:
 		return &Schema{Type: typeObject}, nil
 	default:
@@ -167,7 +230,17 @@ func generateFromType(t reflect.Type) (*Schema, error) {
 	}
 }
 
-func generateStructSchema(t reflect.Type) (*Schema, error) {
+func (c *genContext) genStruct(t reflect.Type) (*Schema, error) {
+	// A back-edge to a type already on the stack is a cycle. Emit a $ref
+	// instead of recursing forever, and flag the type so its definition is
+	// hoisted into $defs once the outermost generation finishes.
+	if _, onStack := c.visiting[t]; onStack {
+		c.recursive[t] = true
+		return &Schema{Ref: defRef(t)}, nil
+	}
+
+	c.visiting[t] = struct{}{}
+
 	// AdditionalProperties: false marks the object as closed so OpenAI
 	// strict tool-calling accepts the schema. Maps, which can grow at
 	// runtime, leave AdditionalProperties unset (handled separately).
@@ -200,7 +273,7 @@ func generateStructSchema(t reflect.Type) (*Schema, error) {
 		}
 
 		// Generate field schema
-		fieldSchema, err := generateFromType(field.Type)
+		fieldSchema, err := c.gen(field.Type)
 		if err != nil {
 			return nil, err
 		}
@@ -211,11 +284,22 @@ func generateStructSchema(t reflect.Type) (*Schema, error) {
 		schema.Properties[fieldName] = fieldSchema
 	}
 
+	delete(c.visiting, t)
+
+	// If this type was referenced recursively, hoist it into $defs and return
+	// a $ref to it (from every position, including the outermost). Keeping the
+	// definition in exactly one place avoids sharing a pointer with the root,
+	// which would otherwise let the root's dialect marker leak into $defs.
+	if c.recursive[t] {
+		c.defs[t.Name()] = schema
+		return &Schema{Ref: defRef(t)}, nil
+	}
+
 	return schema, nil
 }
 
-func generateArraySchema(t reflect.Type) (*Schema, error) {
-	itemSchema, err := generateFromType(t.Elem())
+func (c *genContext) genArray(t reflect.Type) (*Schema, error) {
+	itemSchema, err := c.gen(t.Elem())
 	if err != nil {
 		return nil, err
 	}

--- a/schema/validation.go
+++ b/schema/validation.go
@@ -100,6 +100,33 @@ func (e ValidationErrors) Error() string {
 	return sb.String()
 }
 
+// valContext carries the state shared across a single validation pass. root is
+// the top-level schema whose $defs are consulted to resolve "$ref" pointers;
+// sub-schemas (properties, items, combinators) do not carry their own $defs.
+type valContext struct {
+	root *Schema
+}
+
+// resolveRef looks up a "#/$defs/<name>" pointer in the root document's $defs.
+// It returns nil for pointers it cannot resolve (external or unknown), which
+// callers treat leniently: an unresolvable reference never fails valid input.
+func (vc *valContext) resolveRef(ref string) *Schema {
+	name, ok := strings.CutPrefix(ref, defRefPrefix)
+	if !ok || vc.root == nil {
+		return nil
+	}
+	return vc.root.Defs[name]
+}
+
+// matches reports whether value validates cleanly against sub. It is used by
+// the boolean combinators (oneOf/anyOf) and the "if" applicator, where a
+// non-match must be counted rather than surfaced as an error.
+func (vc *valContext) matches(sub *Schema, value any) bool {
+	var errs ValidationErrors
+	sub.validate(vc, "", value, &errs)
+	return len(errs) == 0
+}
+
 // Validate validates JSON data against a schema.
 // Returns nil if valid, or ValidationErrors if invalid.
 func (s *Schema) Validate(data json.RawMessage) error {
@@ -115,7 +142,7 @@ func (s *Schema) Validate(data json.RawMessage) error {
 	}
 
 	var errs ValidationErrors
-	s.validate("", value, &errs)
+	s.validate(&valContext{root: s}, "", value, &errs)
 
 	if len(errs) > 0 {
 		return errs
@@ -126,7 +153,7 @@ func (s *Schema) Validate(data json.RawMessage) error {
 // ValidateValue validates a Go value against a schema.
 func (s *Schema) ValidateValue(value any) error {
 	var errs ValidationErrors
-	s.validate("", value, &errs)
+	s.validate(&valContext{root: s}, "", value, &errs)
 
 	if len(errs) > 0 {
 		return errs
@@ -134,18 +161,30 @@ func (s *Schema) ValidateValue(value any) error {
 	return nil
 }
 
-func (s *Schema) validate(path string, value any, errs *ValidationErrors) {
+func (s *Schema) validate(vc *valContext, path string, value any, errs *ValidationErrors) {
 	// Handle nil values
 	if value == nil {
 		// null is valid for any type unless required is enforced elsewhere
 		return
 	}
 
+	// $ref delegates validation to the referenced definition. Generated
+	// recursion-breaking nodes are pure references, so resolving and
+	// delegating fully validates them; an unresolvable reference is ignored.
+	if s.Ref != "" {
+		if target := vc.resolveRef(s.Ref); target != nil {
+			target.validate(vc, path, value, errs)
+		}
+		return
+	}
+
+	s.validateCompositions(vc, path, value, errs)
+
 	switch s.Type {
 	case typeObject:
-		s.validateObject(path, value, errs)
+		s.validateObject(vc, path, value, errs)
 	case typeArray:
-		s.validateArray(path, value, errs)
+		s.validateArray(vc, path, value, errs)
 	case typeString:
 		s.validateString(path, value, errs)
 	case typeInteger:
@@ -157,7 +196,60 @@ func (s *Schema) validate(path string, value any, errs *ValidationErrors) {
 	}
 }
 
-func (s *Schema) validateObject(path string, value any, errs *ValidationErrors) {
+// validateCompositions enforces the 2020-12 boolean combinators and the
+// if/then/else conditional: allOf requires every branch to pass, anyOf at
+// least one, oneOf exactly one, and if/then/else selects a branch by whether
+// the "if" schema matches. Each is checked only when present, so a schema
+// using none of them behaves exactly as before.
+func (s *Schema) validateCompositions(vc *valContext, path string, value any, errs *ValidationErrors) {
+	for _, sub := range s.AllOf {
+		sub.validate(vc, path, value, errs)
+	}
+
+	if len(s.AnyOf) > 0 {
+		matched := false
+		for _, sub := range s.AnyOf {
+			if vc.matches(sub, value) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			*errs = append(*errs, &ValidationError{
+				Path:    path,
+				Message: "value does not match any schema in anyOf",
+			})
+		}
+	}
+
+	if len(s.OneOf) > 0 {
+		count := 0
+		for _, sub := range s.OneOf {
+			if vc.matches(sub, value) {
+				count++
+			}
+		}
+		if count != 1 {
+			*errs = append(*errs, &ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("value must match exactly one schema in oneOf, matched %d", count),
+			})
+		}
+	}
+
+	if s.If != nil {
+		switch {
+		case vc.matches(s.If, value):
+			if s.Then != nil {
+				s.Then.validate(vc, path, value, errs)
+			}
+		case s.Else != nil:
+			s.Else.validate(vc, path, value, errs)
+		}
+	}
+}
+
+func (s *Schema) validateObject(vc *valContext, path string, value any, errs *ValidationErrors) {
 	obj, ok := value.(map[string]any)
 	if !ok {
 		*errs = append(*errs, &ValidationError{
@@ -182,12 +274,12 @@ func (s *Schema) validateObject(path string, value any, errs *ValidationErrors) 
 	for name, propSchema := range s.Properties {
 		if val, exists := obj[name]; exists {
 			fieldPath := joinPath(path, name)
-			propSchema.validate(fieldPath, val, errs)
+			propSchema.validate(vc, fieldPath, val, errs)
 		}
 	}
 }
 
-func (s *Schema) validateArray(path string, value any, errs *ValidationErrors) {
+func (s *Schema) validateArray(vc *valContext, path string, value any, errs *ValidationErrors) {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
 		*errs = append(*errs, &ValidationError{
@@ -203,7 +295,7 @@ func (s *Schema) validateArray(path string, value any, errs *ValidationErrors) {
 
 	for i := 0; i < rv.Len(); i++ {
 		itemPath := fmt.Sprintf("%s[%d]", path, i)
-		s.Items.validate(itemPath, rv.Index(i).Interface(), errs)
+		s.Items.validate(vc, itemPath, rv.Index(i).Interface(), errs)
 	}
 }
 

--- a/server/elicitation.go
+++ b/server/elicitation.go
@@ -66,6 +66,9 @@ func (e *Elicitor) Elicit(ctx context.Context, req *ElicitRequest) (*ElicitResul
 	if req.Mode == ElicitModeURL && !e.session.SupportsFeature("elicitation.url") {
 		return nil, fmt.Errorf("client does not support url-mode elicitation")
 	}
+	if b := e.session.InputBroker(); b != nil {
+		return b.elicit(req)
+	}
 	if e.session.sender == nil {
 		return nil, ErrNoRequestSender
 	}

--- a/server/icon_modern_test.go
+++ b/server/icon_modern_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestIcon_LegacyMarshal asserts that an Icon constructed the legacy
+// (2025-11-25, SEP-973) way still serializes with the original uri/mimeType/size
+// fields and does not emit the modern src/sizes/theme keys.
+func TestIcon_LegacyMarshal(t *testing.T) {
+	icon := Icon{URI: "https://example.com/icon.png", MimeType: "image/png", Size: 48}
+
+	data, err := json.Marshal(icon)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	want := map[string]any{
+		"uri":      "https://example.com/icon.png",
+		"mimeType": "image/png",
+		"size":     float64(48),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy Icon JSON = %v, want %v", got, want)
+	}
+}
+
+// TestIcon_ModernMarshal asserts that the modern fields serialize under their
+// spec keys and that unset legacy scalars are omitted.
+func TestIcon_ModernMarshal(t *testing.T) {
+	icon := NewIcon("https://example.com/icon.svg").
+		WithMimeType("image/svg+xml").
+		WithSizes("48x48 96x96").
+		WithTheme("dark")
+
+	data, err := json.Marshal(icon)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	want := map[string]any{
+		"uri":      "", // legacy field retains its non-omitempty tag
+		"mimeType": "image/svg+xml",
+		"src":      "https://example.com/icon.svg",
+		"sizes":    "48x48 96x96",
+		"theme":    "dark",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("modern Icon JSON = %v, want %v", got, want)
+	}
+}
+
+// TestIcon_ModernFieldsOmittedWhenEmpty asserts src/sizes/theme are dropped when
+// unset so legacy-only icons never leak empty modern keys.
+func TestIcon_ModernFieldsOmittedWhenEmpty(t *testing.T) {
+	data, err := json.Marshal(Icon{URI: "data://x"})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	for _, key := range []string{"src", "sizes", "theme"} {
+		var got map[string]any
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		if _, present := got[key]; present {
+			t.Fatalf("expected %q to be omitted, got JSON %s", key, data)
+		}
+	}
+}
+
+// TestIcon_Normalize verifies the legacy<->modern field mapping in both
+// directions and that already-set fields are never overwritten.
+func TestIcon_Normalize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Icon
+		want Icon
+	}{
+		{
+			name: "legacy fills modern",
+			in:   Icon{URI: "https://x/i.png", Size: 48},
+			want: Icon{URI: "https://x/i.png", Size: 48, Src: "https://x/i.png", Sizes: "48x48"},
+		},
+		{
+			name: "modern fills legacy",
+			in:   Icon{Src: "https://x/i.png", Sizes: "64x64"},
+			want: Icon{URI: "https://x/i.png", Size: 64, Src: "https://x/i.png", Sizes: "64x64"},
+		},
+		{
+			name: "does not overwrite existing fields",
+			in:   Icon{URI: "legacy://a", Src: "modern://b", Size: 16, Sizes: "any"},
+			want: Icon{URI: "legacy://a", Src: "modern://b", Size: 16, Sizes: "any"},
+		},
+		{
+			name: "any size descriptor yields no legacy pixel size",
+			in:   Icon{Src: "https://x/i.svg", Sizes: "any"},
+			want: Icon{URI: "https://x/i.svg", Src: "https://x/i.svg", Sizes: "any"},
+		},
+		{
+			name: "multi-descriptor uses first square size",
+			in:   Icon{Src: "https://x/i.png", Sizes: "32x32 64x64"},
+			want: Icon{URI: "https://x/i.png", Size: 32, Src: "https://x/i.png", Sizes: "32x32 64x64"},
+		},
+		{
+			name: "empty icon is unchanged",
+			in:   Icon{},
+			want: Icon{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.Normalize(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Normalize() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewIcon confirms the constructor sets only the modern source.
+func TestNewIcon(t *testing.T) {
+	got := NewIcon("data://icon")
+	want := Icon{Src: "data://icon"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NewIcon() = %+v, want %+v", got, want)
+	}
+}

--- a/server/mrtr.go
+++ b/server/mrtr.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// Multi Round-Trip Requests (MRTR, MCP 2026-07-28) replace every
+// server-initiated request — sampling, elicitation, roots/list — in the
+// stateless model. A stateless server holds no connection to call back over, so
+// instead of blocking on a server→client request it returns a result with
+// resultType "input_required" listing the inputs it needs. The client fulfills
+// them locally and retries the original call carrying the responses; the handler
+// re-runs and its input calls resolve from those responses instead of blocking.
+//
+// The handler is replayed on every round. Its input calls must therefore be
+// deterministic up to the point where new input is needed: each call is assigned
+// a stable id (ir-0, ir-1, …) by call order, so a response supplied on one round
+// is matched back to the same call on the next. This is a replay/continuation
+// model — analogous to algebraic effects simulated by re-execution.
+
+// Input request kinds carried in an InputRequest.Kind (MCP 2026-07-28, MRTR).
+const (
+	InputKindSampling    = "sampling"    // an LLM completion (replaces sampling/createMessage)
+	InputKindElicitation = "elicitation" // structured user input (replaces elicitation/create)
+	InputKindRoots       = "roots"       // workspace roots (replaces roots/list)
+)
+
+// InputRequest describes one piece of input a stateless tool handler needs
+// before it can produce a final result. It is carried in an InputRequiredResult;
+// the client fulfills it and retries the original call with a matching
+// InputResponse (correlated by ID).
+type InputRequest struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind"`
+	// Payload is the request parameters for the kind: a CreateMessageRequest for
+	// sampling, an ElicitRequest for elicitation. Empty for roots (no params).
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// InputResponse carries the client's fulfillment of one InputRequest, correlated
+// by ID. Exactly one of Payload or Error is meaningful: Payload holds the result
+// (CreateMessageResult / ElicitResult / ListRootsResult) the handler receives;
+// Error surfaces a client-side failure to the handler as the input call's error.
+type InputResponse struct {
+	ID      string          `json:"id"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Error   *protocol.Error `json:"error,omitempty"`
+}
+
+// InputRequiredResult is a tool result with resultType "input_required" (MCP
+// 2026-07-28, MRTR): the handler paused because it needs input the client must
+// supply before retrying. RequestState is an opaque token the server may set and
+// the client echoes back on the retry for its own correlation.
+type InputRequiredResult struct {
+	ResultType    string          `json:"resultType"`
+	InputRequests []InputRequest  `json:"inputRequests"`
+	RequestState  json.RawMessage `json:"requestState,omitempty"`
+}
+
+// ErrInputRequired halts a stateless tool handler when it requests input the
+// client has not yet supplied. A handler receives it as the error from an input
+// call (CreateMessage / Elicit / ListRoots) and should propagate it unchanged;
+// the dispatcher converts an unfulfilled input request into an
+// InputRequiredResult rather than an error response.
+var ErrInputRequired = errors.New("mcp: input required (MRTR); client must fulfill inputRequests and retry")
+
+// InputBroker fulfills a stateless handler's input calls from responses the
+// client supplied on retry, and records the requests that remain unfulfilled so
+// the dispatcher can return them as an InputRequiredResult. It is single-use per
+// request and not safe for concurrent input calls (handlers are sequential).
+type InputBroker struct {
+	byID    map[string]InputResponse
+	state   json.RawMessage
+	counter int
+	pending []InputRequest
+}
+
+// NewInputBroker builds a broker seeded with the input responses the client
+// supplied on a retry (empty on the first round) and the request state to echo
+// back on the next InputRequiredResult.
+func NewInputBroker(responses []InputResponse, state json.RawMessage) *InputBroker {
+	byID := make(map[string]InputResponse, len(responses))
+	for _, r := range responses {
+		byID[r.ID] = r
+	}
+	return &InputBroker{byID: byID, state: state}
+}
+
+// request resolves one input call. It assigns the call a stable id by order,
+// returns the previously-supplied response payload when present, and otherwise
+// records the request as pending and returns ErrInputRequired.
+func (b *InputBroker) request(kind string, payload json.RawMessage) (json.RawMessage, error) {
+	id := fmt.Sprintf("ir-%d", b.counter)
+	b.counter++
+	if r, ok := b.byID[id]; ok {
+		if r.Error != nil {
+			return nil, r.Error
+		}
+		return r.Payload, nil
+	}
+	b.pending = append(b.pending, InputRequest{ID: id, Kind: kind, Payload: payload})
+	return nil, ErrInputRequired
+}
+
+// HasPending reports whether the handler left any input request unfulfilled.
+func (b *InputBroker) HasPending() bool { return len(b.pending) > 0 }
+
+// Result assembles the InputRequiredResult for the requests the handler could
+// not fulfill this round.
+func (b *InputBroker) Result() InputRequiredResult {
+	return InputRequiredResult{
+		ResultType:    protocol.ResultTypeInputRequired,
+		InputRequests: b.pending,
+		RequestState:  b.state,
+	}
+}
+
+// sampling resolves a CreateMessage call through the broker.
+func (b *InputBroker) sampling(req *CreateMessageRequest) (*CreateMessageResult, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal sampling request: %w", err)
+	}
+	raw, err := b.request(InputKindSampling, payload)
+	if err != nil {
+		return nil, err
+	}
+	var res CreateMessageResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("decode sampling input response: %w", err)
+	}
+	return &res, nil
+}
+
+// elicit resolves an Elicit call through the broker.
+func (b *InputBroker) elicit(req *ElicitRequest) (*ElicitResult, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal elicitation request: %w", err)
+	}
+	raw, err := b.request(InputKindElicitation, payload)
+	if err != nil {
+		return nil, err
+	}
+	var res ElicitResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("decode elicitation input response: %w", err)
+	}
+	return &res, nil
+}
+
+// listRoots resolves a ListRoots call through the broker.
+func (b *InputBroker) listRoots() (*ListRootsResult, error) {
+	raw, err := b.request(InputKindRoots, nil)
+	if err != nil {
+		return nil, err
+	}
+	var res ListRootsResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("decode roots input response: %w", err)
+	}
+	return &res, nil
+}

--- a/server/mrtr_test.go
+++ b/server/mrtr_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// samplingSession builds a session whose client declares every capability and
+// whose server→client requests resolve through the given broker.
+func brokerSession(t *testing.T, broker *InputBroker) *Session {
+	t.Helper()
+	s := NewSession("test", nil, nil)
+	s.SetClientCapabilities(ClientCapabilities{
+		Sampling:    true,
+		Elicitation: true,
+		Roots:       &RootsCapability{},
+	})
+	s.SetInputBroker(broker)
+	return s
+}
+
+func TestInputBroker_FirstRoundRecordsPending(t *testing.T) {
+	broker := NewInputBroker(nil, nil)
+	s := brokerSession(t, broker)
+
+	_, err := s.CreateMessage(context.Background(), &CreateMessageRequest{MaxTokens: 10})
+	if !errors.Is(err, ErrInputRequired) {
+		t.Fatalf("first sampling call: got err %v, want ErrInputRequired", err)
+	}
+	if !broker.HasPending() {
+		t.Fatal("broker should have a pending request after an unfulfilled call")
+	}
+	res := broker.Result()
+	if res.ResultType != protocol.ResultTypeInputRequired {
+		t.Errorf("resultType = %q, want %q", res.ResultType, protocol.ResultTypeInputRequired)
+	}
+	if len(res.InputRequests) != 1 {
+		t.Fatalf("inputRequests = %d, want 1", len(res.InputRequests))
+	}
+	got := res.InputRequests[0]
+	if got.ID != "ir-0" {
+		t.Errorf("id = %q, want ir-0", got.ID)
+	}
+	if got.Kind != InputKindSampling {
+		t.Errorf("kind = %q, want %q", got.Kind, InputKindSampling)
+	}
+}
+
+func TestInputBroker_ResolvesFromSuppliedResponse(t *testing.T) {
+	want := CreateMessageResult{Role: RoleAssistant, Model: "test-model", Content: NewTextContent("hi")}
+	payload, _ := json.Marshal(want)
+	broker := NewInputBroker([]InputResponse{{ID: "ir-0", Payload: payload}}, nil)
+	s := brokerSession(t, broker)
+
+	got, err := s.CreateMessage(context.Background(), &CreateMessageRequest{MaxTokens: 10})
+	if err != nil {
+		t.Fatalf("CreateMessage with supplied response: %v", err)
+	}
+	if broker.HasPending() {
+		t.Error("broker should have no pending requests when the response was supplied")
+	}
+	if got.Model != want.Model || got.Content.Text != "hi" {
+		t.Errorf("got %+v, want model=%q text=hi", got, want.Model)
+	}
+}
+
+func TestInputBroker_ResponseErrorSurfacesToHandler(t *testing.T) {
+	broker := NewInputBroker([]InputResponse{{
+		ID:    "ir-0",
+		Error: &protocol.Error{Code: protocol.CodeInvalidParams, Message: "user declined"},
+	}}, nil)
+	s := brokerSession(t, broker)
+
+	_, err := s.CreateMessage(context.Background(), &CreateMessageRequest{MaxTokens: 10})
+	var mcpErr *protocol.Error
+	if !errors.As(err, &mcpErr) || mcpErr.Message != "user declined" {
+		t.Fatalf("got err %v, want the supplied protocol error", err)
+	}
+}
+
+func TestInputBroker_SequentialIDsAndReplay(t *testing.T) {
+	// Round 1: only the elicitation is answered; the following sampling call is
+	// unfulfilled, so it must be recorded as ir-1.
+	elicit, _ := json.Marshal(ElicitResult{Action: "accept", Content: map[string]any{"ok": true}})
+	broker := NewInputBroker([]InputResponse{{ID: "ir-0", Payload: elicit}}, nil)
+	s := brokerSession(t, broker)
+
+	er, err := NewElicitor(s).Elicit(context.Background(), &ElicitRequest{Message: "name?"})
+	if err != nil {
+		t.Fatalf("elicit (ir-0) should resolve: %v", err)
+	}
+	if er.Action != "accept" {
+		t.Errorf("elicit action = %q, want accept", er.Action)
+	}
+
+	_, err = s.CreateMessage(context.Background(), &CreateMessageRequest{MaxTokens: 5})
+	if !errors.Is(err, ErrInputRequired) {
+		t.Fatalf("sampling (ir-1) should be unfulfilled: %v", err)
+	}
+	reqs := broker.Result().InputRequests
+	if len(reqs) != 1 || reqs[0].ID != "ir-1" || reqs[0].Kind != InputKindSampling {
+		t.Fatalf("pending = %+v, want single ir-1 sampling", reqs)
+	}
+}
+
+func TestInputBroker_RootsRoundTrip(t *testing.T) {
+	want := ListRootsResult{Roots: []Root{{URI: "file:///work", Name: "work"}}}
+	payload, _ := json.Marshal(want)
+	broker := NewInputBroker([]InputResponse{{ID: "ir-0", Payload: payload}}, nil)
+	s := brokerSession(t, broker)
+
+	got, err := s.ListRoots(context.Background())
+	if err != nil {
+		t.Fatalf("ListRoots: %v", err)
+	}
+	if len(got.Roots) != 1 || got.Roots[0].URI != "file:///work" {
+		t.Fatalf("roots = %+v, want file:///work", got.Roots)
+	}
+	// The result must also populate the session's cached roots.
+	if cached := s.Roots(); len(cached) != 1 || cached[0].URI != "file:///work" {
+		t.Errorf("cached roots = %+v, want file:///work", cached)
+	}
+}
+
+func TestInputBroker_CapabilityGateStillApplies(t *testing.T) {
+	// A client that does not declare sampling must be refused before the broker,
+	// exactly as under legacy semantics.
+	s := NewSession("test", nil, nil)
+	s.SetInputBroker(NewInputBroker(nil, nil))
+	_, err := s.CreateMessage(context.Background(), &CreateMessageRequest{MaxTokens: 1})
+	if err == nil || errors.Is(err, ErrInputRequired) {
+		t.Fatalf("got %v, want a capability error", err)
+	}
+}
+
+func TestInputBroker_RequestStateEcho(t *testing.T) {
+	state := json.RawMessage(`{"round":2}`)
+	broker := NewInputBroker(nil, state)
+	s := brokerSession(t, broker)
+	_, _ = s.CreateMessage(context.Background(), &CreateMessageRequest{MaxTokens: 1})
+	if string(broker.Result().RequestState) != `{"round":2}` {
+		t.Errorf("requestState = %s, want the echoed token", broker.Result().RequestState)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,16 +5,124 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 
 	"go.klarlabs.de/mcp/protocol"
 )
 
-// Icon represents an icon for UI display.
+// Icon represents an icon for UI display. A single Icon value serializes for
+// both MCP icon shapes so callers do not need era-specific types:
+//
+//   - the legacy shape (2025-11-25, SEP-973) uses uri/mimeType/size;
+//   - the modern shape (2026-07-28) uses src/sizes/theme.
+//
+// The two eras describe the same concepts under different names:
+//
+//	legacy URI  ≈ modern Src   (image URL or data URI)
+//	legacy Size ≈ modern Sizes (48 ≈ "48x48"; modern also allows "any" and
+//	                            multiple space-separated descriptors)
+//	MimeType is shared by both eras.
+//
+// Populate the legacy fields, the modern fields, or both. NewIcon builds a
+// modern icon; Normalize fills each era's fields from the other so a value
+// authored for one era serializes sensibly for both. Legacy struct literals
+// keep working unchanged.
 type Icon struct {
-	URI      string `json:"uri"`                // data URI or https URL
-	MimeType string `json:"mimeType,omitempty"` // image/png, image/svg+xml, etc.
-	Size     int    `json:"size,omitempty"`     // pixel size (icons are square)
+	// URI is the legacy (2025-11-25) image source: a data URI or https URL.
+	// Corresponds to the modern Src.
+	URI string `json:"uri"`
+	// MimeType is the image media type (image/png, image/svg+xml, ...). Shared
+	// by both the legacy and modern shapes.
+	MimeType string `json:"mimeType,omitempty"`
+	// Size is the legacy square pixel size (icons are square). Corresponds to
+	// the modern Sizes.
+	Size int `json:"size,omitempty"`
+
+	// Src is the modern (2026-07-28) image source: a data URI or https URL.
+	// Corresponds to the legacy URI.
+	Src string `json:"src,omitempty"`
+	// Sizes is the modern space-separated size descriptor string, e.g.
+	// "48x48 96x96" or "any". Corresponds to the legacy Size.
+	Sizes string `json:"sizes,omitempty"`
+	// Theme selects a light/dark variant of the icon: "light" or "dark". Modern
+	// only; empty means the icon applies to any theme.
+	Theme string `json:"theme,omitempty"`
+}
+
+// NewIcon constructs a modern (2026-07-28) icon with the given source URL or
+// data URI. Chain WithMimeType, WithSizes, and WithTheme to add metadata, and
+// call Normalize to also populate the legacy fields for back-compat.
+func NewIcon(src string) Icon {
+	return Icon{Src: src}
+}
+
+// WithMimeType returns a copy of the icon with the image media type set. The
+// media type is shared by both the legacy and modern shapes.
+func (i Icon) WithMimeType(mimeType string) Icon {
+	i.MimeType = mimeType
+	return i
+}
+
+// WithSizes returns a copy of the icon with the modern space-separated size
+// descriptor string set, e.g. "48x48 96x96" or "any".
+func (i Icon) WithSizes(sizes string) Icon {
+	i.Sizes = sizes
+	return i
+}
+
+// WithTheme returns a copy of the icon carrying a light/dark theme variant
+// ("light" or "dark"). Icons may exist in per-theme variants; attach one theme
+// per Icon value. Modern only.
+func (i Icon) WithTheme(theme string) Icon {
+	i.Theme = theme
+	return i
+}
+
+// Normalize returns a copy of the icon with empty fields filled from their
+// cross-era counterparts: URI and Src copy across verbatim, and Size and Sizes
+// convert (Size 48 ≈ Sizes "48x48"; the first square "NxN" descriptor in Sizes
+// ≈ Size N; "any" yields no pixel Size). It never overwrites a field that is
+// already set, so an icon authored for one era serializes for both.
+func (i Icon) Normalize() Icon {
+	// Source URL: legacy URI <-> modern Src.
+	if i.Src == "" {
+		i.Src = i.URI
+	}
+	if i.URI == "" {
+		i.URI = i.Src
+	}
+	// Size: legacy Size (pixels) <-> modern Sizes (descriptor string).
+	if i.Sizes == "" && i.Size > 0 {
+		i.Sizes = fmt.Sprintf("%dx%d", i.Size, i.Size)
+	}
+	if i.Size == 0 && i.Sizes != "" {
+		i.Size = parseSquareSize(i.Sizes)
+	}
+	return i
+}
+
+// parseSquareSize extracts the pixel size from a modern size descriptor string
+// such as "48x48" or "32x32 64x64", returning the width of the first square
+// descriptor. It returns 0 for "any" or any value it cannot parse.
+func parseSquareSize(sizes string) int {
+	for _, field := range strings.Fields(sizes) {
+		w, h, ok := strings.Cut(field, "x")
+		if !ok {
+			continue
+		}
+		width, err := strconv.Atoi(w)
+		if err != nil {
+			continue
+		}
+		height, err := strconv.Atoi(h)
+		if err != nil || width != height {
+			continue
+		}
+		return width
+	}
+	return 0
 }
 
 // BuildInfo contains build metadata for debugging and version verification.

--- a/server/server.go
+++ b/server/server.go
@@ -94,6 +94,7 @@ type Server struct {
 	tasks        *TaskManager
 	augTasks     *augTaskRegistry
 	resourceSubs *resourceSubscriptions
+	resultCache  *resultCacheConfig
 
 	// regErrs accumulates registration collisions. The fluent builder API
 	// returns the builder rather than an error, so a duplicate tool/resource/
@@ -528,6 +529,30 @@ func (s *Server) HasTaskTools() bool {
 		}
 	}
 	return false
+}
+
+// resultCacheConfig holds the cache hint stamped on cacheable results
+// (tools/list, resources/list, resources/read, …) for modern clients.
+type resultCacheConfig struct {
+	ttlMs int64
+	scope string
+}
+
+// WithResultCache sets the cache hint (ttlMs and cacheScope, "public" or
+// "private") advertised on cacheable list/read results to modern (2026-07-28)
+// clients via CacheableResult. Legacy responses are unaffected.
+func WithResultCache(ttlMs int64, scope string) Option {
+	return func(s *Server) {
+		s.resultCache = &resultCacheConfig{ttlMs: ttlMs, scope: scope}
+	}
+}
+
+// ResultCache returns the configured cache hint, or ok=false when none is set.
+func (s *Server) ResultCache() (ttlMs int64, scope string, ok bool) {
+	if s.resultCache == nil {
+		return 0, "", false
+	}
+	return s.resultCache.ttlMs, s.resultCache.scope, true
 }
 
 // HasCompletions reports whether any prompt/resource completion handler has

--- a/server/session.go
+++ b/server/session.go
@@ -177,6 +177,10 @@ func (s *Session) SupportsFeature(feature string) bool {
 
 // CreateMessage sends a sampling request to the client.
 // Returns an error if the client doesn't support sampling.
+//
+// Note: sampling is deprecated as of MCP 2026-07-28 (12-month window; still
+// functional). Modern servers should call an LLM provider API directly rather
+// than round-tripping a completion through the client.
 func (s *Session) CreateMessage(ctx context.Context, req *CreateMessageRequest) (*CreateMessageResult, error) {
 	return s.createMessage(ctx, req)
 }
@@ -247,6 +251,10 @@ func (s *Session) createMessage(ctx context.Context, req *CreateMessageRequest) 
 
 // ListRoots requests the list of roots from the client.
 // Returns an error if the client doesn't support roots.
+//
+// Note: roots is deprecated as of MCP 2026-07-28 (12-month window; still
+// functional). Modern servers should receive directories/files via tool
+// parameters, resource URIs, or configuration instead.
 func (s *Session) ListRoots(ctx context.Context) (*ListRootsResult, error) {
 	if !s.SupportsFeature("roots") {
 		return nil, fmt.Errorf("client does not support roots")
@@ -315,6 +323,10 @@ func (s *Session) HandleRootsChanged(roots []Root) {
 }
 
 // Log sends a log message at the specified level.
+//
+// Note: logging is deprecated as of MCP 2026-07-28 (12-month window; still
+// functional). Modern servers should log to stderr or emit OpenTelemetry
+// instead of routing log messages through the client.
 func (s *Session) Log(level LogLevel, logger string, data any) {
 	s.mu.RLock()
 	minLevel := s.logLevel

--- a/server/session.go
+++ b/server/session.go
@@ -32,6 +32,11 @@ type Session struct {
 
 	// Client capabilities (what the client supports)
 	clientCaps ClientCapabilities
+
+	// broker fulfills server→client requests (sampling, elicitation, roots) via
+	// the stateless MRTR model (MCP 2026-07-28) when set — the request-scoped
+	// replacement for a RequestSender. Nil under legacy session semantics.
+	broker *InputBroker
 }
 
 // ErrNoRequestSender is returned by server→client request methods (sampling,
@@ -152,6 +157,24 @@ func (s *Session) SetClientCapabilitiesJSON(raw json.RawMessage) {
 	s.SetClientCapabilities(caps)
 }
 
+// SetInputBroker attaches an MRTR input broker (MCP 2026-07-28) so this
+// session's server→client request methods (sampling, elicitation, roots)
+// resolve statelessly from client-supplied input responses instead of a
+// RequestSender.
+func (s *Session) SetInputBroker(b *InputBroker) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broker = b
+}
+
+// InputBroker returns the session's MRTR input broker, or nil under legacy
+// (session-negotiated) semantics.
+func (s *Session) InputBroker() *InputBroker {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.broker
+}
+
 // SupportsFeature returns true if the client supports the given feature.
 func (s *Session) SupportsFeature(feature string) bool {
 	s.mu.RLock()
@@ -204,6 +227,9 @@ func (s *Session) CreateMessageWithTools(ctx context.Context, req *CreateMessage
 func (s *Session) createMessage(ctx context.Context, req *CreateMessageRequest) (*CreateMessageResult, error) {
 	if !s.SupportsFeature("sampling") {
 		return nil, fmt.Errorf("client does not support sampling")
+	}
+	if b := s.InputBroker(); b != nil {
+		return b.sampling(req)
 	}
 	if s.sender == nil {
 		return nil, ErrNoRequestSender
@@ -258,6 +284,16 @@ func (s *Session) createMessage(ctx context.Context, req *CreateMessageRequest) 
 func (s *Session) ListRoots(ctx context.Context) (*ListRootsResult, error) {
 	if !s.SupportsFeature("roots") {
 		return nil, fmt.Errorf("client does not support roots")
+	}
+	if b := s.InputBroker(); b != nil {
+		res, err := b.listRoots()
+		if err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		s.roots = res.Roots
+		s.mu.Unlock()
+		return res, nil
 	}
 	if s.sender == nil {
 		return nil, ErrNoRequestSender

--- a/server/tasks_augment.go
+++ b/server/tasks_augment.go
@@ -137,6 +137,36 @@ func (r *augTaskRegistry) create(ttlMs *int64) (*AugTask, error) {
 	return t, nil
 }
 
+// updateTTL refreshes a non-terminal task's ttl (and expiry), returning the
+// updated task. A nil ttl clears the deadline (unlimited). It returns
+// ErrAugTaskNotFound for an unknown/expired id and ErrAugTaskTerminal for a task
+// that has already finished (its ttl can no longer be meaningfully extended).
+func (r *augTaskRegistry) updateTTL(id string, ttlMs *int64) (*AugTask, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tasks[id]
+	if !ok || r.expiredLocked(t) {
+		if ok {
+			delete(r.tasks, id)
+		}
+		return nil, ErrAugTaskNotFound
+	}
+	if t.Status.terminal() {
+		return nil, ErrAugTaskTerminal
+	}
+	now := r.now()
+	t.TTL = ttlMs
+	if ttlMs != nil {
+		t.ttlDur = time.Duration(*ttlMs) * time.Millisecond
+		t.expireAt = now.Add(t.ttlDur)
+	} else {
+		t.ttlDur = 0
+		t.expireAt = time.Time{}
+	}
+	t.LastUpdatedAt = now.UTC().Format(time.RFC3339)
+	return t, nil
+}
+
 // get returns a live (non-expired) task by id.
 func (r *augTaskRegistry) get(id string) (*AugTask, bool) {
 	r.mu.Lock()
@@ -279,6 +309,15 @@ func (s *Server) AwaitAugTaskResult(ctx context.Context, id string) (result any,
 // CancelAugTask cancels a task (ErrAugTaskNotFound / ErrAugTaskTerminal on
 // failure), returning the updated task.
 func (s *Server) CancelAugTask(id string) (*AugTask, error) { return s.augTasks.cancelTask(id) }
+
+// UpdateAugTask refreshes a non-terminal task's ttl (nil clears the deadline),
+// returning the updated task. It backs the tasks/update method (MCP 2026-07-28):
+// a caller polling a long-running task can extend its lifetime so it is not
+// evicted before completion. Errors: ErrAugTaskNotFound (unknown/expired),
+// ErrAugTaskTerminal (already finished).
+func (s *Server) UpdateAugTask(id string, ttlMs *int64) (*AugTask, error) {
+	return s.augTasks.updateTTL(id, ttlMs)
+}
 
 // ListAugTasks returns tasks newest-first with cursor pagination.
 func (s *Server) ListAugTasks(cursor string, limit int) ([]*AugTask, string) {

--- a/server/tool.go
+++ b/server/tool.go
@@ -144,10 +144,15 @@ func (b *ToolBuilder) Icons(icons ...Icon) *ToolBuilder {
 	return b
 }
 
-// UIResource marks this tool as having an associated MCP App UI resource.
-// The given URI is included in both the nested _meta.ui.resourceUri field
-// (preferred) and the flat _meta["ui/resourceUri"] key (legacy) for maximum
-// host compatibility per the MCP Apps extension spec.
+// UIResource marks this tool as having an associated MCP App UI resource,
+// per the MCP Apps extension (io.modelcontextprotocol/ui, advertised in
+// capabilities.extensions). The given ui:// URI is included in both the nested
+// _meta.ui.resourceUri field (canonical) and the flat _meta["ui/resourceUri"]
+// key for host compatibility.
+//
+// Note: the flat _meta["ui/resourceUri"] form is deprecated by the MCP Apps
+// spec and is slated for removal before GA; it is still emitted here so hosts
+// that only read the flat key keep working. Prefer _meta.ui.resourceUri.
 func (b *ToolBuilder) UIResource(uri string) *ToolBuilder {
 	if b.err != nil {
 		return b

--- a/transport/http.go
+++ b/transport/http.go
@@ -51,6 +51,13 @@ type HTTP struct {
 	// with an Mcp-Session-Id header minted on initialize and echoed thereafter.
 	streamable bool
 
+	// stateless switches the streamable POST path to the MCP 2026-07-28 model:
+	// the Mcp-Session-Id lifecycle is dropped (no minting, no per-request header
+	// requirement) and the Mcp-Method routing header is hard-required (a POST that
+	// omits it is rejected with -32020) rather than merely validated-when-present.
+	// Implies streamable.
+	stateless bool
+
 	mu         sync.RWMutex
 	listenAddr string
 	server     *http.Server
@@ -244,6 +251,24 @@ func WithMaxSSEConnections(n int) HTTPOption {
 func WithStreamable() HTTPOption {
 	return func(h *HTTP) {
 		h.streamable = true
+	}
+}
+
+// WithStreamableStateless enables the modern Streamable HTTP transport in the
+// stateless (MCP 2026-07-28) model. It implies WithStreamable and additionally:
+//
+//   - drops the Mcp-Session-Id lifecycle — no session id is minted on initialize
+//     and none is required on subsequent POSTs (every request self-describes via
+//     its `_meta`, so no server-side session correlation is needed);
+//   - hard-requires the Mcp-Method routing header on every POST (absent → -32020),
+//     rather than the default validate-when-present behavior.
+//
+// It is opt-in and does not affect the legacy (session-negotiated) streamable
+// path when left off.
+func WithStreamableStateless() HTTPOption {
+	return func(h *HTTP) {
+		h.streamable = true
+		h.stateless = true
 	}
 }
 
@@ -810,16 +835,29 @@ func (h *HTTP) handleStreamablePost(w http.ResponseWriter, r *http.Request, hand
 		return
 	}
 
-	// Session lifecycle: mint on initialize, require+echo otherwise. On any
-	// failure the helper has already written the response.
-	sessionID, ok := h.resolveStreamableSession(w, r, ctx, &req)
-	if !ok {
-		return
-	}
-	if sessionID != "" {
-		// Echo the session id so the client can capture (initialize) or confirm it.
-		w.Header().Set(mcpSessionHeader, sessionID)
-		ctx = ContextWithClientID(ctx, sessionID)
+	var sessionID string
+	if h.stateless {
+		// Modern stateless (MCP 2026-07-28): no Mcp-Session-Id lifecycle, and the
+		// Mcp-Method routing header is mandatory (not merely validated-when-present).
+		if r.Header.Get(mcpMethodHeader) == "" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(protocol.NewErrorResponse(req.ID,
+				protocol.NewHeaderMismatch("Mcp-Method header is required in stateless mode")))
+			return
+		}
+	} else {
+		// Session lifecycle: mint on initialize, require+echo otherwise. On any
+		// failure the helper has already written the response.
+		var ok bool
+		sessionID, ok = h.resolveStreamableSession(w, r, ctx, &req)
+		if !ok {
+			return
+		}
+		if sessionID != "" {
+			// Echo the session id so the client can capture (initialize) or confirm it.
+			w.Header().Set(mcpSessionHeader, sessionID)
+			ctx = ContextWithClientID(ctx, sessionID)
+		}
 	}
 
 	// A notification carries no id and MUST NOT be answered with a body. Run it

--- a/transport/http.go
+++ b/transport/http.go
@@ -606,6 +606,70 @@ func (h *HTTP) SendTo(clientID string, data []byte) bool {
 // mcpSessionHeader is the HTTP header carrying the Streamable HTTP session id.
 const mcpSessionHeader = "Mcp-Session-Id"
 
+// Modern (MCP 2026-07-28) Streamable HTTP routing headers. They let an
+// intermediary route a POST without parsing its JSON body: Mcp-Method mirrors
+// the JSON-RPC method, and Mcp-Name mirrors the body's primary named target
+// (tools/call -> name, resources/read -> uri, prompts/get -> name).
+const (
+	mcpMethodHeader = "Mcp-Method"
+	mcpNameHeader   = "Mcp-Name"
+)
+
+// routingParams carries the body fields the modern routing headers mirror. Only
+// the primary named target of a name-bearing method is captured; other params
+// are ignored so the parse stays cheap and tolerant of unknown fields.
+type routingParams struct {
+	Name string `json:"name"`
+	URI  string `json:"uri"`
+}
+
+// bodyRouteName returns the primary named target the Mcp-Name header must match
+// for a name-bearing method, and ok=false for methods that have no such target
+// (Mcp-Name is then not validated). tools/call and prompts/get key on the
+// "name" param; resources/read keys on the "uri" param.
+func bodyRouteName(req *protocol.Request) (string, bool) {
+	var field *string
+	var params routingParams
+	switch req.Method {
+	case protocol.MethodToolsCall, protocol.MethodPromptsGet:
+		field = &params.Name
+	case protocol.MethodResourcesRead:
+		field = &params.URI
+	default:
+		return "", false
+	}
+	if len(req.Params) > 0 {
+		// Ignore malformed params here: a body that fails to unmarshal is caught
+		// downstream by the handler; treat the route name as empty for matching.
+		_ = json.Unmarshal(req.Params, &params)
+	}
+	return *field, true
+}
+
+// validateRoutingHeaders enforces the modern routing headers when present
+// (validate-when-present): a supplied Mcp-Method must equal the body method, and
+// a supplied Mcp-Name must equal the body's primary named target for
+// name-bearing methods. It returns a -32020 error on mismatch, else nil.
+//
+// The headers are validated only, not required. The roadmap lists them as
+// "required" for the stateless revision; hard-requiring them (rejecting a POST
+// that omits Mcp-Method) is a deferred follow-up, most likely gated behind an
+// explicit Stateless option, since the modern Streamable transport is still
+// opt-in/experimental here.
+func validateRoutingHeaders(r *http.Request, req *protocol.Request) *protocol.Error {
+	if hdr := r.Header.Get(mcpMethodHeader); hdr != "" && hdr != req.Method {
+		return protocol.NewHeaderMismatch(fmt.Sprintf(
+			"Mcp-Method header %q does not match request method %q", hdr, req.Method))
+	}
+	if hdr := r.Header.Get(mcpNameHeader); hdr != "" {
+		if want, named := bodyRouteName(req); named && hdr != want {
+			return protocol.NewHeaderMismatch(fmt.Sprintf(
+				"Mcp-Name header %q does not match request target %q", hdr, want))
+		}
+	}
+	return nil
+}
+
 // notifierFunc adapts a plain function to the NotificationSender interface so a
 // per-request notification sink can be injected into the handler context.
 type notifierFunc func(method string, params any) error
@@ -734,6 +798,15 @@ func (h *HTTP) handleStreamablePost(w http.ResponseWriter, r *http.Request, hand
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(protocol.NewErrorResponse(nil, protocol.NewParseError("Invalid JSON")))
+		return
+	}
+
+	// Modern routing headers (MCP 2026-07-28): when supplied, Mcp-Method and
+	// Mcp-Name must agree with the body so intermediaries can trust them for
+	// routing. A disagreement is a -32020 JSON-RPC error carrying the request id.
+	if verr := validateRoutingHeaders(r, &req); verr != nil {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(protocol.NewErrorResponse(req.ID, verr))
 		return
 	}
 

--- a/transport/http.go
+++ b/transport/http.go
@@ -792,6 +792,33 @@ func (h *HTTP) resolveStreamableSession(w http.ResponseWriter, r *http.Request, 
 	return sessionID, true
 }
 
+// resolveStreamablePOSTSession applies the POST-path session policy and returns
+// (sessionID, ctx, ok). In stateless mode (MCP 2026-07-28) it enforces the
+// mandatory Mcp-Method header and mints no session id; otherwise it runs the
+// Mcp-Session-Id lifecycle and echoes the id, threading it onto the context. It
+// returns ok=false when it has already written an error response.
+func (h *HTTP) resolveStreamablePOSTSession(w http.ResponseWriter, r *http.Request, ctx context.Context, req *protocol.Request) (string, context.Context, bool) {
+	if h.stateless {
+		if r.Header.Get(mcpMethodHeader) == "" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(protocol.NewErrorResponse(req.ID,
+				protocol.NewHeaderMismatch("Mcp-Method header is required in stateless mode")))
+			return "", ctx, false
+		}
+		return "", ctx, true
+	}
+	sessionID, ok := h.resolveStreamableSession(w, r, ctx, req)
+	if !ok {
+		return "", ctx, false
+	}
+	if sessionID != "" {
+		// Echo the session id so the client can capture (initialize) or confirm it.
+		w.Header().Set(mcpSessionHeader, sessionID)
+		ctx = ContextWithClientID(ctx, sessionID)
+	}
+	return sessionID, ctx, true
+}
+
 func (h *HTTP) handleStreamablePost(w http.ResponseWriter, r *http.Request, handler Handler) {
 	if !originAllowed(r, h.allowedOrigins, h.allowAllOrigins) {
 		http.Error(w, "origin not allowed", http.StatusForbidden)
@@ -835,28 +862,21 @@ func (h *HTTP) handleStreamablePost(w http.ResponseWriter, r *http.Request, hand
 		return
 	}
 
-	var sessionID string
-	if h.stateless {
-		// Modern stateless (MCP 2026-07-28): no Mcp-Session-Id lifecycle, and the
-		// Mcp-Method routing header is mandatory (not merely validated-when-present).
-		if r.Header.Get(mcpMethodHeader) == "" {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(protocol.NewErrorResponse(req.ID,
-				protocol.NewHeaderMismatch("Mcp-Method header is required in stateless mode")))
+	sessionID, ctx, ok := h.resolveStreamablePOSTSession(w, r, ctx, &req)
+	if !ok {
+		return
+	}
+
+	// subscriptions/listen (MCP 2026-07-28): a single long-lived POST-response
+	// SSE stream that replaces the GET stream + resources/subscribe/unsubscribe.
+	// The handler runs once to register the subscription and return a
+	// subscriptionId; the response then stays open, forwarding subscriptionId-
+	// tagged notifications until the client disconnects. Streamed regardless of
+	// the Accept header, since the method's semantics require a stream.
+	if req.Method == protocol.MethodSubscriptionsListen {
+		if flusher, flushable := w.(http.Flusher); flushable {
+			h.streamableSubscriptionsListen(ctx, w, &req, handler, flusher)
 			return
-		}
-	} else {
-		// Session lifecycle: mint on initialize, require+echo otherwise. On any
-		// failure the helper has already written the response.
-		var ok bool
-		sessionID, ok = h.resolveStreamableSession(w, r, ctx, &req)
-		if !ok {
-			return
-		}
-		if sessionID != "" {
-			// Echo the session id so the client can capture (initialize) or confirm it.
-			w.Header().Set(mcpSessionHeader, sessionID)
-			ctx = ContextWithClientID(ctx, sessionID)
 		}
 	}
 
@@ -923,6 +943,139 @@ func (h *HTTP) streamablePostSSE(ctx context.Context, w http.ResponseWriter, req
 		}
 		_ = sse.WriteData(body)
 	}
+}
+
+// subscriptionStreamBuffer bounds the per-subscription notification backlog,
+// mirroring the standing GET stream's channel depth.
+const subscriptionStreamBuffer = 10
+
+// streamableSubscriptionsListen realizes subscriptions/listen (MCP 2026-07-28)
+// as a long-lived POST-response SSE stream. It runs the handler once to register
+// the subscription and obtain the subscriptionId, opens an SSE response keyed by
+// that id, writes the subscription acknowledgement as the first frame, and then
+// forwards any notifications delivered via NotifySubscription (each tagged with
+// io.modelcontextprotocol/subscriptionId) until the client disconnects.
+func (h *HTTP) streamableSubscriptionsListen(ctx context.Context, w http.ResponseWriter, req *protocol.Request, handler Handler, flusher http.Flusher) {
+	resp, err := handler.HandleRequest(ctx, req)
+	if err != nil {
+		resp = protocol.NewErrorResponse(req.ID, protocol.NewInternalError(err.Error()))
+	}
+	subID := subscriptionIDFromResponse(resp)
+	if resp == nil || resp.Error != nil || subID == "" {
+		// The request did not yield a subscription (e.g. a validation error, or a
+		// non-modern caller): reply with a single JSON object, no stream.
+		w.Header().Set("Content-Type", "application/json")
+		if resp != nil {
+			_ = json.NewEncoder(w).Encode(resp)
+		}
+		return
+	}
+
+	ch := make(chan []byte, subscriptionStreamBuffer)
+	if !h.registerSSEClient(subID, ch) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(protocol.NewErrorResponse(req.ID,
+			protocol.NewInternalError("subscription stream unavailable")))
+		return
+	}
+	defer func() {
+		h.sseClientsMu.Lock()
+		if h.sseClients[subID] == ch {
+			delete(h.sseClients, subID)
+		}
+		h.sseClientsMu.Unlock()
+		h.mu.RLock()
+		hook := h.onDisconnect
+		h.mu.RUnlock()
+		if hook != nil {
+			hook(subID)
+		}
+	}()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	sse := NewSSEWriter(w, flusher)
+	if body, mErr := json.Marshal(resp); mErr == nil {
+		_ = sse.WriteData(body)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			_ = sse.WriteData(msg)
+		}
+	}
+}
+
+// subscriptionIDFromResponse extracts the subscriptionId a subscriptions/listen
+// handler returned, or "" if the response does not carry one.
+func subscriptionIDFromResponse(resp *protocol.Response) string {
+	if resp == nil {
+		return ""
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := m["subscriptionId"].(string)
+	return id
+}
+
+// NotifySubscription delivers a notification to an open subscriptions/listen
+// stream, tagging its params with io.modelcontextprotocol/subscriptionId so the
+// client correlates it to the subscription (MCP 2026-07-28). It returns an error
+// if no stream is open for the id or the stream's buffer is full.
+func (h *HTTP) NotifySubscription(subscriptionID, method string, params any) error {
+	tagged, err := tagSubscriptionParams(params, subscriptionID)
+	if err != nil {
+		return fmt.Errorf("notify subscription %s: %w", subscriptionID, err)
+	}
+	msg, err := json.Marshal(protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		Method:  method,
+		Params:  tagged,
+	})
+	if err != nil {
+		return fmt.Errorf("notify subscription %s: marshal notification: %w", subscriptionID, err)
+	}
+	if !h.SendTo(subscriptionID, msg) {
+		return fmt.Errorf("subscription %s: no open stream or buffer full", subscriptionID)
+	}
+	return nil
+}
+
+// tagSubscriptionParams injects io.modelcontextprotocol/subscriptionId into the
+// params' `_meta` object. Non-object params (which cannot carry `_meta`) are
+// returned unchanged.
+func tagSubscriptionParams(params any, subscriptionID string) (json.RawMessage, error) {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params: %w", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil || obj == nil {
+		return raw, nil // not an object; cannot carry _meta
+	}
+	idRaw, _ := json.Marshal(subscriptionID)
+	meta := map[string]json.RawMessage{}
+	if existing, ok := obj["_meta"]; ok {
+		_ = json.Unmarshal(existing, &meta)
+	}
+	meta[protocol.MetaKeySubscriptionID] = idRaw
+	metaRaw, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal _meta: %w", err)
+	}
+	obj["_meta"] = metaRaw
+	return json.Marshal(obj)
 }
 
 // handleStreamableGet opens a standing server->client SSE stream keyed by the

--- a/transport/streamable_http_test.go
+++ b/transport/streamable_http_test.go
@@ -28,6 +28,8 @@ func streamableTestHandler() Handler {
 				_ = sender.SendNotification("notifications/message", map[string]any{"text": "hello"})
 			}
 			return protocol.NewResponse(req.ID, map[string]any{"ok": true}), nil
+		case protocol.MethodSubscriptionsListen:
+			return protocol.NewResponse(req.ID, map[string]any{"subscriptionId": "sub-test"}), nil
 		default:
 			return protocol.NewResponse(req.ID, map[string]any{"echo": req.Method}), nil
 		}

--- a/transport/streamable_http_test.go
+++ b/transport/streamable_http_test.go
@@ -362,6 +362,142 @@ func TestStreamableHTTP_LegacyDefaultUnchanged(t *testing.T) {
 	}
 }
 
+// postMCPWithHeaders is postMCP plus arbitrary extra request headers, used to
+// exercise the modern Mcp-Method / Mcp-Name routing headers.
+func postMCPWithHeaders(t *testing.T, ts *httptest.Server, accept, sessionID string, req protocol.Request, headers map[string]string) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if accept != "" {
+		httpReq.Header.Set("Accept", accept)
+	}
+	if sessionID != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	resp, err := ts.Client().Do(httpReq)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// decodeJSONRPCError reads a single JSON-RPC response and returns its error.
+func decodeJSONRPCError(t *testing.T, resp *http.Response) *protocol.Error {
+	t.Helper()
+	var out protocol.Response
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out.Error
+}
+
+// TestStreamableHTTP_RoutingHeadersMatch confirms that routing headers agreeing
+// with the body pass validation and the request succeeds.
+func TestStreamableHTTP_RoutingHeadersMatch(t *testing.T) {
+	_, ts := newStreamableServer(t)
+	sid := initSession(t, ts)
+
+	resp := postMCPWithHeaders(t, ts, "application/json", sid, protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  protocol.MethodToolsCall,
+		Params:  json.RawMessage(`{"name":"search"}`),
+	}, map[string]string{
+		"Mcp-Method": protocol.MethodToolsCall,
+		"Mcp-Name":   "search",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if errObj := decodeJSONRPCError(t, resp); errObj != nil {
+		t.Fatalf("unexpected JSON-RPC error: %+v", errObj)
+	}
+}
+
+// TestStreamableHTTP_RoutingHeaderMethodMismatch confirms an Mcp-Method header
+// disagreeing with the body method is rejected with -32020.
+func TestStreamableHTTP_RoutingHeaderMethodMismatch(t *testing.T) {
+	_, ts := newStreamableServer(t)
+	sid := initSession(t, ts)
+
+	resp := postMCPWithHeaders(t, ts, "application/json", sid, protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  "ping",
+	}, map[string]string{
+		"Mcp-Method": protocol.MethodToolsCall,
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	errObj := decodeJSONRPCError(t, resp)
+	if errObj == nil {
+		t.Fatal("expected a JSON-RPC error, got none")
+	}
+	if errObj.Code != protocol.CodeHeaderMismatch {
+		t.Fatalf("error code = %d, want %d", errObj.Code, protocol.CodeHeaderMismatch)
+	}
+}
+
+// TestStreamableHTTP_RoutingHeaderNameMismatch confirms an Mcp-Name header
+// disagreeing with a tools/call name param is rejected with -32020.
+func TestStreamableHTTP_RoutingHeaderNameMismatch(t *testing.T) {
+	_, ts := newStreamableServer(t)
+	sid := initSession(t, ts)
+
+	resp := postMCPWithHeaders(t, ts, "application/json", sid, protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  protocol.MethodToolsCall,
+		Params:  json.RawMessage(`{"name":"search"}`),
+	}, map[string]string{
+		"Mcp-Method": protocol.MethodToolsCall,
+		"Mcp-Name":   "delete",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	errObj := decodeJSONRPCError(t, resp)
+	if errObj == nil {
+		t.Fatal("expected a JSON-RPC error, got none")
+	}
+	if errObj.Code != protocol.CodeHeaderMismatch {
+		t.Fatalf("error code = %d, want %d", errObj.Code, protocol.CodeHeaderMismatch)
+	}
+}
+
+// TestStreamableHTTP_RoutingHeadersAbsent confirms the baseline is unaffected
+// when no routing headers are supplied (validate-when-present).
+func TestStreamableHTTP_RoutingHeadersAbsent(t *testing.T) {
+	_, ts := newStreamableServer(t)
+	sid := initSession(t, ts)
+
+	resp := postMCP(t, ts, "application/json", sid, protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  protocol.MethodToolsCall,
+		Params:  json.RawMessage(`{"name":"search"}`),
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if errObj := decodeJSONRPCError(t, resp); errObj != nil {
+		t.Fatalf("unexpected JSON-RPC error: %+v", errObj)
+	}
+}
+
 // sseDataFrames extracts the payloads of all "data:" frames from an SSE body.
 func sseDataFrames(body string) []string {
 	var frames []string

--- a/transport/streamable_stateless_test.go
+++ b/transport/streamable_stateless_test.go
@@ -1,0 +1,93 @@
+package transport
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// TestStreamableStateless_NoSessionIDRequired confirms that in stateless mode a
+// POST for a non-initialize method succeeds without an Mcp-Session-Id (the
+// session lifecycle is dropped), as long as the required Mcp-Method header is
+// present — in the default streamable mode this same request would be rejected
+// with 404 (unknown/expired session).
+func TestStreamableStateless_NoSessionIDRequired(t *testing.T) {
+	_, ts := newStreamableServer(t, WithStreamableStateless())
+
+	resp := postMCPWithHeaders(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "ping",
+	}, map[string]string{"Mcp-Method": "ping"})
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no session required in stateless mode)", resp.StatusCode)
+	}
+	if errObj := decodeJSONRPCError(t, resp); errObj != nil {
+		t.Fatalf("unexpected JSON-RPC error: %+v", errObj)
+	}
+}
+
+// TestStreamableStateless_RequiresMcpMethodHeader confirms the Mcp-Method
+// routing header is hard-required in stateless mode: a POST omitting it is
+// rejected with -32020 (vs the default validate-when-present behavior, where an
+// absent header is fine).
+func TestStreamableStateless_RequiresMcpMethodHeader(t *testing.T) {
+	_, ts := newStreamableServer(t, WithStreamableStateless())
+
+	resp := postMCP(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "ping",
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	errObj := decodeJSONRPCError(t, resp)
+	if errObj == nil {
+		t.Fatal("expected a JSON-RPC error for missing Mcp-Method, got none")
+	}
+	if errObj.Code != protocol.CodeHeaderMismatch {
+		t.Errorf("error code = %d, want %d (HeaderMismatch)", errObj.Code, protocol.CodeHeaderMismatch)
+	}
+}
+
+// TestStreamableStateless_DoesNotMintSessionID confirms initialize does not mint
+// or echo an Mcp-Session-Id in stateless mode.
+func TestStreamableStateless_DoesNotMintSessionID(t *testing.T) {
+	_, ts := newStreamableServer(t, WithStreamableStateless())
+
+	resp := postMCPWithHeaders(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodInitialize,
+	}, map[string]string{"Mcp-Method": protocol.MethodInitialize})
+	defer func() { _ = resp.Body.Close() }()
+
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		t.Errorf("stateless mode must not mint an Mcp-Session-Id, got %q", sid)
+	}
+}
+
+// TestStreamableStateless_OffKeepsSessionLifecycle is a guard that the default
+// (non-stateless) streamable path still mints and requires a session id.
+func TestStreamableStateless_OffKeepsSessionLifecycle(t *testing.T) {
+	_, ts := newStreamableServer(t)
+
+	// initialize mints a session id.
+	sid := initSession(t, ts)
+
+	// A non-initialize POST without the session id is rejected (404).
+	resp := postMCP(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  "ping",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatal("default streamable mode should require an Mcp-Session-Id on non-initialize POSTs")
+	}
+	_ = sid
+}

--- a/transport/streamable_subscriptions_test.go
+++ b/transport/streamable_subscriptions_test.go
@@ -1,0 +1,103 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// TestStreamableHTTP_SubscriptionsListenStream drives the full subscriptions/listen
+// long-lived POST stream: the first frame acknowledges the subscription (carrying
+// the subscriptionId), and a notification pushed via NotifySubscription arrives on
+// the same stream tagged with io.modelcontextprotocol/subscriptionId.
+func TestStreamableHTTP_SubscriptionsListenStream(t *testing.T) {
+	h, ts := newStreamableServer(t, WithStreamableStateless())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body, err := json.Marshal(protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodSubscriptionsListen,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/mcp", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Mcp-Method", protocol.MethodSubscriptionsListen)
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	// First frame: the subscription acknowledgement carrying the subscriptionId.
+	ack, err := readOneSSEData(resp.Body)
+	if err != nil {
+		t.Fatalf("read ack frame: %v", err)
+	}
+	if !strings.Contains(ack, "sub-test") {
+		t.Fatalf("ack frame = %q, want it to carry subscriptionId sub-test", ack)
+	}
+
+	// Push a resource-updated notification onto the open stream. The stream is
+	// registered synchronously before the ack was flushed, so it is present now.
+	if err := h.NotifySubscription("sub-test", protocol.MethodResourceUpdated,
+		map[string]any{"uri": "email://inbox"}); err != nil {
+		t.Fatalf("NotifySubscription: %v", err)
+	}
+
+	// Second frame: the tagged notification.
+	frame, err := readOneSSEData(resp.Body)
+	if err != nil {
+		t.Fatalf("read notification frame: %v", err)
+	}
+	if !strings.Contains(frame, "email://inbox") {
+		t.Errorf("notification frame = %q, want it to carry the resource uri", frame)
+	}
+	if !strings.Contains(frame, protocol.MetaKeySubscriptionID) || !strings.Contains(frame, "sub-test") {
+		t.Errorf("notification frame = %q, want it tagged with subscriptionId sub-test", frame)
+	}
+}
+
+// TestStreamableHTTP_SubscriptionsListenNoSubID confirms that when the handler
+// returns no subscriptionId (e.g. an error result), the endpoint replies with a
+// single JSON object rather than opening a stream.
+func TestStreamableHTTP_SubscriptionsListenNoSubID(t *testing.T) {
+	h := NewHTTP("127.0.0.1:0", WithStreamableStateless())
+	handler := HandlerFunc(func(_ context.Context, req *protocol.Request) (*protocol.Response, error) {
+		// No subscriptionId in the result.
+		return protocol.NewResponse(req.ID, map[string]any{"resultType": "complete"}), nil
+	})
+	ts := httptest.NewServer(h.createHandler(handler))
+	t.Cleanup(ts.Close)
+
+	resp := postMCPWithHeaders(t, ts, "text/event-stream", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  protocol.MethodSubscriptionsListen,
+	}, map[string]string{"Mcp-Method": protocol.MethodSubscriptionsListen})
+	defer func() { _ = resp.Body.Close() }()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json (no stream without subscriptionId)", ct)
+	}
+	_ = h
+}


### PR DESCRIPTION
Stacked on #125. First increments of the modern, stateless MCP `2026-07-28` revision (RC, SEP-2575). **Experimental** — `2026-07-28` is intentionally NOT in `SupportedVersions` yet; the full stateless path is built incrementally and mcp-go stays **dual-era** (legacy `initialize` still works).

## What's in it
- **`server/discover`** — stateless replacement for the `initialize` handshake: `{ resultType, supportedVersions, capabilities (incl. extensions map), serverInfo, instructions }` in one cacheable request.
- **Stateless per-request `_meta`** — a request carrying `io.modelcontextprotocol/protocolVersion` is validated (required fields → `-32602`), version-checked (`-32022`, `server/discover` exempt), given a request-scoped session from its declared capabilities (sampling/elicitation gating with zero connection state), and stamped `resultType:"complete"`. Legacy requests pass through unchanged.
- **Extensions capability map** (SEP-2133) — `io.modelcontextprotocol/ui` (Apps) + `io.modelcontextprotocol/tasks`.
- **Modern error codes** — `-32020`/`-32021`/`-32022` + constructors; reserved `_meta` key & `resultType` constants.

## Remaining Phase 4 (future increments)
MRTR / `InputRequiredResult`, `subscriptions/listen`, transport routing headers (`Mcp-Method`/`Mcp-Name`), `CacheableResult` (`ttlMs`/`cacheScope`), roots/sampling/logging deprecation annotations, resource-not-found `-32002`→`-32602`. When complete, `2026-07-28` graduates into `SupportedVersions` as the v2 default.

Full `-race` suite and `golangci-lint` clean; every commit through the warden gate.

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT