### PR TITLE
feat(transport)!: stateless-by-default for Streamable HTTP (v1.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.24.0](https://github.com/klarlabs-studio/mcp-go/compare/v1.23.0...v1.24.0) - 2026-07-11
+
+Makes the stateless (MCP 2026-07-28) model the **default** for the Streamable
+HTTP transport. Shipped as a minor (not v2.0.0) by deliberate decision: the only
+consumers are the maintainer's own fleet — all of which serve over **stdio**
+(unaffected by this HTTP-transport change) and upgrade in lockstep — and there
+are no external consumers, so the `/v2` module-path migration is intentionally
+avoided.
+
+### Changed — ⚠️ behavior change (Streamable HTTP)
+
+- **`WithStreamable()` now defaults to stateless.** The Streamable HTTP transport
+  enabled via `WithStreamable()` uses the 2026-07-28 stateless model: it **drops
+  the `Mcp-Session-Id` lifecycle** (none minted on initialize, none required on
+  POSTs) and **hard-requires the `Mcp-Method` routing header** (absent → `-32020`).
+  Previously `WithStreamable()` was session-negotiated (2025-03-26).
+  - **Migration:** to keep the session-negotiated behavior, switch
+    `WithStreamable()` → **`WithStreamableStateful()`** (new). `stdio` servers are
+    unaffected — this only touches the Streamable HTTP transport.
+
+### Added
+
+- **`WithStreamableStateful()`** — opt into the legacy session-negotiated
+  (2025-03-26) Streamable HTTP model (mints/requires `Mcp-Session-Id`, serves the
+  GET SSE stream + DELETE, validates `Mcp-Method` when present). The explicit
+  opt-out from the new stateless default.
+- **`WithStreamableStateless()`** is retained as an explicit spelling of the new
+  default (`== WithStreamable`).
+
 ## [1.23.0](https://github.com/klarlabs-studio/mcp-go/compare/v1.22.0...v1.23.0) - 2026-07-11
 
 Completes the 2026-07-28 stateless surface (Phase 4) on **v1** — additive and

--- a/docs/revisions-roadmap.md
+++ b/docs/revisions-roadmap.md
@@ -246,10 +246,14 @@ clients keep working, then make it the default in v2.
   — the modern log level travels in `_meta`.)
 - [x] Loosen `inputSchema`/`outputSchema` to full JSON Schema 2020-12 (`$ref`,
   `oneOf`/`anyOf`, conditionals).
-- [ ] Make `Stateless` the default; tag **v2.0.0**. **DEFERRED — held at v1 by
-  decision.** All Phase 4 behavior ships behind the `WithStreamableStateless`
-  opt-in so v1 servers are unaffected; the default flip and the `v2.0.0` tag are
-  intentionally not done. Everything above is additive and backward-compatible.
+- [x] Make `Stateless` the default — shipped in **v1.24.0** (NOT v2.0.0, by
+  decision). `WithStreamable()` now defaults to the stateless (2026-07-28) model
+  (drops `Mcp-Session-Id`, hard-requires `Mcp-Method`); `WithStreamableStateful()`
+  is the opt-out into the legacy session-negotiated (2025-03-26) path. This is a
+  behavior change to the streamable HTTP default, released as a minor because the
+  only consumers are the maintainer's own fleet (all stdio — unaffected) and they
+  upgrade in lockstep; there are no external consumers. The `/v2` module-path tax
+  is intentionally avoided. See CHANGELOG [1.24.0].
 
 ---
 

--- a/transport/http.go
+++ b/transport/http.go
@@ -230,9 +230,16 @@ func WithMaxSSEConnections(n int) HTTPOption {
 	}
 }
 
-// WithStreamable enables the modern Streamable HTTP transport (MCP 2025-03-26)
-// on the /mcp endpoint, in addition to the legacy POST /mcp + GET /mcp/sse
-// endpoints, which remain available for backward compatibility.
+// WithStreamable enables the modern Streamable HTTP transport on the /mcp
+// endpoint, in addition to the legacy POST /mcp + GET /mcp/sse endpoints, which
+// remain available for backward compatibility.
+//
+// As of v1.24.0 this defaults to the **stateless** (MCP 2026-07-28) model: the
+// Mcp-Session-Id lifecycle is dropped (no id minted on initialize, none required
+// on subsequent POSTs — every request self-describes via its `_meta`) and the
+// Mcp-Method routing header is hard-required on every POST (absent → -32020).
+// Use WithStreamableStateful to opt back into the legacy session-negotiated
+// (MCP 2025-03-26) model.
 //
 // In streamable mode the single /mcp endpoint:
 //   - POST accepts a JSON-RPC request and replies either with a single JSON
