### PR TITLE
chore(security): nox remediation

### DIFF
--- a/ai.inventory.json
+++ b/ai.inventory.json
@@ -15,6 +15,40 @@
       "name": "main.go",
       "type": "prompt",
       "path": "examples/prompts/main.go"
+    },
+    {
+      "name": "mcp",
+      "type": "mcp_runtime",
+      "path": "mcp.go"
+    },
+    {
+      "name": "mcp",
+      "type": "mcp_runtime",
+      "path": "protocol/constants.go"
+    },
+    {
+      "name": "mcp",
+      "type": "mcp_runtime",
+      "path": "protocol/errors.go"
+    },
+    {
+      "name": "mcp",
+      "type": "mcp_runtime",
+      "path": "server/tool.go"
+    },
+    {
+      "name": "mcp",
+      "type": "mcp_runtime",
+      "path": "transport/http.go"
+    }
+  ],
+  "tool_permission_matrix": [
+    {
+      "agent": "mcp.go",
+      "tools": [
+        "process"
+      ],
+      "path": "mcp.go"
     }
   ]
 }


### PR DESCRIPTION
Automated remediation by `nox fix --actions`: OSV-vulnerable dependency upgrades plus outdated and mutable GitHub Actions pins bumped to their SHA-pinned latest release. Replaces dependabot.