@@ -240,31 +247,37 @@ func WithMaxSSEConnections(n int) HTTPOption {
 //     (Content-Type: text/event-stream), negotiated via the request's Accept
 //     header. Notifications sent by handlers during an SSE-framed reply are
 //     streamed as SSE data frames ahead of the final response frame.
-//   - GET opens a standing server->client SSE stream, keyed by Mcp-Session-Id,
-//     for notifications delivered outside a request/response exchange.
-//   - DELETE tears down the session named by Mcp-Session-Id.
 //
-// The server mints an Mcp-Session-Id on the initialize response and requires it
-// to be echoed on every subsequent request. All existing security controls
-// (origin checks, max body size, authorize hook, request-context hook) apply to
-// the streamable paths unchanged.
+// All existing security controls (origin checks, max body size, authorize hook,
+// request-context hook) apply to the streamable paths unchanged.
 func WithStreamable() HTTPOption {
 	return func(h *HTTP) {
 		h.streamable = true
+		h.stateless = true
+	}
+}
+
+// WithStreamableStateful enables the modern Streamable HTTP transport in the
+// legacy session-negotiated (MCP 2025-03-26) model — the opt-out from the
+// stateless default. In this mode the /mcp endpoint:
+//
+//   - mints an Mcp-Session-Id on the initialize response and requires it to be
+//     echoed on every subsequent request;
+//   - serves GET as a standing server->client SSE stream keyed by Mcp-Session-Id;
+//   - serves DELETE to tear down the session named by Mcp-Session-Id;
+//   - validates the Mcp-Method routing header when present (rather than
+//     hard-requiring it).
+func WithStreamableStateful() HTTPOption {
+	return func(h *HTTP) {
+		h.streamable = true
+		h.stateless = false
 	}
 }
 
 // WithStreamableStateless enables the modern Streamable HTTP transport in the
-// stateless (MCP 2026-07-28) model. It implies WithStreamable and additionally:
-//
-//   - drops the Mcp-Session-Id lifecycle — no session id is minted on initialize
-//     and none is required on subsequent POSTs (every request self-describes via
-//     its `_meta`, so no server-side session correlation is needed);
-//   - hard-requires the Mcp-Method routing header on every POST (absent → -32020),
-//     rather than the default validate-when-present behavior.
-//
-// It is opt-in and does not affect the legacy (session-negotiated) streamable
-// path when left off.
+// stateless (MCP 2026-07-28) model. As of v1.24.0 this is the default for
+// WithStreamable; the option is retained as an explicit spelling of that intent
+// and for callers pinned to earlier versions.
 func WithStreamableStateless() HTTPOption {
 	return func(h *HTTP) {
 		h.streamable = true

--- a/transport/streamable_default_test.go
+++ b/transport/streamable_default_test.go
@@ -1,0 +1,69 @@
+package transport
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.klarlabs.de/mcp/protocol"
+)
+
+// TestStreamableHTTP_DefaultsToStateless confirms that WithStreamable() now
+// enables the stateless (MCP 2026-07-28) model by default: the Mcp-Method
+// routing header is hard-required (absent → -32020) and initialize does not mint
+// an Mcp-Session-Id. WithStreamableStateful() opts back into the session model.
+func TestStreamableHTTP_DefaultsToStateless(t *testing.T) {
+	h := NewHTTP("127.0.0.1:0", WithStreamable())
+	ts := httptest.NewServer(h.createHandler(streamableTestHandler()))
+	t.Cleanup(ts.Close)
+
+	// Missing Mcp-Method is hard-rejected in the stateless default.
+	resp := postMCP(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "ping",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	errObj := decodeJSONRPCError(t, resp)
+	if errObj == nil {
+		t.Fatal("WithStreamable() should default to stateless (require Mcp-Method), got no error")
+	}
+	if errObj.Code != protocol.CodeHeaderMismatch {
+		t.Errorf("error code = %d, want %d (HeaderMismatch)", errObj.Code, protocol.CodeHeaderMismatch)
+	}
+
+	// initialize does not mint a session id in the stateless default.
+	resp2 := postMCPWithHeaders(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  protocol.MethodInitialize,
+	}, map[string]string{"Mcp-Method": protocol.MethodInitialize})
+	defer func() { _ = resp2.Body.Close() }()
+	if sid := resp2.Header.Get("Mcp-Session-Id"); sid != "" {
+		t.Errorf("stateless default must not mint an Mcp-Session-Id, got %q", sid)
+	}
+}
+
+// TestStreamableStateful_KeepsSessionLifecycle confirms WithStreamableStateful()
+// restores the legacy session-negotiated (MCP 2025-03-26) streamable model:
+// initialize mints an Mcp-Session-Id and a non-initialize POST without it is
+// rejected.
+func TestStreamableStateful_KeepsSessionLifecycle(t *testing.T) {
+	h := NewHTTP("127.0.0.1:0", WithStreamableStateful())
+	ts := httptest.NewServer(h.createHandler(streamableTestHandler()))
+	t.Cleanup(ts.Close)
+
+	sid := initSession(t, ts) // fails if no Mcp-Session-Id is minted
+
+	resp := postMCP(t, ts, "application/json", "", protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  "ping",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatal("stateful streamable mode should require an Mcp-Session-Id on non-initialize POSTs")
+	}
+	_ = sid
+}

--- a/transport/streamable_http_test.go
+++ b/transport/streamable_http_test.go
@@ -38,7 +38,10 @@ func streamableTestHandler() Handler {
 
 func newStreamableServer(t *testing.T, opts ...HTTPOption) (*HTTP, *httptest.Server) {
 	t.Helper()
-	h := NewHTTP("127.0.0.1:0", append([]HTTPOption{WithStreamable()}, opts...)...)
+	// WithStreamable defaults to stateless as of v1.24.0; these helpers back the
+	// session-lifecycle tests, so pin them to the stateful (session-negotiated)
+	// model explicitly. A trailing WithStreamableStateless() in opts still wins.
+	h := NewHTTP("127.0.0.1:0", append([]HTTPOption{WithStreamableStateful()}, opts...)...)
 	ts := httptest.NewServer(h.createHandler(streamableTestHandler()))
 	t.Cleanup(ts.Close)
 	return h, ts

--- a/transport/streamable_stateless_test.go
+++ b/transport/streamable_stateless_test.go
@@ -71,8 +71,9 @@ func TestStreamableStateless_DoesNotMintSessionID(t *testing.T) {
 	}
 }
 
-// TestStreamableStateless_OffKeepsSessionLifecycle is a guard that the default
-// (non-stateless) streamable path still mints and requires a session id.
+// TestStreamableStateless_OffKeepsSessionLifecycle is a guard that the stateful
+// streamable path (WithStreamableStateful, which newStreamableServer pins by
+// default) still mints and requires a session id.
 func TestStreamableStateless_OffKeepsSessionLifecycle(t *testing.T) {
 	_, ts := newStreamableServer(t)
 


### PR DESCRIPTION
## Summary

Makes the stateless (MCP 2026-07-28) model the **default** for the Streamable HTTP transport — the deferred "Make Stateless the default" roadmap item, shipped as a **minor (v1.24.0), not v2.0.0**, by deliberate decision.

- **`WithStreamable()` now defaults to stateless**: drops the `Mcp-Session-Id` lifecycle, hard-requires `Mcp-Method` (absent → `-32020`).
- **New `WithStreamableStateful()`** — opt back into the legacy session-negotiated (2025-03-26) model (mints/requires session id, GET SSE stream, DELETE).
- `WithStreamableStateless()` retained as an explicit spelling of the new default.

## Why a minor, not v2

The only consumers are the maintainer's own fleet (~10 repos: rollops, mnemos, coverctl, warden, statekit, briefkasten, scout, nox, chronos, …), **all of which serve MCP over stdio** — unaffected by this HTTP-transport change — and upgrade in lockstep. There are **no external consumers** (0 forks, 0 external importers on pkg.go.dev). Going v2 would impose the `/v2` module-path rewrite across the whole fleet for zero benefit.

## Test

- New `TestStreamableHTTP_DefaultsToStateless` and `TestStreamableStateful_KeepsSessionLifecycle` (TDD: red → green).
- Session-lifecycle test helper pinned to `WithStreamableStateful()`.
- `go build` / `go vet` / `go test ./...` / `go test -race` green; no new lint issues.

https://claude.ai/code/session_01T68jn2UbNWLE178iorAKtC